### PR TITLE
make the target namespace removable

### DIFF
--- a/bindata/bootkube/manifests/configmap-aggregator-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-aggregator-client-ca.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aggregator-client-ca
-  namespace: openshift-config-managed
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "aggregator-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-kubelet-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kubelet-serving-ca.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubelet-serving-ca
-  namespace: {{ .Namespace }}
+  name: initial-kubelet-serving-ca
+  namespace: openshift-config
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-kube-apiserver-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kube-apiserver-client-ca.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: client-ca
-  namespace: {{ .Namespace }}
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "kube-ca.crt" | indent 4 }}
-

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -153,6 +153,10 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/aggregator-client-ca", err))
 	}
+	_, _, err = manageKubeletServingCABundle(c.configMapLister, c.kubeClient.CoreV1(), recorder)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kubelet-serving-ca", err))
+	}
 
 	if len(errors) > 0 {
 		condition := operatorv1.OperatorCondition{
@@ -226,6 +230,24 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
+}
+
+func manageKubeletServingCABundle(lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kubelet-serving-ca"},
+		lister,
+		nil, // TODO remove this
+		nil, // TODO remove this
+		// this is from the installer and contains the value they think we should have
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-kubelet-serving-ca"},
+		// this is from kube-controller-manager and indicates the ca-bundle.crt to verify the signed kubelet serving certs
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
We should be able to delete every namespace except the `openshift-config` namespace and recover.  This clearly separates the initially created certificates from those that are managed.

/assign @mfojtik @sttts 