### PR TITLE
remove git clean when building images

### DIFF
--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -83,8 +83,6 @@ function os::build::image::internal::generic() {
 		fi
 	fi
 
-	# ensure the temporary contents are cleaned up
-	git clean -fdx "${directory}"
 	return "${result}"
 }
 readonly -f os::build::image::internal::generic


### PR DESCRIPTION
Fixes https://github.com/openshift/cluster-kube-apiserver-operator/issues/18