### PR TITLE
tighten kube-apiserver names

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/operator-config.yaml
+++ b/bindata/v3.11.0/kube-apiserver/operator-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: KubeAPIServer
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed

--- a/manifests/0000_10_kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_02_service.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: openshift-kube-apiserver-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
   labels:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
   name: metrics
   namespace: openshift-kube-apiserver-operator
 spec:
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
   sessionAffinity: None
   type: ClusterIP

--- a/manifests/0000_10_kube-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_03_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator-config
+  name: kube-apiserver-operator-config
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/0000_10_kube-apiserver-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_04_clusterrolebinding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver-operator

--- a/manifests/0000_10_kube-apiserver-operator_05_serviceaccount.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_05_serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver-operator
   labels:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
 

--- a/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: openshift-kube-apiserver-operator
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver-operator
   labels:
-    app: openshift-kube-apiserver-operator
+    app: kube-apiserver-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openshift-kube-apiserver-operator
+      app: kube-apiserver-operator
   template:
     metadata:
-      name: openshift-kube-apiserver-operator
+      name: kube-apiserver-operator
       labels:
-        app: openshift-kube-apiserver-operator
+        app: kube-apiserver-operator
     spec:
-      serviceAccountName: openshift-kube-apiserver-operator
+      serviceAccountName: kube-apiserver-operator
       containers:
       - name: operator
         image: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
@@ -51,11 +51,11 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          secretName: openshift-kube-apiserver-operator-serving-cert
+          secretName: kube-apiserver-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          name: openshift-kube-apiserver-operator-config
+          name: kube-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/manifests/0000_10_kube-apiserver-operator_07_clusteroperator.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_07_clusteroperator.yaml
@@ -1,5 +1,5 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: openshift-kube-apiserver-operator
+  name: kube-apiserver
 spec: {}

--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -24,4 +24,4 @@ spec:
     - openshift-kube-apiserver-operator
   selector:
     matchLabels:
-      app: openshift-kube-apiserver-operator
+      app: kube-apiserver-operator

--- a/pkg/operator/operatorclient/staticpod_interface.go
+++ b/pkg/operator/operatorclient/staticpod_interface.go
@@ -18,7 +18,7 @@ func (c *OperatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (c *OperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("instance")
+	instance, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -27,7 +27,7 @@ func (c *OperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOpera
 }
 
 func (c *OperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, status *operatorv1.StaticPodOperatorStatus) (*operatorv1.StaticPodOperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (c *OperatorClient) UpdateStaticPodOperatorStatus(resourceVersion string, s
 }
 
 func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("instance")
+	instance, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -53,7 +53,7 @@ func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operator
 }
 
 func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -69,7 +69,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("instance")
+	original, err := c.Informers.Operator().V1().KubeAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -115,7 +115,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		ctx.EventRecorder,
 	)
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-kube-apiserver-operator",
+		"kube-apiserver",
 		[]configv1.ObjectReference{
 			{Group: "operator.openshift.io", Resource: "kubeapiservers", Name: "cluster"},
 			{Resource: "namespaces", Name: operatorclient.GlobalUserSpecifiedConfigNamespace},

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -89,7 +89,7 @@ func NewTargetConfigController(
 }
 
 func (c TargetConfigController) sync() error {
-	operatorConfig, err := c.operatorConfigClient.KubeAPIServers().Get("instance", metav1.GetOptions{})
+	operatorConfig, err := c.operatorConfigClient.KubeAPIServers().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -249,7 +249,7 @@ func v3110KubeApiserverNsYaml() (*asset, error) {
 var _v3110KubeApiserverOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
 kind: KubeAPIServer
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
 `)


### PR DESCRIPTION
1. kubeapiserveroperatorconfig is now called cluster
2. clusteroperator is now kube-apiserver
3. resources in our namespace no longer have the openshift prefix