### PR TITLE
metrics: add svc for metrics and wire serving certs to deployment

### DIFF
--- a/manifests/0000_10_cluster-kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_02_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-signed-by: service-serving
+  labels:
+    app: openshift-cluster-kube-apiserver-operator
+  name: metrics
+  namespace: openshift-cluster-kube-apiserver-operator
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: openshift-cluster-kube-apiserver-operator
+  sessionAffinity: None
+  type: ClusterIP

--- a/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
@@ -28,6 +28,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /var/run/secrets/serving-certs
+          name: serving-cert
         env:
         - name: IMAGE
           value: quay.io/openshift/origin-hypershift:v4.0
@@ -37,12 +39,10 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          defaultMode: 400
           secretName: openshift-cluster-kube-apiserver-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          defaultMode: 440
           name: openshift-cluster-kube-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
@deads2k @sttts we have the secret volume that we don't mount into container... this is fixing this in addition of metrics service that should be used to serve the operator metrics.

pre-requirement: https://github.com/openshift/library-go/pull/88
/hold