### PR TITLE
Use openshift-kube-apiserve as container name for easier debugging

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -9,7 +9,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: apiserver
+  - name: openshift-kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -331,7 +331,7 @@ metadata:
     revision: "REVISION"
 spec:
   containers:
-  - name: apiserver
+  - name: openshift-kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
"crictl ps -a" does not show pod names. So during disaster recovery full names for the containers is helpful.