### PR TITLE
handle rotation of SA token signers

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sa-token-signing-certs
-  namespace: {{ .Namespace }}
+  name: initial-sa-token-ca
+  namespace: openshift-config
 data:
   ca-bundle.crt: |
     {{ .Assets | load "service-account.pub" | indent 4 }}

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -109,7 +109,7 @@ oauthConfig:
 projectConfig:
   defaultNodeSelector: ""
 serviceAccountPublicKeyFiles:
-- /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs/ca-bundle.crt
+- /etc/kubernetes/static-pod-resources/configmaps/sa-token-ca/ca-bundle.crt
 servicesNodePortRange: 30000-32767
 servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -160,7 +160,7 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "etcd-serving-ca"},
 	{Name: "kubelet-serving-ca"},
 	{Name: "oauth-metadata", Optional: true},
-	{Name: "sa-token-signing-certs"},
+	{Name: "sa-token-ca"},
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -156,6 +156,10 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kubelet-serving-ca", err))
 	}
+	_, _, err = manageSATokenCABundle(c.configMapLister, c.kubeClient.CoreV1(), recorder)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/sa-token-ca", err))
+	}
 
 	if len(errors) > 0 {
 		condition := operatorv1.OperatorCondition{
@@ -229,6 +233,24 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
+}
+
+func manageSATokenCABundle(lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "sa-token-ca"},
+		lister,
+		nil, // TODO remove this
+		nil, // TODO remove this
+		// this is from the installer and contains the value they think we should have
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-sa-token-ca"},
+		// this is from kube-controller-manager and is a ca bundle that contains the certs for verifying the jwts
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "managed-sa-token-ca"},
 	)
 	if err != nil {
 		return nil, false, err

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -186,7 +186,7 @@ oauthConfig:
 projectConfig:
   defaultNodeSelector: ""
 serviceAccountPublicKeyFiles:
-- /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs/ca-bundle.crt
+- /etc/kubernetes/static-pod-resources/configmaps/sa-token-ca/ca-bundle.crt
 servicesNodePortRange: 30000-32767
 servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:


### PR DESCRIPTION
try creating a bundle for SA token JWT verification and see if it works.

/assign @sttts 


/hold
don't merge until after https://github.com/openshift/cluster-kube-apiserver-operator/pull/239 passes