### PR TITLE
add memory request to kube-apiserver and operator pods

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -16,6 +16,9 @@ spec:
     command: ["hypershift", "openshift-kube-apiserver"]
     args:
     - "--config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml"
+    resources:
+      requests:
+        memory: 1Gi
     ports:
     - containerPort: 6443
     volumeMounts:

--- a/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_cluster-kube-apiserver-operator_06_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=2"
+        resources:
+          requests:
+            memory: 50Mi
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -337,6 +337,9 @@ spec:
     command: ["hypershift", "openshift-kube-apiserver"]
     args:
     - "--config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml"
+    resources:
+      requests:
+        memory: 1Gi
     ports:
     - containerPort: 6443
     volumeMounts:


### PR DESCRIPTION
One in a series of PRs to set memory requests for all control plane and high memory use components.

We are encountering master instability (https://github.com/openshift/installer/pull/408 https://github.com/openshift/installer/pull/785) as the number of components increase because many components run `BestEffort` giving the scheduler no information on pod resource usage.

On a steady state empty cluster, `kube-apiserver` uses 980Mi.

{pod_name="openshift-kube-apiserver-dev-master-0"} | 979714048

Setting request to `1Gi`.

This component uses the most memory and CPU of any component.  Possible target for future optimization.

@deads2k @sttts  @derekwaynecarr