### PR TITLE
disable endpoint reconciliation on bootstrap master

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -18,6 +18,7 @@ spec:
     command: ["hypershift", "openshift-kube-apiserver"]
     args:
     - --config=/etc/kubernetes/config/{{ .ConfigFileName }}
+    - --endpoint-reconciler-type=none
     volumeMounts:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host


### PR DESCRIPTION
We don't need to create and endpoint.