### PR TITLE
manifests: provide kube-system configs and secrets

### DIFF
--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -2,26 +2,26 @@ apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 aggregatorConfig:
   proxyClientInfo:
-    certFile: /etc/kubernetes/secrets/apiserver-proxy.crt # origin 3.11: openshift-aggregator.crt
-    keyFile: /etc/kubernetes/secrets/apiserver-proxy.key # origin 3.11: openshift-aggregator.key
+    certFile: /var/run/secrets/aggregator-client/tls.crt
+    keyFile: /var/run/secrets/aggregator-client/tls.key
 authConfig:
   requestHeader:
-    clientCA: /etc/kubernetes/secrets/aggregator-ca.crt # origin 3.11: frontproxy-ca.crt
+    clientCA: /var/run/configmaps/aggregator-client-ca/ca-bundle.crt
 kubeletClientInfo:
-  ca: /etc/kubernetes/secrets/kube-ca.crt # origin 3.11: ca.crt
-  certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.kubelet-client.crt
-  keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.kubelet-client.key
+  ca: /var/run/configmaps/kubelet-serving-ca/ca-bundle.crt
+  certFile: /var/run/secrets/kubelet-client/tls.crt
+  keyFile: /var/run/secrets/kubelet-client/tls.key
 oauthConfig:
-  masterCA: /etc/kubernetes/secrets/root-ca.crt # origin 3.11: ca.crt
+  masterCA: /var/run/configmaps/client-ca/ca-bundle.crt
 serviceAccountPublicKeyFiles:
-- /etc/kubernetes/secrets/service-account.pub # origin 3.11: serviceaccounts.public.key
+- /var/run/configmaps/sa-token-signing-certs/ca-bundle.crt
 servingInfo:
-  certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.server.crt
-  clientCA: /etc/kubernetes/secrets/kube-ca.crt # origin 3.11: ca.crt
-  keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.server.key
+  certFile: /var/run/secrets/serving-cert/tls.crt
+  clientCA: /var/run/configmaps/client-ca/ca-bundle.crt
+  keyFile: /var/run/secrets/serving-cert/tls.key
 storageConfig:
-  ca: /etc/kubernetes/secrets/{{.EtcdServingCA}} # origin 3.11: ca.crt
-  certFile: /etc/kubernetes/secrets/etcd-client.crt # origin 3.11: master.etcd-client.crt
-  keyFile: /etc/kubernetes/secrets/etcd-client.key # origin 3.11: master.etcd-client.key
+  ca: /var/run/configmaps/etcd-serving-ca/ca-bundle.crt
+  certFile: /var/run/secrets/etcd-client/tls.crt
+  keyFile: /var/run/secrets/etcd-client/tls.key
   urls: {{range .EtcdServerURLs}}
   - {{.}}{{end}}

--- a/bindata/bootkube/manifests/daemonset-kube-apiserver.yaml
+++ b/bindata/bootkube/manifests/daemonset-kube-apiserver.yaml
@@ -48,7 +48,7 @@ spec:
         imagePullPolicy: {{ .ImagePullPolicy }}
         command: ["/usr/bin/flock", "--exclusive", "--timeout=60", "/var/lock/api-server.lock", "-c"]
         args:
-        - exec hypershift openshift-kube-apiserver --config=/etc/kubernetes/config/{{ .ConfigFileName }}
+        - exec hypershift openshift-kube-apiserver --config=/var/run/configmaps/config/config.yaml
         securityContext:
           runAsNonRoot: true
           runAsUser: 65534

--- a/bindata/bootkube/manifests/daemonset-kube-apiserver.yaml
+++ b/bindata/bootkube/manifests/daemonset-kube-apiserver.yaml
@@ -60,15 +60,26 @@ spec:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
           readOnly: true
-        - mountPath: /etc/kubernetes/secrets
-          name: secrets
-          readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: etc-kubernetes-cloud
-          readOnly: true
-        - mountPath: /etc/kubernetes/config
+        - mountPath: /var/run/configmaps/config
           name: config
-          readOnly: true
+        - mountPath: /var/run/configmaps/aggregator-client-ca
+          name: aggregator-client-ca
+        - mountPath: /var/run/configmaps/client-ca
+          name: client-ca
+        - mountPath: /var/run/configmaps/etcd-serving-ca
+          name: etcd-serving-ca
+        - mountPath: /var/run/configmaps/kubelet-serving-ca
+          name: kubelet-serving-ca
+        - mountPath: /var/run/configmaps/sa-token-signing-certs
+          name: sa-token-signing-certs
+        - mountPath: /var/run/secrets/aggregator-client
+          name: aggregator-client
+        - mountPath: /var/run/secrets/etcd-client
+          name: etcd-client
+        - mountPath: /var/run/secrets/kubelet-client
+          name: kubelet-client
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -77,18 +88,39 @@ spec:
         operator: Exists
         effect: NoSchedule
       volumes:
+      - name: config
+        configMap:
+          name: kube-apiserver-config
+      - name: aggregator-client-ca
+        configMap:
+          name: aggregator-client-ca
+      - name: client-ca
+        configMap:
+          name: client-ca
+      - name: etcd-serving-ca
+        configMap:
+          name: etcd-serving-ca
+      - name: kubelet-serving-ca
+        configMap:
+          name: kubelet-serving-ca
+      - name: sa-token-signing-certs
+        configMap:
+          name: sa-token-signing-certs
+      - name: aggregator-client
+        secret:
+          secretName: aggregator-client
+      - name: etcd-client
+        secret:
+          secretName: etcd-client
+      - name: kubelet-client
+        secret:
+          secretName: kubelet-client
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
       - hostPath:
           path: {{ .LockHostPath }}
         name: var-lock
-      - hostPath:
-          path: {{ .SecretsHostPath }}
-        name: secrets
-      - hostPath:
-          path: {{ .CloudProviderHostPath }}
-        name: etc-kubernetes-cloud
-      - hostPath:
-          path: {{ .ConfigHostPath }}
-        name: config
       - hostPath:
           path: /etc/ssl/certs
         name: ssl-certs-host

--- a/bindata/bootkube/manifests/kube-system-configmap-aggregator-client-ca.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-aggregator-client-ca.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aggregator-client-ca
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "aggregator-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/kube-system-configmap-client-ca.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-client-ca.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: client-ca
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "kube-ca.crt" | indent 4 }}
+

--- a/bindata/bootkube/manifests/kube-system-configmap-etcd-serving-ca.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-etcd-serving-ca.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-serving-ca
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load .EtcdServingCA | indent 4 }}

--- a/bindata/bootkube/manifests/kube-system-configmap-kube-apiserver-config.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-kube-apiserver-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-apiserver-config
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  config.yaml: |
+    {{ .PostBootstrapKubeAPIServerConfig | indent 4 }}

--- a/bindata/bootkube/manifests/kube-system-configmap-kubelet-serving-ca.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-kubelet-serving-ca.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubelet-serving-ca
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "kube-ca.crt" | indent 4 }}
+

--- a/bindata/bootkube/manifests/kube-system-configmap-sa-token-signing-certs.yaml
+++ b/bindata/bootkube/manifests/kube-system-configmap-sa-token-signing-certs.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sa-token-signing-certs
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "service-account.pub" | indent 4 }}

--- a/bindata/bootkube/manifests/kube-system-secret-aggregator-client.yaml
+++ b/bindata/bootkube/manifests/kube-system-secret-aggregator-client.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aggregator-client
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "apiserver-proxy.crt" | base64 }}
+  tls.key: {{ .Assets | load "apiserver-proxy.key" | base64 }}

--- a/bindata/bootkube/manifests/kube-system-secret-etcd-client.yaml
+++ b/bindata/bootkube/manifests/kube-system-secret-etcd-client.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "etcd-client.crt" | base64 }}
+  tls.key: {{ .Assets | load "etcd-client.key" | base64 }}

--- a/bindata/bootkube/manifests/kube-system-secret-kubelet-client.yaml
+++ b/bindata/bootkube/manifests/kube-system-secret-kubelet-client.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubelet-client
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}
+  tls.key: {{ .Assets | load "apiserver.key" | base64 }}

--- a/bindata/bootkube/manifests/kube-system-secret-serving-cert.yaml
+++ b/bindata/bootkube/manifests/kube-system-secret-serving-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: serving-cert
+  namespace: kube-system
+  labels:
+    tier: "control-plane"
+    k8s-app: "kube-apiserver"
+    openshift.io/control-plane: "true"
+    openshift.io/component: "api"
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}
+  tls.key: {{ .Assets | load "apiserver.key" | base64 }}


### PR DESCRIPTION
Copy the secrets into `kube-system` namespace for the bootkube daemonset and change the daemonset to use them instead of relying on hostPaths, which does not exists on the master nodes.

/cc @deads2k 
/cc @sttts 