### PR TITLE
render: pluralize --config-overrides-file

### DIFF
--- a/cmd/cluster-kube-apiserver-operator/render/render.go
+++ b/cmd/cluster-kube-apiserver-operator/render/render.go
@@ -39,11 +39,12 @@ type manifestOpts struct {
 type renderOpts struct {
 	manifest manifestOpts
 
-	templatesDir        string
-	assetInputDir       string
-	assetOutputDir      string
-	configOverrideFiles []string
-	configOutputFile    string
+	templatesDir                 string
+	assetInputDir                string
+	assetOutputDir               string
+	configOverrideFiles          []string
+	deprecatedConfigOverrideFile string
+	configOutputFile             string
 }
 
 func NewRenderCommand() *cobra.Command {
@@ -77,6 +78,11 @@ func NewRenderCommand() *cobra.Command {
 	cmd.Flags().StringVar(&renderOpts.templatesDir, "templates-input-dir", "/usr/share/bootkube/manifests", "A path to a directory with manifest templates.")
 	cmd.Flags().StringSliceVar(&renderOpts.configOverrideFiles, "config-override-files", nil, "Additional sparse KubeAPIConfig.kubecontrolplane.config.openshift.io/v1 files for customiziation through the installer, merged into the default config in the given order.")
 	cmd.Flags().StringVar(&renderOpts.configOutputFile, "config-output-file", "", "Output path for the KubeAPIServerConfig yaml file.")
+
+	// TODO: Remove these once we break the flag dependency loop in installer
+	cmd.Flags().StringVar(&renderOpts.deprecatedConfigOverrideFile, "config-override-file", "", "")
+	cmd.Flags().MarkHidden("config-override-file")
+	cmd.Flags().MarkDeprecated("config-override-file", "Use 'config-override-files' flag instead")
 
 	return cmd
 }
@@ -186,6 +192,10 @@ func (r *renderOpts) configFromDefaultsPlusOverride(data *Config, tlsOverride st
 	bootstrapOverrides, err := readFileTemplate(tlsOverride, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config override file %q: %v", tlsOverride, err)
+	}
+	// TODO: Remove this when the flag is gone
+	if len(r.deprecatedConfigOverrideFile) > 0 {
+		r.configOverrideFiles = append(r.configOverrideFiles, r.deprecatedConfigOverrideFile)
 	}
 	configs := [][]byte{defaultConfig, bootstrapOverrides}
 	for _, fname := range r.configOverrideFiles {


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-apiserver-operator/pull/69 with deprecation instead of changing the flag. Allow us to fix installer and remove deprecated flag afterwards.