### PR TITLE
make it easy to specify multiple SA token verification certs

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -108,8 +108,6 @@ oauthConfig:
     authorizeTokenMaxAgeSeconds: 300
 projectConfig:
   defaultNodeSelector: ""
-serviceAccountPublicKeyFiles:
-- /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs/ca-bundle.crt
 servicesNodePortRange: 30000-32767
 servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,7 +1,8 @@
 package configobservercontroller
 
 import (
-	kubeinformers "k8s.io/client-go/informers"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/satokencerts"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"k8s.io/client-go/tools/cache"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -26,11 +27,29 @@ type ConfigObserver struct {
 func NewConfigObserver(
 	operatorClient v1helpers.OperatorClient,
 	operatorConfigInformers operatorv1informers.SharedInformerFactory,
-	kubeInformersForKubeSystemNamespace kubeinformers.SharedInformerFactory,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	configInformer configinformers.SharedInformerFactory,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
 	eventRecorder events.Recorder,
 ) *ConfigObserver {
+	interestingNamespaces := []string{
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.TargetNamespace,
+		operatorclient.OperatorNamespace,
+		"kube-system",
+	}
+
+	preRunCaches := []cache.InformerSynced{
+		operatorConfigInformers.Operator().V1().KubeAPIServers().Informer().HasSynced,
+		kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().Endpoints().Informer().HasSynced,
+		configInformer.Config().V1().Authentications().Informer().HasSynced,
+		configInformer.Config().V1().Images().Informer().HasSynced,
+	}
+	for _, ns := range interestingNamespaces {
+		preRunCaches = append(preRunCaches, kubeInformersForNamespaces.InformersFor(ns).Core().V1().ConfigMaps().Informer().HasSynced)
+	}
+
 	c := &ConfigObserver{
 		ConfigObserver: configobserver.NewConfigObserver(
 			operatorClient,
@@ -38,34 +57,36 @@ func NewConfigObserver(
 			configobservation.Listers{
 				AuthConfigLister:  configInformer.Config().V1().Authentications().Lister(),
 				ImageConfigLister: configInformer.Config().V1().Images().Lister(),
-				EndpointsLister:   kubeInformersForKubeSystemNamespace.Core().V1().Endpoints().Lister(),
-				ConfigmapLister:   kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Lister(),
+				ConfigmapLister:   kubeInformersForNamespaces.ConfigMapLister(),
+				EndpointsLister:   kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().Endpoints().Lister(),
 				APIServerLister:   configInformer.Config().V1().APIServers().Lister(),
 				ResourceSync:      resourceSyncer,
 				PreRunCachesSynced: []cache.InformerSynced{
 					operatorConfigInformers.Operator().V1().KubeAPIServers().Informer().HasSynced,
-					kubeInformersForKubeSystemNamespace.Core().V1().Endpoints().Informer().HasSynced,
-					kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
+					kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().Endpoints().Informer().HasSynced,
 					configInformer.Config().V1().Authentications().Informer().HasSynced,
 					configInformer.Config().V1().Images().Informer().HasSynced,
 					configInformer.Config().V1().APIServers().Informer().HasSynced,
 				},
 			},
+			apiserver.ObserveDefaultUserServingCertificate,
+			apiserver.ObserveNamedCertificates,
+			apiserver.ObserveUserClientCABundle,
+			auth.ObserveAuthMetadata,
 			etcd.ObserveStorageURLs,
 			network.ObserveRestrictedCIDRs,
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,
-			auth.ObserveAuthMetadata,
-			apiserver.ObserveDefaultUserServingCertificate,
-			apiserver.ObserveNamedCertificates,
-			apiserver.ObserveUserClientCABundle,
+			satokencerts.ObserveSATokenCerts,
 		),
 	}
 
+	for _, ns := range interestingNamespaces {
+		kubeInformersForNamespaces.InformersFor(ns).Core().V1().ConfigMaps().Informer().AddEventHandler(c.EventHandler())
+	}
 	operatorConfigInformers.Operator().V1().KubeAPIServers().Informer().AddEventHandler(c.EventHandler())
-	kubeInformersForKubeSystemNamespace.Core().V1().Endpoints().Informer().AddEventHandler(c.EventHandler())
-	kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.EventHandler())
+	kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().Endpoints().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Images().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Authentications().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().APIServers().Informer().AddEventHandler(c.EventHandler())

--- a/pkg/operator/configobservation/satokencerts/observe_satokencerts.go
+++ b/pkg/operator/configobservation/satokencerts/observe_satokencerts.go
@@ -1,0 +1,79 @@
+package satokencerts
+
+import (
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+)
+
+// ObserveSATokenCerts checks which configmaps exist and bases the configuration for verifying sa tokens on them.
+// There are two possible sources: the installer and the kube-controller-manger-operator, but we wire to the target namespace
+// to avoid setting a config we cannot fulfill which would crash the kube-apiserver.
+func ObserveSATokenCerts(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	errs := []error{}
+	prevObservedConfig := map[string]interface{}{}
+
+	// copy non-empty .serviceAccountPublicKeyFiles from existingConfig to prevObservedConfig
+	saTokenCertsPath := []string{"serviceAccountPublicKeyFiles"}
+	existingSATokenCerts, _, err := unstructured.NestedStringSlice(existingConfig, saTokenCertsPath...)
+	if err != nil {
+		return prevObservedConfig, append(errs, err)
+	}
+	if len(existingSATokenCerts) > 0 {
+		if err := unstructured.SetNestedStringSlice(prevObservedConfig, existingSATokenCerts, saTokenCertsPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	observedConfig := map[string]interface{}{}
+	saTokenCertDirs := []string{}
+
+	// add initial-sa-token-signing-certs configmap mount path to saTokenCertDirs if configmap exists
+	initialCerts, err := listers.ConfigmapLister.ConfigMaps(operatorclient.TargetNamespace).Get("initial-sa-token-signing-certs")
+	switch {
+	case errors.IsNotFound(err):
+		// do nothing because we aren't going to add a path to a missing configmap
+	case err != nil:
+		// we had an error, return what we had before and exit. this really shouldn't happen
+		return prevObservedConfig, append(errs, err)
+	case len(initialCerts.Data) > 0:
+		// this means we have this configmap and it has values, so wire up the directory
+		saTokenCertDirs = append(saTokenCertDirs, "/etc/kubernetes/static-pod-resources/configmaps/initial-sa-token-signing-certs")
+	default:
+		// do nothing because aren't going to add a path to a configmap with no files
+	}
+
+	kcmCerts, err := listers.ConfigmapLister.ConfigMaps(operatorclient.TargetNamespace).Get("kube-controller-manager-sa-token-signing-certs")
+	switch {
+	case errors.IsNotFound(err):
+		// do nothing because we aren't going to add a path to a missing configmap
+	case err != nil:
+		// we had an error, return what we had before and exit. this really shouldn't happen
+		return prevObservedConfig, append(errs, err)
+	case len(kcmCerts.Data) > 0:
+		// this means we have this configmap and it has values, so wire up the directory
+		saTokenCertDirs = append(saTokenCertDirs, "/etc/kubernetes/static-pod-resources/configmaps/kube-controller-manager-sa-token-signing-certs")
+	default:
+		// do nothing because aren't going to add a path to a configmap with no files
+	}
+
+	if len(saTokenCertDirs) > 0 {
+		if err := unstructured.SetNestedStringSlice(observedConfig, saTokenCertDirs, saTokenCertsPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(existingSATokenCerts, saTokenCertDirs) {
+		recorder.Eventf("ObserveSATokenCerts", "serviceAccountPublicKeyFiles changed to %v", saTokenCertDirs)
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -32,13 +32,21 @@ func NewResourceSyncController(
 	); err != nil {
 		return nil, err
 	}
-	// this configmap holds the cert used to verify SA token JWTs
+	// this configmap holds the cert used to verify SA token JWTs created by the bootstrap kube-controller-manager
 	if err := resourceSyncController.SyncConfigMap(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "sa-token-signing-certs"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "initial-sa-token-signing-certs"},
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-sa-token-signing-certs"},
 	); err != nil {
 		return nil, err
 	}
+	// this configmaps holds the certs used to verify the SA token JWTs created by the kube-controller-manager-operator
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-controller-manager-sa-token-signing-certs"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "sa-token-signing-certs"},
+	); err != nil {
+		return nil, err
+	}
+
 	// this secret contains the client cert/key pair used to communicate to kubelets
 	// TODO this needs to rotate and we will consume it as input from the kubelet operator
 	if err := resourceSyncController.SyncSecret(

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -82,7 +82,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	configObserver := configobservercontroller.NewConfigObserver(
 		operatorClient,
 		operatorConfigInformers,
-		kubeInformersForNamespaces.InformersFor("kube-system"),
+		kubeInformersForNamespaces,
 		configInformers,
 		resourceSyncController,
 		ctx.EventRecorder,
@@ -166,6 +166,8 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "client-ca"},
 	{Name: "config"},
 	{Name: "etcd-serving-ca"},
+	{Name: "initial-sa-token-signing-certs", Optional: true},
+	{Name: "kube-controller-manager-sa-token-signing-certs", Optional: true},
 	{Name: "kubelet-serving-ca"},
 	{Name: "oauth-metadata", Optional: true},
 	{Name: "sa-token-signing-certs"},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -185,8 +185,6 @@ oauthConfig:
     authorizeTokenMaxAgeSeconds: 300
 projectConfig:
   defaultNodeSelector: ""
-serviceAccountPublicKeyFiles:
-- /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs/ca-bundle.crt
 servicesNodePortRange: 30000-32767
 servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:


### PR DESCRIPTION
SA token verification takes a list of signing public keys to verify the SA tokens.  This separates out the initial one create by the installer and makes it possible to union more in.

I'm going to open an origin pull to make this take a directory, alpha sort, and use that.

/assign @sttts 