### PR TITLE
Use consistently IMAGE_ORG everywhere

### DIFF
--- a/Dockerfile-origin-release
+++ b/Dockerfile-origin-release
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0 as origin-relea
 
 FROM centos:7 as jq
 ARG IMAGES
-ARG IMAGE_REPOSITORY_NAME
+ARG IMAGE_ORG
 RUN curl -sLk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /tmp/jq-linux64 && \
     cp /tmp/jq-linux64 /usr/bin/jq && \
     chmod +x /usr/bin/jq && \
@@ -10,7 +10,7 @@ RUN curl -sLk https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
 
 COPY --from=origin-release release-manifests/image-references .
 RUN cat image-references
-RUN jq '.spec.tags |= map(.name as $name | if (['$IMAGES'] | index($name)) then ("'$IMAGE_REPOSITORY_NAME'/origin-"+$name+":latest") as $override | ("Switching \($name): \(.from.name) => \($override)" | stderr) as $stderr | .from.name |= $override else . end)' image-references > image-references-updated
+RUN jq '.spec.tags |= map(.name as $name | if (['$IMAGES'] | index($name)) then ("'$IMAGE_ORG'/origin-"+$name+":latest") as $override | ("Switching \($name): \(.from.name) => \($override)" | stderr) as $stderr | .from.name |= $override else . end)' image-references > image-references-updated
 
 FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0
 COPY --from=jq image-references-updated release-manifests/image-references

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ QUOTED_IMAGES=\"$(subst $(,),\"$(,)\",$(IMAGES))\"
 
 origin-release:
 	docker pull registry.svc.ci.openshift.org/openshift/origin-release:v4.0
-	imagebuilder -file Dockerfile-origin-release --build-arg "IMAGE_REPOSITORY_NAME=$(IMAGE_REPOSITORY_NAME)" --build-arg "IMAGES=$(QUOTED_IMAGES)" -t "$(IMAGE_REPOSITORY_NAME)/origin-release:latest" hack
+	imagebuilder -file Dockerfile-origin-release --build-arg "IMAGE_ORG=$(IMAGE_ORG)" --build-arg "IMAGES=$(QUOTED_IMAGES)" -t "$(IMAGE_ORG)/origin-release:latest" hack
 	@echo
 	@echo "To install:"
 	@echo
-	@echo "  IMAGE_REPOSITORY_NAME=$(IMAGE_REPOSITORY_NAME) make images"
-	@echo "  docker push $(IMAGE_REPOSITORY_NAME)/origin-release:latest"
-	@echo "  docker push $(IMAGE_REPOSITORY_NAME)/origin-cluster-kube-apiserver-operator"
-	@echo "  OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(IMAGE_REPOSITORY_NAME)/origin-release:latest bin/openshift-install cluster --log-level=debug"
+	@echo "  IMAGE_ORG=$(IMAGE_ORG) make images"
+	@echo "  docker push $(IMAGE_ORG)/origin-release:latest"
+	@echo "  docker push $(IMAGE_ORG)/origin-cluster-kube-apiserver-operator"
+	@echo "  OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(IMAGE_ORG)/origin-release:latest bin/openshift-install cluster --log-level=debug"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The Kubernetes API Server operator manages and updates the [Kubernetes API server](https://github.com/kubernetes/kubernetes) deployed on top of
 [OpenShift](https://openshift.io). The operator is based on OpenShift [library-go](https://github.com/openshift/library-go) framework and it
  is installed via [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
- 
+
 It contains the following components:
 
 * Operator
@@ -27,7 +27,7 @@ Currently changes in following external components are being observed:
 
 * `host-etcd` *endpoints* in *kube-system* namespace
   - The observed endpoint addresses are used to configure the `storageConfig.urls` in Kubernetes API server configuration.
-* `cluster` *image.config.openshift.io* custom resource 
+* `cluster` *image.config.openshift.io* custom resource
   - The observed CR resource is used to configure the `imagePolicyConfig.internalRegistryHostname` in Kubernetes API server configuration
 * `cluster-config-v1` *configmap* in *kube-system* namespace
   - The observed configmap `install-config` is decoded and the `networking.podCIDR` and `networking.serviceCIDR` is extracted and used as input for `admissionPluginConfig.openshift.io/RestrictedEndpointsAdmission
@@ -39,7 +39,7 @@ The configuration for the Kubernetes API server is the result of merging:
 * a [default config](https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml)
 * observed config (compare observed values above) `spec.spec.unsupportedConfigOverrides` from the `kubeapiserveroperatorconfig`.
 
-All of these are sparse configurations, i.e. unvalidated json snippets which are merged in order to form a valid configuration at the end. 
+All of these are sparse configurations, i.e. unvalidated json snippets which are merged in order to form a valid configuration at the end.
 
 ## Debugging
 
@@ -67,4 +67,20 @@ The current operator status is reported using the `ClusterOperator` resource. To
 
 ```
 $ oc get clusteroperator openshift-cluster-kube-apiserver-operator
+```
+
+## Developing and debugging the bootkube bootstrap phase
+
+The operator image version used by the [https://github.com/openshift/installer/blob/master/pkg/asset/ignition/bootstrap/content/bootkube.go#L86](installer) bootstrap phase can be overridden by creating a custom origin-release image pointing to the developer's operator `:latest` image:
+
+```
+$ IMAGE_ORG=sttts make images
+$ docker push sttts/origin-cluster-kube-apiserver-operator
+
+$ cd ../cluster-kube-apiserver-operator
+$ IMAGES=cluster-kube-apiserver-operator IMAGE_ORG=sttts make origin-release
+$ docker push sttts/origin-release:latest
+
+$ cd ../installer
+$ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/sttts/origin-release:latest bin/openshift-install cluster ...
 ```


### PR DESCRIPTION
Our build scripts are using `IMAGE_ORG` so I've updated the docs and unified all the places to use the same everywhere. 
/assign @sttts 