### PR TITLE
disable endpoint reconciliation on bootstrap master

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -37,3 +37,10 @@ admissionPluginConfig:
       - {{.}}{{end}}{{range .ClusterCIDR}}
       - {{.}}{{end}}
   {{end}}
+apiServerArguments:
+  storage-backend:
+    - etcd3
+  storage-media-type:
+    - application/vnd.kubernetes.protobuf
+  endpoint-reconciler-type:
+    - none


### PR DESCRIPTION
specify a set of apiServerArguments to override the endpoint-reconciler-type