### PR TITLE
make bootstrap apiserver privileged to work around selinux

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -24,6 +24,7 @@ spec:
       rm -f /var/lock/* || true
     securityContext:
       runAsNonRoot: false
+      privileged: true
     volumeMounts:
     - mountPath: /var/lock
       name: var-lock
@@ -36,6 +37,7 @@ spec:
     - exec hypershift openshift-kube-apiserver --config=/etc/kubernetes/config/{{ .ConfigFileName }}
     securityContext:
       runAsNonRoot: true
+      privileged: true
       runAsUser: 65534
     volumeMounts:
     - mountPath: /var/lock


### PR DESCRIPTION
This will allow to pass selinux for bootstrap static pod. The daemonset pods does not need this for some reason... I tested this and it works. It probably can be tweaked further with `seLinuxOptions`.