### PR TITLE
switch network admission plugin name

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -29,7 +29,7 @@ storageConfig:
 servicesSubnet: {{index .ServiceCIDR 0}}{{end}}
 admissionPluginConfig:
   {{if .ServiceCIDR }}
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
       apiVersion: v1
       kind: RestrictedEndpointsAdmissionConfig

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,14 +1,14 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admissionPluginConfig:
-  ExternalIPRanger:
+  network.openshift.io/ExternalIPRanger:
     configuration:
       allowIngressIP: true
       apiVersion: v1
       externalIPNetworkCIDRs: null
       kind: ExternalIPRangerAdmissionConfig
     location: ""
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
       apiVersion: v1
       kind: RestrictedEndpointsAdmissionConfig

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -16,7 +16,7 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 	listers := genericListers.(configobservation.Listers)
 
 	var errs []error
-	restrictedCIDRsPath := []string{"admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
+	restrictedCIDRsPath := []string{"admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
 
 	previouslyObservedConfig := map[string]interface{}{}
 	if currentRestrictedCIDRBs, _, err := unstructured.NestedStringSlice(existingConfig, restrictedCIDRsPath...); len(currentRestrictedCIDRBs) > 0 {

--- a/pkg/operator/configobservation/network/observe_network_test.go
+++ b/pkg/operator/configobservation/network/observe_network_test.go
@@ -33,7 +33,7 @@ func TestObserveClusterConfig(t *testing.T) {
 	if len(errors) > 0 {
 		t.Error("expected len(errors) == 0")
 	}
-	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -78,14 +78,14 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admissionPluginConfig:
-  ExternalIPRanger:
+  network.openshift.io/ExternalIPRanger:
     configuration:
       allowIngressIP: true
       apiVersion: v1
       externalIPNetworkCIDRs: null
       kind: ExternalIPRangerAdmissionConfig
     location: ""
-  openshift.io/RestrictedEndpointsAdmission:
+  network.openshift.io/RestrictedEndpointsAdmission:
     configuration:
       apiVersion: v1
       kind: RestrictedEndpointsAdmissionConfig


### PR DESCRIPTION
switch the network admission plugin name.  We'll go after the serialization separately.