### PR TITLE
tighten names

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/operator-config.yaml
+++ b/bindata/v3.11.0/kube-apiserver/operator-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
 kind: KubeAPIServerOperatorConfig
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed

--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
-  name: openshift-kube-apiserver
+  name: kube-apiserver
   labels:
-    app: openshift-kube-apiserver
+    app: kube-apiserver
     apiserver: "true"
     revision: "REVISION"
 spec:
   containers:
-  - name: openshift-kube-apiserver
+  - name: kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError

--- a/manifests/0000_10_kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_02_service.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: openshift-kube-apiserver-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
   labels:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
   name: metrics
   namespace: openshift-kube-apiserver-operator
 spec:
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
   sessionAffinity: None
   type: ClusterIP

--- a/manifests/0000_10_kube-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_03_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator-config
+  name: kube-apiserver-operator-config
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/0000_10_kube-apiserver-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_04_clusterrolebinding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver-operator

--- a/manifests/0000_10_kube-apiserver-operator_05_serviceaccount.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_05_serviceaccount.yaml
@@ -2,7 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
-  labels:
-    app: openshift-kube-apiserver-operator
-
+  name: kube-apiserver-operator

--- a/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver-operator
   labels:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openshift-kube-apiserver-operator
+      app: kube-apiserver-operator
   template:
     metadata:
-      name: openshift-kube-apiserver-operator
+      name: kube-apiserver-operator
       labels:
-        app: openshift-kube-apiserver-operator
+        app: kube-apiserver-operator
     spec:
-      serviceAccountName: openshift-kube-apiserver-operator
+      serviceAccountName: kube-apiserver-operator
       containers:
       - name: operator
         image: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
@@ -46,11 +46,11 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          secretName: openshift-kube-apiserver-operator-serving-cert
+          secretName: kube-apiserver-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          name: openshift-kube-apiserver-operator-config
+          name: kube-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/manifests/0000_10_kube-apiserver-operator_07_clusteroperator.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_07_clusteroperator.yaml
@@ -1,5 +1,5 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver
 spec: {}

--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -24,4 +24,4 @@ spec:
     - openshift-kube-apiserver-operator
   selector:
     matchLabels:
-      app: openshift-kube-apiserver-operator
+      app: kube-apiserver-operator

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -141,7 +141,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	staticPodControllers := staticpod.NewControllers(
 		targetNamespaceName,
-		"openshift-kube-apiserver",
+		"kube-apiserver",
 		[]string{"cluster-kube-apiserver-operator", "installer"},
 		deploymentConfigMaps,
 		deploymentSecrets,
@@ -153,8 +153,14 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		ctx.EventRecorder,
 	)
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-kube-apiserver-operator",
-		[]configv1.ObjectReference{},
+		"kube-apiserver",
+		[]configv1.ObjectReference{
+			{Group: "kubeapiserver.operator.openshift.io", Resource: "kubeapiserveroperatorconfigs", Name: "cluster"},
+			{Resource: "namespaces", Name: userSpecifiedGlobalConfigNamespace},
+			{Resource: "namespaces", Name: machineSpecifiedGlobalConfigNamespace},
+			{Resource: "namespaces", Name: operatorNamespace},
+			{Resource: "namespaces", Name: targetNamespaceName},
+		},
 		configClient.ConfigV1(),
 		staticPodOperatorClient,
 		ctx.EventRecorder,

--- a/pkg/operator/staticpod_interface.go
+++ b/pkg/operator/staticpod_interface.go
@@ -18,7 +18,7 @@ func (c *staticPodOperatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c *staticPodOperatorClient) Get() (*operatorv1.OperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -27,7 +27,7 @@ func (c *staticPodOperatorClient) Get() (*operatorv1.OperatorSpec, *operatorv1.S
 }
 
 func (c *staticPodOperatorClient) UpdateStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
-	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (c *staticPodOperatorClient) UpdateStatus(resourceVersion string, status *o
 
 // TODO collapse this onto get
 func (c *staticPodOperatorClient) CurrentStatus() (operatorv1.OperatorStatus, error) {
-	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return operatorv1.OperatorStatus{}, err
 	}
@@ -54,7 +54,7 @@ func (c *staticPodOperatorClient) CurrentStatus() (operatorv1.OperatorStatus, er
 }
 
 func (c *staticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	instance, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -63,7 +63,7 @@ func (c *staticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, 
 }
 
 func (c *staticPodOperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +79,7 @@ func (c *staticPodOperatorClient) UpdateOperatorSpec(resourceVersion string, spe
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *staticPodOperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, string, error) {
-	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("instance")
+	original, err := c.informers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -76,7 +76,7 @@ func NewTargetConfigReconciler(
 }
 
 func (c TargetConfigReconciler) sync() error {
-	operatorConfig, err := c.operatorConfigClient.KubeAPIServerOperatorConfigs().Get("instance", metav1.GetOptions{})
+	operatorConfig, err := c.operatorConfigClient.KubeAPIServerOperatorConfigs().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -226,7 +226,7 @@ func v3110KubeApiserverNsYaml() (*asset, error) {
 var _v3110KubeApiserverOperatorConfigYaml = []byte(`apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
 kind: KubeAPIServerOperatorConfig
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
 `)
@@ -276,14 +276,14 @@ var _v3110KubeApiserverPodYaml = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
-  name: openshift-kube-apiserver
+  name: kube-apiserver
   labels:
-    app: openshift-kube-apiserver
+    app: kube-apiserver
     apiserver: "true"
     revision: "REVISION"
 spec:
   containers:
-  - name: openshift-kube-apiserver
+  - name: kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
1. kubeapiserveroperatorconfig is now called `cluster`
2. clusteroperator is now kube-apiserver
3. resources in our namespace no longer have the openshift prefix
4. static pod is now called kube-apiserver (no prefix)

These names match recent updates.  No other changes.