### PR TITLE
use explicit lock path

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -21,7 +21,7 @@ spec:
     - |
       chgrp 65534 /var/lock
       chmod 775 /var/lock
-      rm -f /var/lock/* || true
+      rm -f /var/lock/api-server.lock || true
     securityContext:
       runAsNonRoot: false
       privileged: true


### PR DESCRIPTION
The lock directory might be shared with controller manager, it is better to remove the files we create in apiserver instead of nuking entire directory.

/cc @sttts 
/cc @openshift/sig-master 