### PR TITLE
create installer loop

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/installer-pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/installer-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: installer-<deployment-id>-<nodeName>
+  labels:
+    app: installer
+spec:
+  # TODO change this
+  serviceAccountName: openshift-kube-apiserver-sa
+  containers:
+  - name: apiserver
+    image: ${IMAGE}
+    imagePullPolicy: Always
+    command: ["cluster-kube-apiserver-operator", "operator"]
+  restartPolicy: Never

--- a/pkg/operator/installer_controller_v311_00.go
+++ b/pkg/operator/installer_controller_v311_00.go
@@ -1,0 +1,183 @@
+package operator
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/apis/kubeapiserver/v1alpha1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1alpha1helpers"
+)
+
+// createInstallerController_v311_00_to_latest takes care of creating content for the static pods to deploy.
+// returns whether or not requeue and if an error happened when updating status.  Normally it updates status itself.
+func createInstallerController_v311_00_to_latest(c InstallerController, operatorConfig *v1alpha1.KubeApiserverOperatorConfig) (bool, error) {
+	operatorConfigOriginal := operatorConfig.DeepCopy()
+
+	for i := range operatorConfig.Status.TargetKubeletStates {
+		var currKubeletState *v1alpha1.KubeletState
+		var prevKubeletState *v1alpha1.KubeletState
+		currKubeletState = &operatorConfig.Status.TargetKubeletStates[i]
+		if i > 0 {
+			prevKubeletState = &operatorConfig.Status.TargetKubeletStates[i-1]
+		}
+
+		// if we are in a transition, check to see if our installer pod completed
+		if currKubeletState.CurrentDeploymentID != currKubeletState.TargetDeploymentID {
+			// TODO check to see if our installer pod completed.  Success or failure there indicates whether we should be failed.
+			newCurrKubeletState, err := checkIfInstallComplete(c.kubeClient, currKubeletState)
+			if err != nil {
+				return true, err
+			}
+
+			// if we make a change to this status, we want to write it out to the API before we commence work on the next kubelet.
+			// it's an extra write/read, but it makes the state debuggable from outside this process
+			if !equality.Semantic.DeepEqual(newCurrKubeletState, currKubeletState) {
+				glog.Infof("%q moving to %v", currKubeletState.NodeName, spew.Sdump(*newCurrKubeletState))
+				operatorConfig.Status.TargetKubeletStates[i] = *newCurrKubeletState
+				if !reflect.DeepEqual(operatorConfigOriginal, operatorConfig) {
+					_, updateError := c.operatorConfigClient.KubeApiserverOperatorConfigs().UpdateStatus(operatorConfig)
+					return false, updateError
+				}
+			}
+			break
+		}
+
+		deploymentIDToStart := getDeploymentIDToStart(currKubeletState, prevKubeletState, operatorConfig)
+		if deploymentIDToStart == 0 {
+			glog.V(4).Infof("%q does not need update", currKubeletState.NodeName)
+			continue
+		}
+		glog.Infof("%q needs to deploy to %d", currKubeletState.NodeName, deploymentIDToStart)
+
+		// we need to start a deployment create a pod that will lay down the static pod resources
+		newCurrKubeletState, err := createInstallerPod(c.kubeClient, currKubeletState, operatorConfig, deploymentIDToStart)
+		if err != nil {
+			return true, err
+		}
+		// if we make a change to this status, we want to write it out to the API before we commence work on the next kubelet.
+		// it's an extra write/read, but it makes the state debuggable from outside this process
+		if !equality.Semantic.DeepEqual(newCurrKubeletState, currKubeletState) {
+			glog.Infof("%q moving to %v", currKubeletState.NodeName, spew.Sdump(*newCurrKubeletState))
+			operatorConfig.Status.TargetKubeletStates[i] = *newCurrKubeletState
+			if !reflect.DeepEqual(operatorConfigOriginal, operatorConfig) {
+				_, updateError := c.operatorConfigClient.KubeApiserverOperatorConfigs().UpdateStatus(operatorConfig)
+				return false, updateError
+			}
+		}
+		break
+	}
+
+	v1alpha1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1alpha1.OperatorCondition{
+		Type:   "InstallerControllerFailing",
+		Status: operatorv1alpha1.ConditionFalse,
+	})
+	if !reflect.DeepEqual(operatorConfigOriginal, operatorConfig) {
+		_, updateError := c.operatorConfigClient.KubeApiserverOperatorConfigs().UpdateStatus(operatorConfig)
+		if updateError != nil {
+			return true, updateError
+		}
+	}
+
+	return false, nil
+}
+
+// checkIfInstallComplete returns the new KubeletState or and error
+func checkIfInstallComplete(c kubernetes.Interface, currKubeletState *v1alpha1.KubeletState) (*v1alpha1.KubeletState, error) {
+	ret := currKubeletState.DeepCopy()
+	installerPod, err := c.CoreV1().Pods(targetNamespaceName).Get(getInstallerPodName(currKubeletState.TargetDeploymentID, currKubeletState.NodeName), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		ret.LastFailedDeploymentID = currKubeletState.TargetDeploymentID
+		return ret, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	switch installerPod.Status.Phase {
+	case corev1.PodSucceeded:
+		ret.CurrentDeploymentID = currKubeletState.TargetDeploymentID
+		ret.TargetDeploymentID = 0
+		ret.LastFailedDeploymentID = 0
+	case corev1.PodFailed:
+		ret.TargetDeploymentID = 0
+		ret.LastFailedDeploymentID = currKubeletState.TargetDeploymentID
+	}
+
+	return ret, nil
+}
+
+// getDeploymentIDToStart returns the deploymentID we need to start or zero if none
+func getDeploymentIDToStart(currKubeletState, prevKubeletState *v1alpha1.KubeletState, operatorConfig *v1alpha1.KubeApiserverOperatorConfig) int32 {
+	if prevKubeletState == nil {
+		currentAtLatest := currKubeletState.CurrentDeploymentID == operatorConfig.Status.LatestDeploymentID
+		failedAtLatest := currKubeletState.LastFailedDeploymentID == operatorConfig.Status.LatestDeploymentID
+		if !currentAtLatest && !failedAtLatest {
+			return operatorConfig.Status.LatestDeploymentID
+		}
+	}
+
+	prevInTransition := prevKubeletState.CurrentDeploymentID != prevKubeletState.TargetDeploymentID
+	if prevInTransition {
+		return 0
+	}
+
+	prevAhead := currKubeletState.CurrentDeploymentID > currKubeletState.CurrentDeploymentID
+	failedAtPrev := currKubeletState.LastFailedDeploymentID == prevKubeletState.CurrentDeploymentID
+	if prevAhead && !failedAtPrev {
+		return currKubeletState.CurrentDeploymentID
+	}
+
+	return 0
+}
+
+func getInstallerPodName(deploymentID int32, nodeName string) string {
+	return fmt.Sprintf("installer-%d-%s", deploymentID, nodeName)
+}
+
+// createInstallerPod creates the installer pod with the secrets required to
+func createInstallerPod(c kubernetes.Interface, currKubeletState *v1alpha1.KubeletState, operatorConfig *v1alpha1.KubeApiserverOperatorConfig, deploymentID int32) (*v1alpha1.KubeletState, error) {
+	required := resourceread.ReadPodV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/installer-pod.yaml"))
+	switch corev1.PullPolicy(operatorConfig.Spec.ImagePullPolicy) {
+	case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
+		required.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(operatorConfig.Spec.ImagePullPolicy)
+	case "":
+	default:
+		return nil, fmt.Errorf("invalid imagePullPolicy specified: %v", operatorConfig.Spec.ImagePullPolicy)
+	}
+	required.Name = getInstallerPodName(deploymentID, currKubeletState.NodeName)
+	required.Spec.NodeName = currKubeletState.NodeName
+	required.Spec.Containers[0].Image = operatorConfig.Spec.ImagePullSpec
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", operatorConfig.Spec.Logging.Level))
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-deployment-id=%d", deploymentID))
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-namespace=%q", targetNamespaceName))
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-pod=%q", deploymentConfigMaps_v311_00_to_latest[0]))
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-resource-dir=%q", "/etc/kubernetes/static-pod-resources"))
+	required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-pod-manifest-dir=%q", "/etc/kubernetes/manifests"))
+	for _, name := range deploymentConfigMaps_v311_00_to_latest[1:] {
+		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-configmaps=%q", nameFor(name, deploymentID)))
+	}
+	for _, name := range deploymentSecrets_v311_00_to_latest {
+		required.Spec.Containers[0].Args = append(required.Spec.Containers[0].Args, fmt.Sprintf("-secrets=%q", nameFor(name, deploymentID)))
+	}
+
+	if _, err := c.CoreV1().Pods(targetNamespaceName).Create(required); err != nil {
+		glog.Errorf("failed to create pod for %q: %v", currKubeletState.NodeName, resourceread.WritePodV1OrDie(required))
+		return nil, err
+	}
+
+	ret := currKubeletState.DeepCopy()
+	ret.TargetDeploymentID = deploymentID
+
+	return ret, nil
+}

--- a/pkg/operator/nodeController.go
+++ b/pkg/operator/nodeController.go
@@ -1,0 +1,154 @@
+package operator
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/apis/kubeapiserver/v1alpha1"
+	operatorconfigclientv1alpha1 "github.com/openshift/cluster-kube-apiserver-operator/pkg/generated/clientset/versioned/typed/kubeapiserver/v1alpha1"
+	operatorconfiginformerv1alpha1 "github.com/openshift/cluster-kube-apiserver-operator/pkg/generated/informers/externalversions/kubeapiserver/v1alpha1"
+)
+
+type NodeController struct {
+	operatorConfigClient operatorconfigclientv1alpha1.KubeapiserverV1alpha1Interface
+
+	nodeLister corelisterv1.NodeLister
+
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewNodeController(
+	operatorConfigInformer operatorconfiginformerv1alpha1.KubeApiserverOperatorConfigInformer,
+	kubeInformersClusterScoped informers.SharedInformerFactory,
+	operatorConfigClient operatorconfigclientv1alpha1.KubeapiserverV1alpha1Interface,
+	kubeClient kubernetes.Interface,
+) *NodeController {
+	c := &NodeController{
+		operatorConfigClient: operatorConfigClient,
+		nodeLister:           kubeInformersClusterScoped.Core().V1().Nodes().Lister(),
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "NodeController"),
+	}
+
+	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
+	kubeInformersClusterScoped.Core().V1().Nodes().Informer().AddEventHandler(c.eventHandler())
+
+	return c
+}
+
+func (c NodeController) sync() error {
+	operatorConfig, err := c.operatorConfigClient.KubeApiserverOperatorConfigs().Get("instance", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	operatorConfigOriginal := operatorConfig.DeepCopy()
+
+	selector, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Equals, []string{""})
+	if err != nil {
+		panic(err)
+	}
+	nodes, err := c.nodeLister.List(labels.NewSelector().Add(*selector))
+	if err != nil {
+		return err
+	}
+
+	newTargetKubeletStates := []v1alpha1.KubeletState{}
+	// remove entries for missing nodes
+	for i, kubeletState := range operatorConfigOriginal.Status.TargetKubeletStates {
+		found := false
+		for _, node := range nodes {
+			if kubeletState.NodeName == node.Name {
+				found = true
+			}
+		}
+		if found {
+			newTargetKubeletStates = append(newTargetKubeletStates, operatorConfigOriginal.Status.TargetKubeletStates[i])
+		}
+	}
+
+	// add entries for new nodes
+	for _, node := range nodes {
+		found := false
+		for _, kubeletState := range operatorConfigOriginal.Status.TargetKubeletStates {
+			if kubeletState.NodeName == node.Name {
+				found = true
+			}
+		}
+		if found {
+			continue
+		}
+
+		newTargetKubeletStates = append(newTargetKubeletStates, v1alpha1.KubeletState{NodeName: node.Name})
+	}
+	operatorConfig.Status.TargetKubeletStates = newTargetKubeletStates
+
+	if !reflect.DeepEqual(operatorConfigOriginal, operatorConfig) {
+		_, updateError := c.operatorConfigClient.KubeApiserverOperatorConfigs().UpdateStatus(operatorConfig)
+		return updateError
+	}
+
+	return nil
+}
+
+// Run starts the kube-apiserver and blocks until stopCh is closed.
+func (c *NodeController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting NodeController")
+	defer glog.Infof("Shutting down NodeController")
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *NodeController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *NodeController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *NodeController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -34,6 +34,7 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 		return err
 	}
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
+	kubeInformersClusterScoped := informers.NewSharedInformerFactory(kubeClient, 10*time.Minute)
 	kubeInformersNamespaced := informers.NewFilteredSharedInformerFactory(kubeClient, 10*time.Minute, targetNamespaceName, nil)
 	kubeInformersEtcdNamespaced := informers.NewFilteredSharedInformerFactory(kubeClient, 10*time.Minute, etcdNamespaceName, nil)
 
@@ -60,9 +61,21 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 		operatorConfigClient.KubeapiserverV1alpha1(),
 		kubeClient,
 	)
-	deploymentContent := NewDeploymentController(
+	deploymentController := NewDeploymentController(
 		operatorConfigInformers.Kubeapiserver().V1alpha1().KubeApiserverOperatorConfigs(),
 		kubeInformersNamespaced,
+		operatorConfigClient.KubeapiserverV1alpha1(),
+		kubeClient,
+	)
+	installerController := NewInstallerController(
+		operatorConfigInformers.Kubeapiserver().V1alpha1().KubeApiserverOperatorConfigs(),
+		kubeInformersNamespaced,
+		operatorConfigClient.KubeapiserverV1alpha1(),
+		kubeClient,
+	)
+	nodeController := NewNodeController(
+		operatorConfigInformers.Kubeapiserver().V1alpha1().KubeApiserverOperatorConfigs(),
+		kubeInformersClusterScoped,
 		operatorConfigClient.KubeapiserverV1alpha1(),
 		kubeClient,
 	)
@@ -82,11 +95,14 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	)
 
 	operatorConfigInformers.Start(stopCh)
+	kubeInformersClusterScoped.Start(stopCh)
 	kubeInformersNamespaced.Start(stopCh)
 	kubeInformersEtcdNamespaced.Start(stopCh)
 
 	go prereqs.Run(1, stopCh)
-	go deploymentContent.Run(1, stopCh)
+	go deploymentController.Run(1, stopCh)
+	go installerController.Run(1, stopCh)
+	go nodeController.Run(1, stopCh)
 	go configObserver.Run(1, stopCh)
 	go clusterOperatorStatus.Run(1, stopCh)
 

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -5,16 +5,16 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/blang/semver"
 	"github.com/golang/glog"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -54,10 +54,12 @@ func NewTargetConfigReconciler(
 	}
 
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())
+	namespacedKubeInformers.Rbac().V1().Roles().Informer().AddEventHandler(c.eventHandler())
+	namespacedKubeInformers.Rbac().V1().RoleBindings().Informer().AddEventHandler(c.eventHandler())
 	namespacedKubeInformers.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
+	namespacedKubeInformers.Core().V1().Secrets().Informer().AddEventHandler(c.eventHandler())
 	namespacedKubeInformers.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())
 	namespacedKubeInformers.Core().V1().Services().Informer().AddEventHandler(c.eventHandler())
-	namespacedKubeInformers.Apps().V1().Deployments().Informer().AddEventHandler(c.eventHandler())
 
 	// we only watch some namespaces
 	namespacedKubeInformers.Core().V1().Namespaces().Informer().AddEventHandler(c.namespaceEventHandler())

--- a/pkg/operator/target_config_reconciler_v311_00.go
+++ b/pkg/operator/target_config_reconciler_v311_00.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/apis/kubeapiserver/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/apis/kubeapiserver/v1alpha1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -61,7 +61,7 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, op
 			message = message + err.Error() + "\n"
 		}
 		v1alpha1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1alpha1.OperatorCondition{
-			Type:    "TargetConfigReconiclerFailing",
+			Type:    "TargetConfigReconcilerFailing",
 			Status:  operatorv1alpha1.ConditionTrue,
 			Reason:  "SynchronizationError",
 			Message: message,
@@ -74,7 +74,7 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, op
 	}
 
 	v1alpha1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1alpha1.OperatorCondition{
-		Type:   "TargetConfigReconiclerFailing",
+		Type:   "TargetConfigReconcilerFailing",
 		Status: operatorv1alpha1.ConditionFalse,
 	})
 	if !reflect.DeepEqual(operatorConfigOriginal, operatorConfig) {

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -3,6 +3,7 @@
 // bindata/v3.11.0/kube-apiserver/cm.yaml
 // bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
 // bindata/v3.11.0/kube-apiserver/deployment-config-overrides.yaml
+// bindata/v3.11.0/kube-apiserver/installer-pod.yaml
 // bindata/v3.11.0/kube-apiserver/ns.yaml
 // bindata/v3.11.0/kube-apiserver/operator-config.yaml
 // bindata/v3.11.0/kube-apiserver/pod-cm.yaml
@@ -242,6 +243,39 @@ func v3110KubeApiserverDeploymentConfigOverridesYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/deployment-config-overrides.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3110KubeApiserverInstallerPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: installer-<deployment-id>-<nodeName>
+  labels:
+    app: installer
+spec:
+  # TODO change this
+  serviceAccountName: openshift-kube-apiserver-sa
+  containers:
+  - name: apiserver
+    image: ${IMAGE}
+    imagePullPolicy: Always
+    command: ["cluster-kube-apiserver-operator", "operator"]
+  restartPolicy: Never
+`)
+
+func v3110KubeApiserverInstallerPodYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverInstallerPodYaml, nil
+}
+
+func v3110KubeApiserverInstallerPodYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverInstallerPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/installer-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -593,6 +627,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/kube-apiserver/cm.yaml":                          v3110KubeApiserverCmYaml,
 	"v3.11.0/kube-apiserver/defaultconfig.yaml":               v3110KubeApiserverDefaultconfigYaml,
 	"v3.11.0/kube-apiserver/deployment-config-overrides.yaml": v3110KubeApiserverDeploymentConfigOverridesYaml,
+	"v3.11.0/kube-apiserver/installer-pod.yaml":               v3110KubeApiserverInstallerPodYaml,
 	"v3.11.0/kube-apiserver/ns.yaml":                          v3110KubeApiserverNsYaml,
 	"v3.11.0/kube-apiserver/operator-config.yaml":             v3110KubeApiserverOperatorConfigYaml,
 	"v3.11.0/kube-apiserver/pod-cm.yaml":                      v3110KubeApiserverPodCmYaml,
@@ -649,6 +684,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"cm.yaml":                          {v3110KubeApiserverCmYaml, map[string]*bintree{}},
 			"defaultconfig.yaml":               {v3110KubeApiserverDefaultconfigYaml, map[string]*bintree{}},
 			"deployment-config-overrides.yaml": {v3110KubeApiserverDeploymentConfigOverridesYaml, map[string]*bintree{}},
+			"installer-pod.yaml":               {v3110KubeApiserverInstallerPodYaml, map[string]*bintree{}},
 			"ns.yaml":                          {v3110KubeApiserverNsYaml, map[string]*bintree{}},
 			"operator-config.yaml":             {v3110KubeApiserverOperatorConfigYaml, map[string]*bintree{}},
 			"pod-cm.yaml":                      {v3110KubeApiserverPodCmYaml, map[string]*bintree{}},


### PR DESCRIPTION
This adds one loop for the installerController and another loop to maintain the individual targetKubeletStatus for nodes as they come and go.  The pod itself fails to run (image problems), but it's a strong start.


```
  containers:
  - args:
    - -v=4
    - -deployment-id=1
    - -namespace="openshift-kube-apiserver"
    - -pod="kube-apiserver-pod"
    - -resource-dir="/etc/kubernetes/static-pod-resources"
    - -pod-manifest-dir="/etc/kubernetes/manifests"
    - -configmaps="deployment-kube-apiserver-config-1"
    - -configmaps="aggregator-client-ca-1"
    - -configmaps="client-ca-1"
    - -configmaps="etcd-serving-ca-1"
    - -configmaps="kubelet-serving-ca-1"
    - -configmaps="sa-token-signing-certs-1"
    - -secrets="aggregator-client-1"
    - -secrets="etcd-client-1"
    - -secrets="kubelet-client-1"
    - -secrets="serving-cert-1"
    command:
    - cluster-kube-apiserver-operator
    - operator

```

After this we need to 
1. fix the image
2. adjust the host mounts
3. fix the pod completion detection

/assign @sttts 