### PR TITLE
add category for crd:

### DIFF
--- a/manifests/install/operator.yaml
+++ b/manifests/install/operator.yaml
@@ -20,6 +20,8 @@ items:
       kind: KubeApiserverOperatorConfig
       plural: kubeapiserveroperatorconfigs
       singular: kubeapiserveroperatorconfig
+      categories:
+      - coreoperators
     subresources:
       status: {}
 


### PR DESCRIPTION
This let's us do 

`oc get coreoperators -oyaml` and see all the core operator resources we have (four at least).

/assign @mfojtik @sttts 