### PR TITLE
make new openshift/api CRD

### DIFF
--- a/manifests/0000_10_kube-apiserver-operator_01_config.crd.old.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_01_config.crd.old.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+spec:
+  scope: Cluster
+  group: kubeapiserver.operator.openshift.io
+  version: v1alpha1
+  names:
+    kind: KubeAPIServerOperatorConfig
+    plural: kubeapiserveroperatorconfigs
+    singular: kubeapiserveroperatorconfig
+    categories:
+    - coreoperators
+  subresources:
+    status: {}

--- a/manifests/0000_10_kube-apiserver-operator_01_config.crd.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_01_config.crd.yaml
@@ -1,16 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+  name: kubeapiservers.operator.openshift.io
 spec:
   scope: Cluster
-  group: kubeapiserver.operator.openshift.io
-  version: v1alpha1
+  group: operator.openshift.io
+  version: v1
   names:
-    kind: KubeAPIServerOperatorConfig
-    plural: kubeapiserveroperatorconfigs
-    singular: kubeapiserveroperatorconfig
-    categories:
-    - coreoperators
+    kind: KubeAPIServer
+    plural: kubeapiservers
+    singular: kubeapiserver
   subresources:
     status: {}


### PR DESCRIPTION
in order to switch to the new api types, we need to update the authentication operator (pull open), but that won't work until the resource it watches actually exists, so this starts that process

/assign @mfojtik 