### PR TITLE
Makefile: print what origin-release target actually does

### DIFF
--- a/hack/lib/Dockerfile-origin-release
+++ b/hack/lib/Dockerfile-origin-release
@@ -9,7 +9,8 @@ RUN curl -sLk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
     rm -f /tmp/jq-linux64
 
 COPY --from=origin-release release-manifests/image-references .
-RUN jq '.spec.tags |= map(.name as $name | if (['$IMAGES'] | index($name)) then .from.name |= "'$IMAGE_REPOSITORY_NAME'/origin-"+$name+":latest" else . end)' image-references > image-references-updated
+RUN cat image-references
+RUN jq '.spec.tags |= map(.name as $name | if (['$IMAGES'] | index($name)) then ("'$IMAGE_REPOSITORY_NAME'/origin-"+$name+":latest") as $override | ("Switching \($name): \(.from.name) => \($override)" | stderr) as $stderr | .from.name |= $override else . end)' image-references > image-references-updated
 
 FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0
 COPY --from=jq image-references-updated release-manifests/image-references


### PR DESCRIPTION
This is helpful to notice errors in the origin-release creation early.