### PR TITLE
render: make etcd-serving-ca customizable

### DIFF
--- a/bindata/bootkube/manifests/configmap-etcd-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-etcd-serving-ca.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ .Namespace }}
 data:
   ca-bundle.crt: |
-    {{ .Assets | load "root-ca.crt" | indent 4 }}
+    {{ .Assets | load .EtcdServingCA | indent 4 }}

--- a/cmd/cluster-kube-apiserver-operator/render/config.go
+++ b/cmd/cluster-kube-apiserver-operator/render/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// EtcdServerURLs is a list of etcd server URLs.
 	EtcdServerURLs []string
 
+	// EtcdServingCA is the serving CA used by the etcd servers.
+	EtcdServingCA string
+
 	// Namespace is the target namespace for the bootstrap kubeapi server to be created.
 	Namespace string
 

--- a/cmd/cluster-kube-apiserver-operator/render/render.go
+++ b/cmd/cluster-kube-apiserver-operator/render/render.go
@@ -32,6 +32,7 @@ type manifestOpts struct {
 	secretsHostPath       string
 	lockHostPath          string
 	etcdServerURLs        []string
+	etcdServingCA         string
 }
 
 // renderOpts holds values to drive the render command.
@@ -69,6 +70,7 @@ func NewRenderCommand() *cobra.Command {
 	cmd.Flags().StringVar(&renderOpts.manifest.configFileName, "manifest-config-file-name", "kube-apiserver-config.yaml", "The config file name inside the manifest-config-host-path.")
 	cmd.Flags().StringVar(&renderOpts.manifest.cloudProviderHostPath, "manifest-cloud-provider-host-path", "/etc/kubernetes/cloud", "A host path mounted into the apiserver pods to hold cloud provider configuration.")
 	cmd.Flags().StringArrayVar(&renderOpts.manifest.etcdServerURLs, "manifest-etcd-server-urls", []string{"https://127.0.0.1:2379"}, "The etcd server URL, comma separated.")
+	cmd.Flags().StringVar(&renderOpts.manifest.etcdServingCA, "manifest-etcd-serving-ca", "root-ca.crt", "The etcd serving ca.")
 
 	cmd.Flags().StringVar(&renderOpts.assetOutputDir, "asset-output-dir", "", "Output path for rendered manifests.")
 	cmd.Flags().StringVar(&renderOpts.assetInputDir, "asset-input-dir", "", "A path to directory with certificates and secrets.")
@@ -106,6 +108,9 @@ func (r *renderOpts) Validate() error {
 	}
 	if len(r.manifest.etcdServerURLs) == 0 {
 		return errors.New("missing etcd server URLs: --manifest-etcd-server-urls")
+	}
+	if len(r.manifest.etcdServingCA) == 0 {
+		return errors.New("missing etcd serving CA: --manifest-etcd-serving-ca")
 	}
 
 	if len(r.assetInputDir) == 0 {
@@ -146,6 +151,7 @@ func (r *renderOpts) Run() error {
 		SecretsHostPath:       r.manifest.secretsHostPath,
 		LockHostPath:          r.manifest.lockHostPath,
 		EtcdServerURLs:        r.manifest.etcdServerURLs,
+		EtcdServingCA:         r.manifest.etcdServingCA,
 	}
 
 	// create post-poststrap configuration


### PR DESCRIPTION
Replacement of https://github.com/openshift/cluster-kube-apiserver-operator/pull/51 to unblock us and to move the issue into the installer (where it can be resolved one way or the other).