### PR TITLE
manifests: fix image name

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,7 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
-  - name: hyperkube
+  - name: hypershift
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-hypershift:v4.0


### PR DESCRIPTION
```
$ oc get is origin-v4.0-20181012001457 -o yaml | grep -B5 "tag: hyperkube"
  - items:
    - created: 2018-10-12T00:14:57Z
      dockerImageReference: docker-registry.default.svc:5000/openshift/origin-v4.0-20181012001457@sha256:d02876d2764600ced0124d9fec8b346c547d3e8334acb66db99f14ed9de630b0
      generation: 1
      image: sha256:d02876d2764600ced0124d9fec8b346c547d3e8334acb66db99f14ed9de630b0
    tag: hyperkube

$ oc get is origin-v4.0-20181012001457 -o yaml | grep -B5 "tag: hypershift"
  - items:
    - created: 2018-10-12T00:14:57Z
      dockerImageReference: docker-registry.default.svc:5000/openshift/origin-v4.0-20181012001457@sha256:492237def6e4b5db4f95838240d493b093fa13c84b77dac82ed8396b26eb67ed
      generation: 1
      image: sha256:492237def6e4b5db4f95838240d493b093fa13c84b77dac82ed8396b26eb67ed
    tag: hypershift
```

In my 4.0 cluster:
```
$ oc get pod apiserver-7796f495cb-gt2nt -o yaml | grep image:
    image: registry.svc.ci.openshift.org/openshift/origin-v4.0-20181011224027@sha256:d02876d2764600ced0124d9fec8b346c547d3e8334acb66db99f14ed9de630b0

$ oc get event | grep hypershift
54m         56m          12        apiserver-7796f495cb-zrz7n.155cb9022b1da0f0   Pod          spec.containers{apiserver}   Warning   Failed              kubelet, dev-master-0   Error: container create failed: container_linux.go:336: starting container process caused "exec: \"hypershift\": executable file not found in $PATH"
```

https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/manifests/image-references#L9

The PR fixes the image name so the `hypershift` image is used.

@deads2k @sttts 