### PR TITLE
Exposed config

### DIFF
--- a/manifests/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/manifests/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,6 +1,2 @@
-# TODO this will change to KubeAPIServerConfig
-apiVersion: v1
-kind: MasterConfig
-signer:
-  certFile: /var/run/secrets/signing-key/tls.crt
-  keyFile: /var/run/secrets/signing-key/tls.key
+apiVersion: kubecontrolplane.config.openshift.io/v1
+kind: KubeAPIServerConfig

--- a/manifests/v3.11.0/kube-apiserver/deployment.yaml
+++ b/manifests/v3.11.0/kube-apiserver/deployment.yaml
@@ -33,15 +33,55 @@ spec:
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /var/run/configmaps/aggregator-client-ca
+          name: aggregator-client-ca
+        - mountPath: /var/run/configmaps/client-ca
+          name: client-ca
+        - mountPath: /var/run/configmaps/etcd-serving-ca
+          name: etcd-serving-ca
+        - mountPath: /var/run/configmaps/kubelet-serving-ca
+          name: kubelet-serving-ca
+        - mountPath: /var/run/configmaps/sa-token-signing-certs
+          name: sa-token-signing-certs
+        - mountPath: /var/run/secrets/aggregator-client
+          name: aggregator-client
+        - mountPath: /var/run/secrets/etcd-client
+          name: etcd-client
+        - mountPath: /var/run/secrets/kubelet-client
+          name: kubelet-client
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
       volumes:
-      - name: serving-cert
-        secret:
-          secretName: serving-cert
       - name: config
         configMap:
           name: deployment-apiserver-config
+      - name: aggregator-client-ca
+        configMap:
+          name: aggregator-client-ca
+      - name: client-ca
+        configMap:
+          name: client-ca
+      - name: etcd-serving-ca
+        configMap:
+          name: etcd-serving-ca
+      - name: kubelet-serving-ca
+        configMap:
+          name: kubelet-serving-ca
+      - name: sa-token-signing-certs
+        configMap:
+          name: sa-token-signing-certs
+      - name: aggregator-client
+        secret:
+          secretName: aggregator-client
+      - name: etcd-client
+        secret:
+          secretName: etcd-client
+      - name: kubelet-client
+        secret:
+          secretName: kubelet-client
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
 
 
 

--- a/manifests/v3.11.0/kube-apiserver/public-info-role.yaml
+++ b/manifests/v3.11.0/kube-apiserver/public-info-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openshift-kube-apiserver
+  name: system:openshift:operator:kube-apiserver:public
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  resourceNames:
+  - public-info

--- a/manifests/v3.11.0/kube-apiserver/public-info-rolebinding.yaml
+++ b/manifests/v3.11.0/kube-apiserver/public-info-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-kube-apiserver
+  name: system:openshift:operator:kube-apiserver:public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:openshift:operator:kube-apiserver:public
+subjects:
+- kind: Group
+  name: system:authenticated

--- a/manifests/v3.11.0/kube-apiserver/public-info.yaml
+++ b/manifests/v3.11.0/kube-apiserver/public-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-apiserver
+  name: public-info
+data:
+  # version is the current of the kube-apiserver.  It is updated *after* it is being served consistently.
+  version:
+  # imagePolicyConfig.internalRegistryHostname is internal registry used for imagePolicyAdmission
+  # TODO this probably won't make it to 4.0, we're likely to stuff the entire imagePolicyAdmission config in here
+  imagePolicyConfig.internalRegistryHostname:
+  # imagePolicyConfig.externalRegistryHostname is external registry used for imagePolicyAdmission
+  # TODO this probably won't make it to 4.0, we're likely to stuff the entire imagePolicyAdmission config in here
+  imagePolicyConfig.externalRegistryHostname:
+  # defaultNodeSelector is used when no specific node selector is on a namespace
+  # TODO we'd really like to see this collapsed onto upstream values
+  projectConfig.defaultNodeSelector:

--- a/pkg/operator/sync_kubapiserver_v311_00.go
+++ b/pkg/operator/sync_kubapiserver_v311_00.go
@@ -44,7 +44,6 @@ func syncKubeApiserver_v311_00_to_latest(c KubeApiserverOperator, operatorConfig
 		errors = append(errors, fmt.Errorf("%q: %v", "sa", err))
 	}
 
-	// TODO create a new configmap whenever the data value changes
 	_, configMapModified, err := manageKubeApiserverConfigMap_v311_00_to_latest(c.corev1Client, operatorConfig)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap", err))

--- a/pkg/operator/sync_kubapiserver_v311_00.go
+++ b/pkg/operator/sync_kubapiserver_v311_00.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcecread"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // syncKubeApiserver_v311_00_to_latest takes care of synchronizing (not upgrading) the thing we're managing.
@@ -32,6 +34,18 @@ func syncKubeApiserver_v311_00_to_latest(c KubeApiserverOperator, operatorConfig
 		errors = append(errors, fmt.Errorf("%q: %v", "ns", err))
 	}
 
+	requiredPublicRole := resourceread.ReadRoleV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/public-info-role.yaml"))
+	_, _, err = resourceapply.ApplyRole(c.rbacv1Client, requiredPublicRole)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "svc", err))
+	}
+
+	requiredPublicRoleBinding := resourceread.ReadRoleBindingV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/public-info-rolebinding.yaml"))
+	_, _, err = resourceapply.ApplyRoleBinding(c.rbacv1Client, requiredPublicRoleBinding)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "svc", err))
+	}
+
 	requiredService := resourceread.ReadServiceV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/svc.yaml"))
 	_, _, err = resourceapply.ApplyService(c.corev1Client, requiredService)
 	if err != nil {
@@ -44,7 +58,7 @@ func syncKubeApiserver_v311_00_to_latest(c KubeApiserverOperator, operatorConfig
 		errors = append(errors, fmt.Errorf("%q: %v", "sa", err))
 	}
 
-	_, configMapModified, err := manageKubeApiserverConfigMap_v311_00_to_latest(c.corev1Client, operatorConfig)
+	apiserverConfig, configMapModified, err := manageKubeApiserverConfigMap_v311_00_to_latest(c.corev1Client, operatorConfig)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap", err))
 	}
@@ -62,6 +76,15 @@ func syncKubeApiserver_v311_00_to_latest(c KubeApiserverOperator, operatorConfig
 	actualDeployment, _, err := manageKubeApiserverDeployment_v311_00_to_latest(c.appsv1Client, operatorConfig, previousAvailability, forceDeployment)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "deployment", err))
+	}
+
+	configData := ""
+	if apiserverConfig != nil{
+		configData = apiserverConfig.Data["config.yaml"]
+	}
+	_, _, err = manageKubeApiserverPublicConfigMap_v311_00_to_latest(c.corev1Client, configData, operatorConfig)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/public-info", err))
 	}
 
 	return resourcemerge.ApplyGenerationAvailability(versionAvailability, actualDeployment, errors...), errors
@@ -83,4 +106,34 @@ func manageKubeApiserverDeployment_v311_00_to_latest(client appsclientv1.Deploym
 	required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", options.Spec.Logging.Level))
 
 	return resourceapply.ApplyDeployment(client, required, resourcemerge.ExpectedDeploymentGeneration(required, previousAvailability), forceDeployment)
+}
+
+func manageKubeApiserverPublicConfigMap_v311_00_to_latest(client coreclientv1.ConfigMapsGetter, apiserverConfigString string, operatorConfig *v1alpha1.KubeApiserverOperatorConfig) (*corev1.ConfigMap, bool, error) {
+	uncastUnstructured, err := runtime.Decode(unstructured.UnstructuredJSONScheme, []byte(apiserverConfigString))
+	if err != nil{
+		return nil, false, err
+	}
+	apiserverConfig := uncastUnstructured.(runtime.Unstructured)
+
+
+	configMap := resourceread.ReadConfigMapV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/public-info.yaml"))
+	if operatorConfig.Status.CurrentAvailability != nil{
+		configMap.Data["version"] = operatorConfig.Status.CurrentAvailability.Version
+	} else{
+		configMap.Data["version"] = ""
+	}
+	configMap.Data["imagePolicyConfig.internalRegistryHostname"], _, err = unstructured.NestedString(apiserverConfig.UnstructuredContent(), "imagePolicyConfig", "internalRegistryHostname")
+	if err != nil{
+		return nil, false, err
+	}
+	configMap.Data["imagePolicyConfig.externalRegistryHostname"], _, err  =  unstructured.NestedString(apiserverConfig.UnstructuredContent(), "imagePolicyConfig", "externalRegistryHostname")
+	if err != nil{
+		return nil, false, err
+	}
+	configMap.Data["projectConfig.defaultNodeSelector"] , _, err =  unstructured.NestedString(apiserverConfig.UnstructuredContent(), "projectConfig", "defaultNodeSelector")
+	if err != nil{
+		return nil, false, err
+	}
+
+	return resourceapply.ApplyConfigMap(client, configMap)
 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -4,6 +4,9 @@
 // manifests/v3.11.0/kube-apiserver/defaultconfig.yaml
 // manifests/v3.11.0/kube-apiserver/deployment.yaml
 // manifests/v3.11.0/kube-apiserver/ns.yaml
+// manifests/v3.11.0/kube-apiserver/public-info-role.yaml
+// manifests/v3.11.0/kube-apiserver/public-info-rolebinding.yaml
+// manifests/v3.11.0/kube-apiserver/public-info.yaml
 // manifests/v3.11.0/kube-apiserver/sa.yaml
 // manifests/v3.11.0/kube-apiserver/svc.yaml
 // DO NOT EDIT!
@@ -218,6 +221,101 @@ func v3110KubeApiserverNsYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v3110KubeApiserverPublicInfoRoleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openshift-kube-apiserver
+  name: system:openshift:operator:kube-apiserver:public
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  resourceNames:
+  - public-info
+`)
+
+func v3110KubeApiserverPublicInfoRoleYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverPublicInfoRoleYaml, nil
+}
+
+func v3110KubeApiserverPublicInfoRoleYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverPublicInfoRoleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/public-info-role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3110KubeApiserverPublicInfoRolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-kube-apiserver
+  name: system:openshift:operator:kube-apiserver:public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:openshift:operator:kube-apiserver:public
+subjects:
+- kind: Group
+  name: system:authenticated
+`)
+
+func v3110KubeApiserverPublicInfoRolebindingYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverPublicInfoRolebindingYaml, nil
+}
+
+func v3110KubeApiserverPublicInfoRolebindingYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverPublicInfoRolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/public-info-rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3110KubeApiserverPublicInfoYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-apiserver
+  name: public-info
+data:
+  # version is the current of the kube-apiserver.  It is updated *after* it is being served consistently.
+  version:
+  # imagePolicyConfig.internalRegistryHostname is internal registry used for imagePolicyAdmission
+  # TODO this probably won't make it to 4.0, we're likely to stuff the entire imagePolicyAdmission config in here
+  imagePolicyConfig.internalRegistryHostname:
+  # imagePolicyConfig.externalRegistryHostname is external registry used for imagePolicyAdmission
+  # TODO this probably won't make it to 4.0, we're likely to stuff the entire imagePolicyAdmission config in here
+  imagePolicyConfig.externalRegistryHostname:
+  # defaultNodeSelector is used when no specific node selector is on a namespace
+  # TODO we'd really like to see this collapsed onto upstream values
+  projectConfig.defaultNodeSelector:`)
+
+func v3110KubeApiserverPublicInfoYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverPublicInfoYaml, nil
+}
+
+func v3110KubeApiserverPublicInfoYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverPublicInfoYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/public-info.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v3110KubeApiserverSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -329,6 +427,9 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/kube-apiserver/defaultconfig.yaml": v3110KubeApiserverDefaultconfigYaml,
 	"v3.11.0/kube-apiserver/deployment.yaml": v3110KubeApiserverDeploymentYaml,
 	"v3.11.0/kube-apiserver/ns.yaml": v3110KubeApiserverNsYaml,
+	"v3.11.0/kube-apiserver/public-info-role.yaml": v3110KubeApiserverPublicInfoRoleYaml,
+	"v3.11.0/kube-apiserver/public-info-rolebinding.yaml": v3110KubeApiserverPublicInfoRolebindingYaml,
+	"v3.11.0/kube-apiserver/public-info.yaml": v3110KubeApiserverPublicInfoYaml,
 	"v3.11.0/kube-apiserver/sa.yaml": v3110KubeApiserverSaYaml,
 	"v3.11.0/kube-apiserver/svc.yaml": v3110KubeApiserverSvcYaml,
 }
@@ -379,6 +480,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"defaultconfig.yaml": &bintree{v3110KubeApiserverDefaultconfigYaml, map[string]*bintree{}},
 			"deployment.yaml": &bintree{v3110KubeApiserverDeploymentYaml, map[string]*bintree{}},
 			"ns.yaml": &bintree{v3110KubeApiserverNsYaml, map[string]*bintree{}},
+			"public-info-role.yaml": &bintree{v3110KubeApiserverPublicInfoRoleYaml, map[string]*bintree{}},
+			"public-info-rolebinding.yaml": &bintree{v3110KubeApiserverPublicInfoRolebindingYaml, map[string]*bintree{}},
+			"public-info.yaml": &bintree{v3110KubeApiserverPublicInfoYaml, map[string]*bintree{}},
 			"sa.yaml": &bintree{v3110KubeApiserverSaYaml, map[string]*bintree{}},
 			"svc.yaml": &bintree{v3110KubeApiserverSvcYaml, map[string]*bintree{}},
 		}},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -73,12 +73,8 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v3110KubeApiserverDefaultconfigYaml = []byte(`# TODO this will change to KubeAPIServerConfig
-apiVersion: v1
-kind: MasterConfig
-signer:
-  certFile: /var/run/secrets/signing-key/tls.crt
-  keyFile: /var/run/secrets/signing-key/tls.key
+var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
+kind: KubeAPIServerConfig
 `)
 
 func v3110KubeApiserverDefaultconfigYamlBytes() ([]byte, error) {
@@ -131,15 +127,55 @@ spec:
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /var/run/configmaps/aggregator-client-ca
+          name: aggregator-client-ca
+        - mountPath: /var/run/configmaps/client-ca
+          name: client-ca
+        - mountPath: /var/run/configmaps/etcd-serving-ca
+          name: etcd-serving-ca
+        - mountPath: /var/run/configmaps/kubelet-serving-ca
+          name: kubelet-serving-ca
+        - mountPath: /var/run/configmaps/sa-token-signing-certs
+          name: sa-token-signing-certs
+        - mountPath: /var/run/secrets/aggregator-client
+          name: aggregator-client
+        - mountPath: /var/run/secrets/etcd-client
+          name: etcd-client
+        - mountPath: /var/run/secrets/kubelet-client
+          name: kubelet-client
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
       volumes:
-      - name: serving-cert
-        secret:
-          secretName: serving-cert
       - name: config
         configMap:
           name: deployment-apiserver-config
+      - name: aggregator-client-ca
+        configMap:
+          name: aggregator-client-ca
+      - name: client-ca
+        configMap:
+          name: client-ca
+      - name: etcd-serving-ca
+        configMap:
+          name: etcd-serving-ca
+      - name: kubelet-serving-ca
+        configMap:
+          name: kubelet-serving-ca
+      - name: sa-token-signing-certs
+        configMap:
+          name: sa-token-signing-certs
+      - name: aggregator-client
+        secret:
+          secretName: aggregator-client
+      - name: etcd-client
+        secret:
+          secretName: etcd-client
+      - name: kubelet-client
+        secret:
+          secretName: kubelet-client
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
 
 
 


### PR DESCRIPTION
This exposes information the openshift apiserver operator needs.  Technically it works, but it errors when merging configuration because a sparse config doesn't technically require an apiversion and kind.  This produces an interesting/awful hot loop.

The bug is preexisting, so this is still strictly an improvement.

/assign @sttts @mfojtik 