### PR TITLE
fix printing version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 #
 FROM openshift/origin-release:golang-1.10
 COPY . /go/src/github.com/openshift/cluster-kube-apiserver-operator
-RUN cd /go/src/github.com/openshift/cluster-kube-apiserver-operator && go build ./cmd/cluster-kube-apiserver-operator
+WORKDIR /go/src/github.com/openshift/cluster-kube-apiserver-operator
+ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-kube-apiserver-operator
 
 FROM centos:7
 RUN mkdir -p /usr/share/bootkube/manifests

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/cluster-kube-apiserver-operator/cmd/cluster-kube-apiserver-operator/render"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 )
 
@@ -42,6 +43,12 @@ func NewOperatorCommand() *cobra.Command {
 			cmd.Help()
 			os.Exit(1)
 		},
+	}
+
+	if v := version.Get().String(); len(v) == 0 {
+		cmd.Version = "<unknown>"
+	} else {
+		cmd.Version = v
 	}
 
 	cmd.AddCommand(operator.NewOperator())


### PR DESCRIPTION
1) Before the `--version` flag was not defined and we were not setting the `-ldflag` during the go build. I think it only makes sense to set it when building the images so I updated the Dockerfile. Now:

```
$ docker run --rm  openshift/origin-cluster-kube-apiserver-operator:latest --version
cluster-kube-apiserver-operator version v0.0.0-alpha.0-188-gbf4d1be
```