### PR TITLE
WIP: bump(*): library-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7174bf0d568352e23ba7343f43391f7ebde4801ed75e5b1af421ce5ab29c1a71
-updated: 2018-12-04T16:28:14.580398875-05:00
+hash: d6cbe8c8543f91803dc655dc6a2135493ed5235647753135bcb4ecae21d9921c
+updated: 2018-12-06T10:36:45.519879+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -242,7 +242,8 @@ imports:
   - config/informers/externalversions/internalinterfaces
   - config/listers/config/v1
 - name: github.com/openshift/library-go
-  version: 83571e49a3f2e3c1f1ba4b15c618285aef810435
+  version: 21db1f64df6ac854c49ab98999c9ea03b7e01483
+  repo: https://github.com/mfojtik/library-go
   subpackages:
   - pkg/assets
   - pkg/config/client
@@ -257,6 +258,7 @@ imports:
   - pkg/operator/configobserver
   - pkg/operator/configobserver/network
   - pkg/operator/events
+  - pkg/operator/metrics
   - pkg/operator/render
   - pkg/operator/render/options
   - pkg/operator/resource/resourceapply

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,7 +19,8 @@ import:
 - package: github.com/openshift/client-go
   version: master
 - package: github.com/openshift/library-go
-  version: master
+  repo: https://github.com/mfojtik/library-go
+  version: operator-metrics
 - package: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
 - package: k8s.io/gengo/args

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - squeed
+  - dcbw
+  - danwinship
+  - knobunc
+approvers:
+  - squeed
+  - dcbw
+  - danwinship
+  - knobunc

--- a/vendor/github.com/openshift/library-go/pkg/operator/metrics/collector.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/metrics/collector.go
@@ -1,0 +1,190 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+const (
+	openshiftOperatorNamePrefix = "operator_v1_openshift_io"
+	workkey                     = "key"
+)
+
+// OperatorStateGetter knows how to get the current operator state and provides operator client informer.
+type OperatorStateGetter interface {
+	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, staticPodStatus *operatorv1.StaticPodOperatorStatus, resourceVersion string, err error)
+	Informer() cache.SharedIndexInformer
+}
+
+// operatorMetricUpdater knows how to update a single tracked metric.
+type operatorMetricUpdater interface {
+	Update(*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, *operatorv1.StaticPodOperatorStatus) error
+}
+
+type operatorMetricUpdateFn func(*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, *operatorv1.StaticPodOperatorStatus) (float64, []string, error)
+
+type Collector struct {
+	operatorClient  OperatorStateGetter
+	operatorMetrics []operatorMetricUpdater
+	targetNamespace string
+
+	queue     workqueue.RateLimitingInterface
+	hasSynced cache.InformerSynced
+}
+
+type operatorMetric struct {
+	prometheusDesc *prometheus.Desc
+	currentValue   float64
+	currentLabels  []string
+
+	valueMutex sync.RWMutex
+	updateFn   operatorMetricUpdateFn
+}
+
+func (m *operatorMetric) Update(spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, staticPodStatus *operatorv1.StaticPodOperatorStatus) error {
+	m.valueMutex.Lock()
+	defer m.valueMutex.Unlock()
+	value, labels, err := m.updateFn(spec, status, staticPodStatus)
+	if err != nil {
+		return err
+	}
+	m.currentValue = value
+	m.currentLabels = labels
+	return nil
+}
+
+// NewOperatorStatusMetricsCollector returns a metrics collector that automatically collect prometheus metrics from given operator status.
+func NewOperatorStatusMetricsCollector(client OperatorStateGetter, targetOperatorNamespace string) *Collector {
+	collector := &Collector{
+		operatorClient:  client,
+		targetNamespace: targetOperatorNamespace,
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "OperatorStatusMetricsCollector"),
+		hasSynced:       client.Informer().HasSynced,
+	}
+
+	// register default set of metrics we track
+	addStatusAvailableConditionMetrics(collector)
+	addStatusFailedConditionMetrics(collector)
+	addStaticPodStatusLatestRevisionMetrics(collector)
+	addStaticPodNodesWithLatestRevisionMetrics(collector)
+	addStaticPodNodesWithFailuresMetrics(collector)
+
+	client.Informer().AddEventHandler(collector.eventHandler())
+
+	// NOTE: Only call this once and this must be called after all metrics are registered otherwise prometheus will panic.
+	prometheus.MustRegister(collector)
+
+	return collector
+}
+
+func (c *Collector) register(name, description string, labels []string, updateFn operatorMetricUpdateFn) {
+	c.operatorMetrics = append(c.operatorMetrics, &operatorMetric{
+		prometheusDesc: prometheus.NewDesc(
+			metricNameToQuery(c.targetNamespace, name),
+			description,
+			labels,
+			nil,
+		),
+		updateFn: updateFn,
+	})
+}
+
+func metricNameToQuery(namespace, name string) string {
+	return strings.Join([]string{openshiftOperatorNamePrefix, strings.Replace(namespace, "-", "_", -1), name}, "_")
+}
+
+func (c *Collector) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting MetricsCollector for %s", c.targetNamespace)
+	defer glog.Infof("Shutting down MetricsCollector for %s", c.targetNamespace)
+
+	if !cache.WaitForCacheSync(stopCh, c.hasSynced) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *Collector) sync() error {
+	operatorSpec, operatorStatus, staticPodOperatorStatus, _, err := c.operatorClient.GetOperatorState()
+	if err != nil && errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		glog.Warningf("Unable to get operator status: %v", err)
+		return err
+	}
+	for _, m := range c.operatorMetrics {
+		if err := m.Update(operatorSpec, operatorStatus, staticPodOperatorStatus); err != nil {
+			glog.Warningf("Unable to update metrics for operator: %v", err)
+		}
+	}
+	return nil
+}
+
+// Describe implements Prometheus Collector interface
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	for _, m := range c.operatorMetrics {
+		ch <- m.(*operatorMetric).prometheusDesc
+	}
+}
+
+// Collect implements Prometheus Collector interface
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	for _, metric := range c.operatorMetrics {
+		m := metric.(*operatorMetric)
+		ch <- prometheus.MustNewConstMetric(m.prometheusDesc, prometheus.GaugeValue, m.currentValue, m.currentLabels...)
+	}
+}
+
+func (c *Collector) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Collector) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *Collector) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workkey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workkey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workkey) },
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/metrics/status_metrics.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/metrics/status_metrics.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"github.com/openshift/api/operator/v1"
+)
+
+func addStatusAvailableConditionMetrics(c *Collector) {
+	c.register(
+		"condition_available",
+		"Tracks operator available condition",
+		[]string{"status"},
+		func(spec *v1.OperatorSpec, status *v1.OperatorStatus, staticPodStatus *v1.StaticPodOperatorStatus) (float64, []string, error) {
+			var conditions []v1.OperatorCondition
+			if status != nil {
+				conditions = status.Conditions
+			}
+			if staticPodStatus != nil {
+				conditions = staticPodStatus.Conditions
+			}
+			for _, c := range conditions {
+				if c.Type != v1.OperatorStatusTypeAvailable {
+					continue
+				}
+				switch c.Status {
+				case v1.ConditionTrue:
+					return 1, []string{string(v1.ConditionTrue)}, nil
+				case v1.ConditionFalse:
+					return 1, []string{string(v1.ConditionFalse)}, nil
+				case v1.ConditionUnknown:
+					return 1, []string{string(v1.ConditionUnknown)}, nil
+				}
+			}
+			return 0, []string{}, nil
+		})
+}
+
+func addStatusFailedConditionMetrics(c *Collector) {
+	c.register(
+		"condition_failed",
+		"Tracks operator failed condition",
+		[]string{"status"},
+		func(spec *v1.OperatorSpec, status *v1.OperatorStatus, staticPodStatus *v1.StaticPodOperatorStatus) (float64, []string, error) {
+			var conditions []v1.OperatorCondition
+			if status != nil {
+				conditions = status.Conditions
+			}
+			if staticPodStatus != nil {
+				conditions = staticPodStatus.Conditions
+			}
+			for _, c := range conditions {
+				if c.Type != v1.OperatorStatusTypeFailing {
+					continue
+				}
+				switch c.Status {
+				case v1.ConditionTrue:
+					return 1, []string{string(v1.ConditionTrue)}, nil
+				case v1.ConditionFalse:
+					return 1, []string{string(v1.ConditionFalse)}, nil
+				case v1.ConditionUnknown:
+					return 1, []string{string(v1.ConditionUnknown)}, nil
+				}
+			}
+			return 0, []string{}, nil
+		})
+}
+
+func addStaticPodStatusLatestRevisionMetrics(c *Collector) {
+	c.register(
+		"static_pod_latest_revision",
+		"Tracks static pod operator latest revision",
+		[]string{},
+		func(spec *v1.OperatorSpec, _ *v1.OperatorStatus, status *v1.StaticPodOperatorStatus) (float64, []string, error) {
+			if status == nil {
+				return 0, []string{}, nil
+			}
+			return float64(status.LatestAvailableRevision), []string{}, nil
+		})
+}
+
+func addStaticPodNodesWithLatestRevisionMetrics(c *Collector) {
+	c.register(
+		"static_pod_nodes_with_latest_revision", "Tracks number of nodes having latest revision",
+		[]string{},
+		func(spec *v1.OperatorSpec, _ *v1.OperatorStatus, status *v1.StaticPodOperatorStatus) (float64, []string, error) {
+			if status == nil {
+				return 0, []string{}, nil
+			}
+			latestRevision := status.LatestAvailableRevision
+			counter := 0
+			for _, s := range status.NodeStatuses {
+				if s.CurrentRevision == latestRevision {
+					counter += 1
+				}
+			}
+			return float64(counter), []string{}, nil
+		})
+}
+
+func addStaticPodNodesWithFailuresMetrics(c *Collector) {
+	c.register(
+		"static_pod_failed_nodes",
+		"Tracks number of nodes having latest revision",
+		[]string{},
+		func(spec *v1.OperatorSpec, _ *v1.OperatorStatus, status *v1.StaticPodOperatorStatus) (float64, []string, error) {
+			if status == nil {
+				return 0, []string{}, nil
+			}
+			latestRevision := status.LatestAvailableRevision
+			counter := 0
+			for _, s := range status.NodeStatuses {
+				if s.LastFailedRevision == latestRevision {
+					counter += 1
+				}
+			}
+			return float64(counter), []string{}, nil
+		})
+}


### PR DESCRIPTION
Testing the operator status metrics.

sample metrics: https://gist.github.com/mfojtik/efa06bf61d0614d91023d6cd4cd36f8d

@deads2k ^ this is already useful, seems like we are not cleaning the failed condition and we are failed and available in the same time:

```yaml
apiVersion: config.openshift.io/v1
kind: ClusterOperator
metadata:
  creationTimestamp: 2018-12-06T09:40:57Z
  generation: 1
  name: openshift-cluster-kube-apiserver-operator
  resourceVersion: "46288"
  selfLink: /apis/config.openshift.io/v1/clusteroperators/openshift-cluster-kube-apiserver-operator
  uid: 083d0772-f93b-11e8-82a0-12cf2a48f7ca
spec: {}
status:
  conditions:
  - lastTransitionTime: 2018-12-06T10:34:08Z
    message: 'Failing: Get https://172.30.0.1:443/api/v1/namespaces/openshift-kube-apiserver/pods/installer-2-ip-10-0-22-20.ec2.internal:
      dial tcp 172.30.0.1:443: connect: connection refused'
    reason: Failing
    status: "True"
    type: Failing
  - lastTransitionTime: 2018-12-06T10:34:08Z
    message: 3 of 3 nodes are at revision 3
    status: "True"
    type: Available
  - lastTransitionTime: 2018-12-06T10:34:08Z
    message: 0 of 3 nodes are at revision 3
    reason: AllNodesAtLatestRevision
    status: "False"
    type: Progressing
  extension: null
  version: ""
```