### PR TITLE
[wip] Add static installer pod revision history pruning

### DIFF
--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
+	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
 )
 
 func main() {
@@ -54,6 +55,7 @@ func NewOperatorCommand() *cobra.Command {
 	cmd.AddCommand(operator.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand())
 	cmd.AddCommand(installerpod.NewInstaller())
+	cmd.AddCommand(prune.NewPrune())
 
 	return cmd
 }

--- a/pkg/apis/kubeapiserver/v1alpha1/types.go
+++ b/pkg/apis/kubeapiserver/v1alpha1/types.go
@@ -33,6 +33,10 @@ type KubeAPIServerOperatorConfigSpec struct {
 	// This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work
 	// this time instead of failing again on the same config.
 	ForceRedeploymentReason string `json:"forceRedeploymentReason"`
+
+	// operatorRevisionLimit is a map which can specify the number of static pod installer revisions to keep on disk.
+	// Specify a limit for successful revisions with the key "succeeded" and failed revisions with "failed"
+	OperatorRevisionLimit map[string]int64 `json:"operatorRevisionLimit,omitempty"`
 }
 
 type KubeAPIServerOperatorConfigStatus struct {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -79,6 +79,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		targetNamespaceName,
 		"openshift-kube-apiserver",
 		[]string{"cluster-kube-apiserver-operator", "installer"},
+		[]string{"cluster-kube-apiserver-operator", "prune"},
 		deploymentConfigMaps,
 		deploymentSecrets,
 		staticPodOperatorClient,
@@ -86,6 +87,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeInformersForOpenshiftKubeAPIServerNamespace,
 		kubeInformersClusterScoped,
 		ctx.EventRecorder,
+		10,
+		10,
 	)
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"openshift-cluster-kube-apiserver-operator",
@@ -140,6 +143,7 @@ var deploymentConfigMaps = []string{
 	"etcd-serving-ca",
 	"kubelet-serving-ca",
 	"sa-token-signing-certs",
+	"revision-status",
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -26,6 +26,9 @@ import (
 )
 
 func RunOperator(ctx *controllercmd.ControllerContext) error {
+	operatorConfigGVR := schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "kubeapiserveroperatorconfigs"}
+	operatorConfigName := "instance"
+
 	kubeClient, err := kubernetes.NewForConfig(ctx.KubeConfig)
 	if err != nil {
 		return err
@@ -56,7 +59,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	v1helpers.EnsureOperatorConfigExists(
 		dynamicClient,
 		v311_00_assets.MustAsset("v3.11.0/kube-apiserver/operator-config.yaml"),
-		schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "kubeapiserveroperatorconfigs"},
+		operatorConfigGVR,
 	)
 
 	configObserver := configobservercontroller.NewConfigObserver(
@@ -87,8 +90,9 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeInformersForOpenshiftKubeAPIServerNamespace,
 		kubeInformersClusterScoped,
 		ctx.EventRecorder,
-		10,
-		10,
+		dynamicClient,
+		operatorConfigGVR,
+		operatorConfigName,
 	)
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"openshift-cluster-kube-apiserver-operator",


### PR DESCRIPTION
Adds a call to the pruner created in https://github.com/openshift/library-go/pull/82 (needs to merge first)

Still need to work on adding the history limit fields to the operator spec, but for now we decided to hardcode the values and revisit that. If they are just added to the spec for the KubeAPIServer, the library-go code won't have access to that. So we'll need to write them to a configmap or something if we want to be able to watch for changes and update accordingly