### PR TITLE
Trust cluster-ingress-operator's CA certificate

### DIFF
--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -2,6 +2,7 @@ package operatorclient
 
 const (
 	EtcdNamespaceName                     = "kube-system"
+	IngressOperatorNamespace              = "openshift-ingress-operator"
 	GlobalUserSpecifiedConfigNamespace    = "openshift-config"
 	GlobalMachineSpecifiedConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-kube-apiserver-operator"

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -39,6 +39,13 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, err
 	}
+	// this bundle is what cluster-ingress-operator uses to mint default certificates for routers
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "router-ca"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.IngressOperatorNamespace, Name: "router-ca"},
+	); err != nil {
+		return nil, err
+	}
 	// this ca bundle contains certs used by the kube-apiserver to verify client certs
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-client-ca"},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -52,6 +52,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
 		operatorclient.TargetNamespace,
 		operatorclient.OperatorNamespace,
+		operatorclient.IngressOperatorNamespace,
 		"kube-system",
 	)
 	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
@@ -121,6 +122,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 			{Resource: "namespaces", Name: operatorclient.GlobalUserSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.GlobalMachineSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
+			{Resource: "namespaces", Name: operatorclient.IngressOperatorNamespace},
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},
 		},
 		configClient.ConfigV1(),

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -84,6 +84,7 @@ func NewTargetConfigController(
 	kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
+	kubeInformersForNamespaces.InformersFor(operatorclient.IngressOperatorNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 	kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
 
 	return c
@@ -230,6 +231,8 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
+		// this bundle is what cluster-ingress-operator uses to mint default certificates for routers
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.IngressOperatorNamespace, Name: "router-ca"},
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
This PR is related to [NE-139](https://jira.coreos.com/browse/NE-139).

This PR depends on https://github.com/openshift/cluster-ingress-operator/pull/109.

* `pkg/operator/operatorclient/interfaces.go` (`IngressOperatorNamespace`): New constant for cluster-ingress-operator's namespace.
* `pkg/operator/resourcesynccontroller/resourcesynccontroller.go` (`NewResourceSyncController`): Sync cluster-ingress-operator's router-ca configmap.
* `pkg/operator/starter.go` (`RunOperator`): Watch cluster-ingress-operator's namespace.  Add the namespace to related resources in the clusteroperator.
* `pkg/operator/targetconfigcontroller/targetconfigcontroller.go`
(`NewTargetConfigController`): React to changes to configmaps in cluster-ingress-operator's namespace.
(`manageClientCABundle`): Incorporate cluster-ingress-operator's CA certificate into the trust bundle.