### PR TITLE
Add cabundle configmap observer

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	etcdNamespaceName   = "kube-system"
-	targetNamespaceName = "openshift-kube-apiserver"
-	workQueueKey        = "key"
+	etcdNamespaceName              = "kube-system"
+	targetNamespaceName            = "openshift-kube-apiserver"
+	serviceCertSignerNamespaceName = "openshift-service-cert-signer"
+	workQueueKey                   = "key"
 )
 
 type KubeAPIServerOperator struct {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -36,6 +36,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	kubeInformersForOpenshiftKubeAPIServerNamespace := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(targetNamespaceName))
 	kubeInformersForKubeSystemNamespace := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace("kube-system"))
+	kubeInformersForOpenshiftServiceCertSignerNamespace := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(serviceCertSignerNamespaceName))
 
 	v1alpha1helpers.EnsureOperatorConfigExists(
 		dynamicClient,
@@ -57,7 +58,9 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 		operatorConfigInformers,
 		kubeInformersForKubeSystemNamespace,
 		operatorConfigClient.KubeapiserverV1alpha1(),
+		kubeInformersForOpenshiftServiceCertSignerNamespace,
 		kubeClient,
+		clientConfig,
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
@@ -70,6 +73,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	operatorConfigInformers.Start(stopCh)
 	kubeInformersForOpenshiftKubeAPIServerNamespace.Start(stopCh)
 	kubeInformersForKubeSystemNamespace.Start(stopCh)
+	kubeInformersForOpenshiftServiceCertSignerNamespace.Start(stopCh)
 
 	go operator.Run(1, stopCh)
 	go configObserver.Run(1, stopCh)


### PR DESCRIPTION
cc @deads2k @sttts 

Adds a ca-bundle configmap, whose ca.crt value is populated by the serving-service-cert-signer controller.  Adds an observer for the ca.crt value of the new configmap

Will add a test