### PR TITLE
Enable --enable-aggregator-routing by default

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -25,6 +25,9 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
+  enable-aggregator-routing:
+  - "true"
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -102,6 +102,9 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
+  enable-aggregator-routing:
+  - "true"
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
Use endpoints IPs directly instead of service IPs, taking some of the networking logic out of the (stability) equation.