### PR TITLE
bindata: set target-ram-mb to 1Gi in default config

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -25,6 +25,8 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  target-ram-mb:
+  - "1024"
 auditConfig:
   auditFilePath: ""
   enabled: false

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -103,6 +103,8 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  target-ram-mb:
+  - "1024"
 auditConfig:
   auditFilePath: ""
   enabled: false


### PR DESCRIPTION
In https://github.com/openshift/cluster-kube-apiserver-operator/pull/161, the memory request was set to `1Gi`.  However, the apiserver cache size scales with the amount of RAM on the node by default.  Through experimentation, is seems to be 30% of RAM on the node, but I can't find the code that actually does this.

Either way, there is a flag `target-ram-mb` to manually control it.  In order for the memory request for the kube-apiserver to be valid for all deployments, we need to set this.

The upstream heuristic for watch cache sizing is 60MB/node, which is pretty generous.  The means that a 1Gi `target-ram-mb` should be valid for a ~20 node cluster according to the upstream heuristic and probably even 3-4x that in reality.  I figure this is our 95% case.

@deads2k @sttts @smarterclayton @derekwaynecarr 