### PR TITLE
operator: wait for spec.observedConfig to be filled before installing

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -91,6 +91,12 @@ func (c TargetConfigReconciler) sync() error {
 		return nil
 	}
 
+	// block until config is obvserved
+	if len(operatorConfig.Spec.ObservedConfig.Raw) == 0 {
+		glog.Info("Waiting for observed configuration to be available")
+		return nil
+	}
+
 	requeue, err := createTargetConfigReconciler_v311_00_to_latest(c, c.eventRecorder, operatorConfig)
 	if requeue && err == nil {
 		return fmt.Errorf("synthetic requeue request")


### PR DESCRIPTION
Installing an initial apiserver with broken, incomplete might fail the pivot from bootstrap to operator mode. We should therefore wait until the config has been observed once before installing any static pod to the masters.

This might reduce flakes.