### PR TITLE
static-pod: set graceful termination grace period

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -7,6 +7,7 @@ metadata:
     app: openshift-kube-apiserver
     apiserver: "true"
     revision: "REVISION"
+  deletionGracePeriodSeconds: 65 # a bit more than the kube-apiserver shutdown timeout of 60 sec
 spec:
   containers:
   - name: openshift-kube-apiserver

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -328,6 +328,7 @@ metadata:
     app: openshift-kube-apiserver
     apiserver: "true"
     revision: "REVISION"
+  deletionGracePeriodSeconds: 65 # a bit more than the kube-apiserver shutdown timeout of 60 sec
 spec:
   containers:
   - name: openshift-kube-apiserver


### PR DESCRIPTION
The kube-apiserver shutdown timeout is 60 sec. We give it some more seconds to complete a clean shutdown.