### PR TITLE
move all irreplaceable content to openshift-config

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sa-token-signing-certs
-  namespace: {{ .Namespace }}
+  name: initial-sa-token-signing-certs
+  namespace: openshift-config
 data:
   ca-bundle.crt: |
     {{ .Assets | load "service-account.pub" | indent 4 }}

--- a/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
+++ b/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubelet-client
-  namespace: {{ .Namespace }}
+  name: initial-kubelet-client
+  namespace: openshift-config
 type: SecretTypeTLS
 data:
   tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
+++ b/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: serving-cert
-  namespace: {{ .Namespace }}
+  name: initial-serving-cert
+  namespace: openshift-config
 type: SecretTypeTLS
 data:
   tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}


### PR DESCRIPTION
The installer provides a set of certificates that we cannot replace, cannot remove, and cannot rotate.  These are the only irreplaceable content in our operator and target namespaces. This pull moves that content into `openshift-config` since we cannot manage it.  In theory, this will make it possible to delete the entire operator and target namespace and recover from it.

/assign @sttts @mfojtik 