### PR TITLE
Unify kube-apiserver-config name

### DIFF
--- a/bindata/bootkube/manifests/configmap-kube-apiserver-config.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-apiserver-config.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-apiserver-config
-  namespace: {{ .Namespace }}
-data:
-  config.yaml: |
-    {{ .PostBootstrapKubeAPIServerConfig | indent 4 }}

--- a/bindata/v3.11.0/kube-apiserver/cm.yaml
+++ b/bindata/v3.11.0/kube-apiserver/cm.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-apiserver
-  name: deployment-apiserver-config
+  name: deployment-kube-apiserver-config
 data:
   config.yaml:

--- a/bindata/v3.11.0/kube-apiserver/deployment.yaml
+++ b/bindata/v3.11.0/kube-apiserver/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: deployment-apiserver-config
+          name: deployment-kube-apiserver-config
       - name: aggregator-client-ca
         configMap:
           name: aggregator-client-ca

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -59,7 +59,7 @@ var _v3110KubeApiserverCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-apiserver
-  name: deployment-apiserver-config
+  name: deployment-kube-apiserver-config
 data:
   config.yaml:
 `)
@@ -302,7 +302,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: deployment-apiserver-config
+          name: deployment-kube-apiserver-config
       - name: aggregator-client-ca
         configMap:
           name: aggregator-client-ca


### PR DESCRIPTION
We should use the full component name to be consistent.

Moreover, the config from the render step is not used.