### PR TITLE
svc.yaml: set type:ClusterIP to avoid repeated updates

### DIFF
--- a/manifests/v3.11.0/kube-apiserver/svc.yaml
+++ b/manifests/v3.11.0/kube-apiserver/svc.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
 spec:
+  type: ClusterIP
   selector:
     apiserver: "true"
   ports:


### PR DESCRIPTION
We compare the type on apply. It is defaulted to ClusterIP on the server, but is empty in the operator manifest.