### PR TITLE
update admission configuration for groupification

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -29,9 +29,9 @@ storageConfig:
 servicesSubnet: {{index .ServiceCIDR 0}}{{end}}
 admissionPluginConfig:
   {{if .ServiceCIDR }}
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
-      apiVersion: v1
+      apiVersion: network.openshift.io/v1
       kind: RestrictedEndpointsAdmissionConfig
       restrictedCIDRs: {{range .ServiceCIDR}}
       - {{.}}{{end}}{{range .ClusterCIDR}}

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,16 +1,16 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admissionPluginConfig:
-  ExternalIPRanger:
+  network.openshift.io/ExternalIPRanger:
     configuration:
       allowIngressIP: true
-      apiVersion: v1
+      apiVersion: network.openshift.io/v1
       externalIPNetworkCIDRs: null
       kind: ExternalIPRangerAdmissionConfig
     location: ""
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
-      apiVersion: v1
+      apiVersion: network.openshift.io/v1
       kind: RestrictedEndpointsAdmissionConfig
       restrictedCIDRs:
       - 10.3.0.0/16 # ServiceCIDR

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -16,7 +16,7 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 	listers := genericListers.(configobservation.Listers)
 
 	var errs []error
-	restrictedCIDRsPath := []string{"admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
+	restrictedCIDRsPath := []string{"admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
 
 	previouslyObservedConfig := map[string]interface{}{}
 	if currentRestrictedCIDRBs, _, err := unstructured.NestedStringSlice(existingConfig, restrictedCIDRsPath...); len(currentRestrictedCIDRBs) > 0 {
@@ -42,7 +42,7 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 
 	// set observed values
 	//  admissionPluginConfig:
-	//    openshift.io/RestrictedEndpointsAdmission:
+	//    network.openshift.io/RestrictedEndpointsAdmission:
 	//	  configuration:
 	//	    restrictedCIDRs:
 	//	    - 10.3.0.0/16 # ServiceCIDR

--- a/pkg/operator/configobservation/network/observe_network_test.go
+++ b/pkg/operator/configobservation/network/observe_network_test.go
@@ -33,7 +33,7 @@ func TestObserveClusterConfig(t *testing.T) {
 	if len(errors) > 0 {
 		t.Error("expected len(errors) == 0")
 	}
-	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -78,16 +78,16 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admissionPluginConfig:
-  ExternalIPRanger:
+  network.openshift.io/ExternalIPRanger:
     configuration:
       allowIngressIP: true
-      apiVersion: v1
+      apiVersion: network.openshift.io/v1
       externalIPNetworkCIDRs: null
       kind: ExternalIPRangerAdmissionConfig
     location: ""
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
-      apiVersion: v1
+      apiVersion: network.openshift.io/v1
       kind: RestrictedEndpointsAdmissionConfig
       restrictedCIDRs:
       - 10.3.0.0/16 # ServiceCIDR


### PR DESCRIPTION
Admission plugins and their configuration types have been groupified.  We tolerate both at the moment to make this transition, but once we merge this pull we will remove the old configuration.


@openshift/sig-networking fyi
/assign @sttts @mfojtik @soltysh 