### PR TITLE
operator: move spec.observedConfig wait to sync

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -91,6 +91,12 @@ func (c TargetConfigReconciler) sync() error {
 		return nil
 	}
 
+	// block until config is obvserved
+	if len(operatorConfig.Spec.ObservedConfig.Raw) == 0 {
+		glog.Info("Waiting for observed configuration to be available")
+		return nil
+	}
+
 	requeue, err := createTargetConfigReconciler_v311_00_to_latest(c, operatorConfig)
 	if requeue && err == nil {
 		return fmt.Errorf("synthetic requeue request")

--- a/pkg/operator/target_config_reconciler_v311_00.go
+++ b/pkg/operator/target_config_reconciler_v311_00.go
@@ -40,10 +40,16 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, op
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "etcd-certs", err))
 	}
-	_, _, err = manageKubeApiserverConfigMap_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q: %v", "configmap/deployment-kube-apiserver-config", err))
+
+	if len(operatorConfig.Spec.ObservedConfig.Raw) == 0 {
+		errors = append(errors, fmt.Errorf("initial observation of cluster configuration is not finished yet: spec.observedConfig is empty"))
+	} else {
+		_, _, err = manageKubeApiserverConfigMap_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("%q: %v", "configmap/deployment-kube-apiserver-config", err))
+		}
 	}
+
 	_, _, err = managePod_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig, c.targetImagePullSpec)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-pod", err))

--- a/pkg/operator/target_config_reconciler_v311_00.go
+++ b/pkg/operator/target_config_reconciler_v311_00.go
@@ -40,16 +40,10 @@ func createTargetConfigReconciler_v311_00_to_latest(c TargetConfigReconciler, op
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "etcd-certs", err))
 	}
-
-	if len(operatorConfig.Spec.ObservedConfig.Raw) == 0 {
-		errors = append(errors, fmt.Errorf("initial observation of cluster configuration is not finished yet: spec.observedConfig is empty"))
-	} else {
-		_, _, err = manageKubeApiserverConfigMap_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("%q: %v", "configmap/deployment-kube-apiserver-config", err))
-		}
+	_, _, err = manageKubeApiserverConfigMap_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/deployment-kube-apiserver-config", err))
 	}
-
 	_, _, err = managePod_v311_00_to_latest(c.kubeClient.CoreV1(), operatorConfig, c.targetImagePullSpec)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-pod", err))


### PR DESCRIPTION
To be in line with openshift-apiserver operator. Doing this in sync is much simpler and direct.