### PR TITLE
observed managed named certificates

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -168,6 +168,17 @@ func TestObserveNamedCertificates(t *testing.T) {
 			},
 		},
 	}
+	localhostCertInfo := map[string]interface{}{
+		"names":    []interface{}{"localhost", "127.0.0.1"},
+		"certFile": "/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key",
+	}
+
+	serviceNameHostInfo := map[string]interface{}{
+		"names":    []interface{}{"kubernetes.default.svc.cluster.local"},
+		"certFile": "/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key",
+	}
 
 	testCases := []struct {
 		name           string
@@ -225,6 +236,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						localhostCertInfo, serviceNameHostInfo,
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -257,6 +269,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						localhostCertInfo, serviceNameHostInfo,
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -291,6 +304,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						localhostCertInfo, serviceNameHostInfo,
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -332,6 +346,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						localhostCertInfo, serviceNameHostInfo,
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -61,6 +61,7 @@ func NewConfigObserver(
 				EndpointsLister:   kubeInformersForNamespaces.InformersFor("kube-system").Core().V1().Endpoints().Lister(),
 				APIServerLister:   configInformer.Config().V1().APIServers().Lister(),
 				NetworkLister:     configInformer.Config().V1().Networks().Lister(),
+				DNSLister:         configInformer.Config().V1().DNSs().Lister(),
 				ResourceSync:      resourceSyncer,
 				PreRunCachesSynced: []cache.InformerSynced{
 					operatorConfigInformers.Operator().V1().KubeAPIServers().Informer().HasSynced,
@@ -69,6 +70,7 @@ func NewConfigObserver(
 					configInformer.Config().V1().Images().Informer().HasSynced,
 					configInformer.Config().V1().APIServers().Informer().HasSynced,
 					configInformer.Config().V1().Networks().Informer().HasSynced,
+					configInformer.Config().V1().DNSs().Informer().HasSynced,
 				},
 			},
 			apiserver.ObserveDefaultUserServingCertificate,
@@ -93,6 +95,7 @@ func NewConfigObserver(
 	configInformer.Config().V1().Authentications().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().APIServers().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Networks().Informer().AddEventHandler(c.EventHandler())
+	configInformer.Config().V1().DNSs().Informer().AddEventHandler(c.EventHandler())
 
 	return c
 }

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -15,6 +15,7 @@ type Listers struct {
 	ConfigmapLister   corelistersv1.ConfigMapLister
 	APIServerLister   configlistersv1.APIServerLister
 	NetworkLister     configlistersv1.NetworkLister
+	DNSLister         configlistersv1.DNSLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced


### PR DESCRIPTION
* Added `listers` parameter to `observeAPIServerConfigFunc` so `observeNamedCertificates()` can observe from other configs besides `APIServer`.
* Added `DNS` lister to `Lister`, but unable to use it to complete the `<clusterName>-api.<baseDomain>` hostname as I was unable to observer the `clusterName`.
* This pull can be merged without breaking anything, but it's meant for future work being done by @deads2k .