### PR TITLE
move to operator specific namespace

### DIFF
--- a/manifests/0000_10_cluster-kube-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_00_namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/run-level: "0"
-  name: openshift-core-operators
+  name: openshift-cluster-kube-apiserver-operator

--- a/manifests/0000_10_cluster-kube-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_03_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-kube-apiserver-operator
   name: openshift-cluster-kube-apiserver-operator-config
 data:
   config.yaml: |

--- a/manifests/0000_10_cluster-kube-apiserver-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_04_clusterrolebinding.yaml
@@ -7,5 +7,5 @@ roleRef:
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-kube-apiserver-operator
   name: openshift-cluster-kube-apiserver-operator

--- a/manifests/0000_10_cluster-kube-apiserver-operator_05_serviceaccount.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_05_serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-kube-apiserver-operator
   name: openshift-cluster-kube-apiserver-operator
   labels:
     app: openshift-cluster-kube-apiserver-operator

--- a/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-kube-apiserver-operator
   name: openshift-cluster-kube-apiserver-operator
   labels:
     app: openshift-cluster-kube-apiserver-operator

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -91,8 +91,8 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-kube-apiserver",
-		"openshift-kube-apiserver",
+		"openshift-cluster-kube-apiserver-operator",
+		"openshift-cluster-kube-apiserver-operator",
 		dynamicClient,
 		staticPodOperatorClient,
 	)


### PR DESCRIPTION
Moves our namespace to `openshift-cluster-kube-apiserver-operator` and updates our ClusterOperator to match.

/assign @sanchezl 