### PR TITLE
render: add rbac rules for proxy/logs from apiserver

### DIFF
--- a/bindata/bootkube/manifests/cluster-role-binding-kube-apiserver.yaml
+++ b/bindata/bootkube/manifests/cluster-role-binding-kube-apiserver.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-apiserver
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kube-apiserver

--- a/bindata/bootkube/manifests/cluster-role-kube-apiserver.yaml
+++ b/bindata/bootkube/manifests/cluster-role-kube-apiserver.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-apiserver
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+  - create


### PR DESCRIPTION
This fixes (together with the correct empty kubelet CA in the apiserver config) the use of `kubectl logs`.