### PR TITLE
sync restrictedCIDRs with install-config

### DIFF
--- a/pkg/operator/observe_config.go
+++ b/pkg/operator/observe_config.go
@@ -7,10 +7,10 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
+	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,13 +19,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
 
 	operatorconfigclientv1alpha1 "github.com/openshift/cluster-kube-apiserver-operator/pkg/generated/clientset/versioned/typed/kubeapiserver/v1alpha1"
-	operatorconfiginformerv1alpha1 "github.com/openshift/cluster-kube-apiserver-operator/pkg/generated/informers/externalversions/kubeapiserver/v1alpha1"
+	kubeapiserveroperatorinformers "github.com/openshift/cluster-kube-apiserver-operator/pkg/generated/informers/externalversions"
 )
+
+type observeConfigFunc func(kubernetes.Interface, *rest.Config, map[string]interface{}) (map[string]interface{}, error)
 
 type ConfigObserver struct {
 	operatorConfigClient operatorconfigclientv1alpha1.KubeapiserverV1alpha1Interface
@@ -36,11 +39,14 @@ type ConfigObserver struct {
 	queue workqueue.RateLimitingInterface
 
 	rateLimiter flowcontrol.RateLimiter
+	// observers are used to build the observed configuration. They are called in
+	// order and are expected to mutate the config based on cluster state.
+	observers []observeConfigFunc
 }
 
 func NewConfigObserver(
-	operatorConfigInformer operatorconfiginformerv1alpha1.KubeApiserverOperatorConfigInformer,
-	etcdNamespacedKubeInformers kubeinformers.SharedInformerFactory,
+	operatorConfigInformers kubeapiserveroperatorinformers.SharedInformerFactory,
+	kubeInformersForKubeSystemNamespace kubeinformers.SharedInformerFactory,
 	operatorConfigClient operatorconfigclientv1alpha1.KubeapiserverV1alpha1Interface,
 	kubeClient kubernetes.Interface,
 ) *ConfigObserver {
@@ -51,10 +57,15 @@ func NewConfigObserver(
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
 
 		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
+		observers: []observeConfigFunc{
+			observeEtcdEndpoints,
+			observeClusterConfig,
+		},
 	}
 
-	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
-	etcdNamespacedKubeInformers.Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
+	operatorConfigInformers.Kubeapiserver().V1alpha1().KubeApiserverOperatorConfigs().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForKubeSystemNamespace.Core().V1().Endpoints().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 
 	return c
 }
@@ -62,28 +73,20 @@ func NewConfigObserver(
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
 func (c ConfigObserver) sync() error {
+
+	observedConfig := map[string]interface{}{}
+	var err error
+
+	for _, observer := range c.observers {
+		observedConfig, err = observer(c.kubeClient, &rest.Config{}, observedConfig)
+		if err != nil {
+			return err
+		}
+	}
+
 	operatorConfig, err := c.operatorConfigClient.KubeApiserverOperatorConfigs().Get("instance", metav1.GetOptions{})
 	if err != nil {
 		return err
-	}
-	observedConfig := map[string]interface{}{}
-
-	// we read the etcd endpoints from the endpoints object and then manually pull out the hostnames to get the etcd urls for our config.
-	// Setting them observed config causes the normal reconciliation loop to run
-	etcdURLs := []string{}
-	etcdEndpoints, err := c.kubeClient.CoreV1().Endpoints(etcdNamespaceName).Get("etcd", metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	if etcdEndpoints != nil {
-		for _, subset := range etcdEndpoints.Subsets {
-			for _, address := range subset.Addresses {
-				etcdURLs = append(etcdURLs, "https://"+address.Hostname+"."+etcdEndpoints.Annotations["alpha.installer.openshift.io/dns-suffix"]+":2379")
-			}
-		}
-	}
-	if len(etcdURLs) > 0 {
-		unstructured.SetNestedStringSlice(observedConfig, etcdURLs, "storageConfig", "urls")
 	}
 
 	// don't worry about errors
@@ -100,6 +103,88 @@ func (c ConfigObserver) sync() error {
 	}
 
 	return nil
+}
+
+// observeEtcdEndpoints reads the etcd endpoints from the endpoints object and then manually pull out the hostnames to
+// get the etcd urls for our config. Setting them observed config causes the normal reconciliation loop to run
+func observeEtcdEndpoints(kubeClient kubernetes.Interface, clientConfig *rest.Config, observedConfig map[string]interface{}) (map[string]interface{}, error) {
+	etcdURLs := []string{}
+	etcdEndpoints, err := kubeClient.CoreV1().Endpoints(etcdNamespaceName).Get("etcd", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return observedConfig, nil
+	}
+	if err != nil {
+		return observedConfig, err
+	}
+	for _, subset := range etcdEndpoints.Subsets {
+		for _, address := range subset.Addresses {
+			etcdURLs = append(etcdURLs, "https://"+address.Hostname+"."+etcdEndpoints.Annotations["alpha.installer.openshift.io/dns-suffix"]+":2379")
+		}
+	}
+	if len(etcdURLs) > 0 {
+		unstructured.SetNestedStringSlice(observedConfig, etcdURLs, "storageConfig", "urls")
+	} else {
+		glog.Warningf("no etcd endpoints found")
+	}
+	return observedConfig, nil
+}
+
+// observeClusterConfig observes CIDRs from cluster-config-v1 in order to populate list of restrictedCIDRs
+func observeClusterConfig(kubeClient kubernetes.Interface, clientConfig *rest.Config, observedConfig map[string]interface{}) (map[string]interface{}, error) {
+	clusterConfig, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get("cluster-config-v1", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		glog.Warningf("cluster-config-v1 not found in the kube-system namespace")
+		return observedConfig, nil
+	}
+	if err != nil {
+		return observedConfig, err
+	}
+
+	installConfigYaml, ok := clusterConfig.Data["install-config"]
+	if !ok {
+		return observedConfig, nil
+	}
+	installConfig := map[string]interface{}{}
+	err = yaml.Unmarshal([]byte(installConfigYaml), &installConfig)
+	if err != nil {
+		glog.Warningf("Unable to parse install-config: %s", err)
+		return observedConfig, nil
+	}
+
+	// extract needed values
+	//  data:
+	//   install-config:
+	//     networking:
+	//       podCIDR: 10.2.0.0/16
+	//       serviceCIDR: 10.3.0.0/16
+	restrictedCIDRs := []string{}
+	networking, ok := installConfig["networking"].(map[string]interface{})
+	if !ok {
+		return observedConfig, nil
+	}
+	if cidr := networking["podCIDR"]; cidr != nil {
+		restrictedCIDRs = append(restrictedCIDRs, fmt.Sprintf("%v", cidr))
+	} else {
+		glog.Warningf("No value found for install-config/networking/podCIDR.")
+	}
+	if cidr := networking["serviceCIDR"]; cidr != nil {
+		restrictedCIDRs = append(restrictedCIDRs, fmt.Sprintf("%v", cidr))
+	} else {
+		glog.Warningf("No value found for install-config/networking/serviceCIDR.")
+	}
+	// set observed values
+	//  admissionPluginConfig:
+	//    openshift.io/RestrictedEndpointsAdmission:
+	//	  configuration:
+	//	    restrictedCIDRs:
+	//	    - 10.3.0.0/16 # ServiceCIDR
+	//	    - 10.2.0.0/16 # ClusterCIDR
+	if len(restrictedCIDRs) > 0 {
+		unstructured.SetNestedStringSlice(observedConfig, restrictedCIDRs,
+			"admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	}
+
+	return observedConfig, nil
 }
 
 func (c *ConfigObserver) Run(workers int, stopCh <-chan struct{}) {

--- a/pkg/operator/observe_config_test.go
+++ b/pkg/operator/observe_config_test.go
@@ -1,0 +1,41 @@
+package operator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestObserveClusterConfig(t *testing.T) {
+	const (
+		podCIDR     = "10.9.8.7/99"
+		serviceCIDR = "11.6.7.5/88"
+	)
+	kubeClient := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config-v1",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"install-config": "networking:\n  podCIDR: " + podCIDR + "\n  serviceCIDR: " + serviceCIDR + "\n",
+		},
+	})
+	result, err := observeClusterConfig(kubeClient, &rest.Config{}, map[string]interface{}{})
+	if err != nil {
+		t.Error("expected err == nil")
+	}
+	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restrictedCIDRs[0] != podCIDR {
+		t.Error(restrictedCIDRs[0])
+	}
+	if restrictedCIDRs[1] != serviceCIDR {
+		t.Error(restrictedCIDRs[1])
+	}
+}


### PR DESCRIPTION
Enables the cluster-kube-apiserver-operator to receive notifications of changes to the  `cluster-config-v1` ConfigMap in the `kube-system` namespace, from which some CIDRs are extracted, i.e:
```yaml
data:
  install-config:
    networking:
    podCIDR: 10.2.0.0/16
    serviceCIDR: 10.3.0.0/16
```
Adds the discovered CIDRs to the `restrictedCIDRs` array to the cluster kube apiserver's config. e.g.:
```yaml
admissionPluginConfig:
  openshift.io/RestrictedEndpointsAdmission:
    configuration:
      restrictedCIDRs:
        - 10.3.0.0/16 # ServiceCIDR
        - 10.2.0.0/16 # ClusterCIDR
```
Resolves #50 