### PR TITLE
stop permafailing status

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -85,9 +85,10 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		ctx.EventRecorder,
 	)
 
-	targetConfigReconciler := targetconfigcontroller.NewTargetConfigReconciler(
+	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),
 		operatorConfigInformers.Kubeapiserver().V1alpha1().KubeAPIServerOperatorConfigs(),
+		operatorClient,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace),
 		operatorConfigClient.KubeapiserverV1alpha1(),


### PR DESCRIPTION
`TargetConfigController` was setting a status in response to being unable to set a status and created a situation of permafailing status. In addition to being a dumb thing to do (why try to set the thing you couldn't set), this stuck us in the CVO.

/assign @mfojtik @sanchezl 