### PR TITLE
Observe apiserver config

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -1,0 +1,274 @@
+package apiserver
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/imdario/mergo"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+)
+
+const (
+	userServingCertPublicCertFile            = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.crt"
+	userServingCertPrivateKeyFile            = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.key"
+	maxUserNamedCerts                        = 10
+	userServingCertResourceName              = "user-serving-cert"
+	namedUserServingCertResourceNameFormat   = "user-serving-cert-%03d"
+	namedUserServingCertPublicCertFileFormat = "/etc/kubernetes/static-pod-resources/secrets/%v/tls.crt"
+	namedUserServingCertPrivateKeyFileFormat = "/etc/kubernetes/static-pod-resources/secrets/%v/tls.key"
+)
+
+var namedUserServingCertResourceNames = []string{
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 0),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 1),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 2),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 3),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 4),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 5),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 6),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 7),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 8),
+	fmt.Sprintf(namedUserServingCertResourceNameFormat, 9),
+}
+
+// resourceSyncFunc syncs a resource from the source location to the destination location.
+type resourceSyncFunc func(destination, source resourcesynccontroller.ResourceLocation) error
+
+// observeAPIServerConfigFunc observes configuration and returns the observedConfig and a map describing a list of
+// resources to sync.
+type observeAPIServerConfigFunc func(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error)
+
+// ObserveUserClientCABundle returns an ObserveConfigFunc that observes a user managed certificate bundle containing
+// signers that will be recognized for incoming client certificates in addition to the operator managed signers.
+func ObserveUserClientCABundle() configobserver.ObserveConfigFunc {
+	return newAPIServerObserver(observeUserClientCABundle, [][]string{}, []string{"user-client-ca"}, corev1.ConfigMap{})
+}
+
+// ObserveDefaultUserServingCertificate returns an ObserveConfigFunc that observes user managed TLS cert info for
+// serving secure traffic.
+func ObserveDefaultUserServingCertificate() configobserver.ObserveConfigFunc {
+	configPaths := [][]string{{"servingInfo", "certFile"}, {"servingInfo", "keyFile"}}
+	return newAPIServerObserver(observeDefaultUserServingCertificate, configPaths, []string{userServingCertResourceName}, corev1.ConfigMap{})
+}
+
+// ObserveNamedCertificates returns an ObserveConfigFunc that observes user managed TLS cert info for serving secure
+// traffic to specific hostnames.
+func ObserveNamedCertificates() configobserver.ObserveConfigFunc {
+	configPaths := [][]string{{"servingInfo", "namedCertificates"}}
+	return newAPIServerObserver(observeNamedCertificates, configPaths, namedUserServingCertResourceNames, corev1.Secret{})
+}
+
+// observeUserClientCABundle observes a user managed ConfigMap containing a certificate bundle for the signers that will
+// be recognized for incoming client certificates in addition to the operator managed signers.
+func observeUserClientCABundle(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+	configMapName := apiServer.Spec.ClientCA.Name
+	if len(configMapName) == 0 {
+		return nil, nil, nil // previously observed resource (if any) should be deleted
+	}
+	// The user managed client CA bundle will be combined with other operator managed client CA bundles (by the target
+	// config controller) into a common client CA bundle managed by the operator. As such, since the user managed client
+	// CA bundle is never explicitly referenced in the kube-apiserver config, the returned observed config will always
+	// be empty.
+	return nil, map[string]*string{"user-client-ca": &configMapName}, nil
+}
+
+// observeDefaultUserServingCertificate observes user managed Secret containing the default cert info for serving
+// secure traffic.
+func observeDefaultUserServingCertificate(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+	var errs []error
+	servingCertSecretName := apiServer.Spec.ServingCerts.DefaultServingCertificate.Name
+	if len(servingCertSecretName) == 0 {
+		return nil, nil, nil // previously observed config and resources (if any) should be deleted
+	}
+	// generate an observed configuration that will configure the kube-apiserver to use the user managed default serving
+	// cert info instead of the operator managed default serving cert info.
+	observedConfig := map[string]interface{}{}
+	certFile := fmt.Sprint(userServingCertPublicCertFile)
+	if err := unstructured.SetNestedField(observedConfig, certFile, "servingInfo", "certFile"); err != nil {
+		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(userServingCertResourceName), append(errs, err)
+	}
+	keyFile := fmt.Sprint(userServingCertPrivateKeyFile)
+	if err := unstructured.SetNestedField(observedConfig, keyFile, "servingInfo", "keyFile"); err != nil {
+		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(userServingCertResourceName), append(errs, err)
+	}
+	return observedConfig, map[string]*string{"user-serving-cert": &servingCertSecretName}, errs
+}
+
+// observeNamedCertificates observes user managed Secrets containing TLS cert info for serving secure traffic to
+// specific hostnames.
+func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+	var errs []error
+
+	observedConfig := map[string]interface{}{}
+
+	namedCertificates := apiServer.Spec.ServingCerts.NamedCertificates
+	if len(namedCertificates) > maxUserNamedCerts {
+		err := fmt.Errorf("apiservers.config.openshift.io/cluster: spec.servingCerts.namedCertificates cannot have more than %v entries", maxUserNamedCerts)
+		recorder.Warningf("ObserveNamedCertificatesFailed", err.Error())
+		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+	}
+
+	// add the named cert info to the observed config. return the previously observed config on any error.
+	namedCertificatesPath := []string{"servingInfo", "namedCertificates"}
+	resourceSyncRules := map[string]*string{}
+	if len(namedCertificates) > 0 {
+		var observedNamedCertificates []interface{}
+		for index, namedCertificate := range namedCertificates {
+			observedNamedCertificate := map[string]interface{}{}
+			if len(namedCertificate.Names) > 0 {
+				if err := unstructured.SetNestedStringSlice(observedNamedCertificate, namedCertificate.Names, "names"); err != nil {
+					return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+				}
+			}
+			sourceSecretName := namedCertificate.ServingCertificate.Name
+			if len(sourceSecretName) == 0 {
+				err := fmt.Errorf("apiservers.config.openshift.io/cluster: spec.servingCerts.namedCertificates[%v].servingCertificate.name not found", index)
+				recorder.Warningf("ObserveNamedCertificatesFailed", err.Error())
+				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+			}
+			// pick one of the available target resource names
+			targetSecretName := fmt.Sprintf(namedUserServingCertResourceNameFormat, index)
+
+			// add a sync rule to copy the user specified secret to the operator namespace
+			resourceSyncRules[targetSecretName] = &sourceSecretName
+
+			// add the named certificate to the observed config
+			certFile := fmt.Sprintf(namedUserServingCertPublicCertFileFormat, targetSecretName)
+			if err := unstructured.SetNestedField(observedNamedCertificate, certFile, "certFile"); err != nil {
+				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+			}
+			keyFile := fmt.Sprintf(namedUserServingCertPrivateKeyFileFormat, targetSecretName)
+			if err := unstructured.SetNestedField(observedNamedCertificate, keyFile, "keyFile"); err != nil {
+				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+			}
+			observedNamedCertificates = append(observedNamedCertificates, observedNamedCertificate)
+		}
+		if err := unstructured.SetNestedField(observedConfig, observedNamedCertificates, namedCertificatesPath...); err != nil {
+			return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+		}
+	}
+
+	return observedConfig, resourceSyncRules, errs
+}
+
+// newAPIServerObserver returns an ObserveConfigFunc that observes configuration and resources.
+func newAPIServerObserver(observeAPIServerConfig observeAPIServerConfigFunc, configPaths [][]string, resourceNames []string, resourceType interface{}) configobserver.ObserveConfigFunc {
+	return func(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+		listers := genericListers.(configobservation.Listers)
+		var errs []error
+
+		// pick the correct resource sync function
+		resourceSync := listers.ResourceSyncer().SyncSecret
+		if _, ok := resourceType.(corev1.ConfigMap); ok {
+			resourceSync = listers.ResourceSyncer().SyncConfigMap
+		}
+
+		// extract the previously observed config. capture, but don't react to, errors.
+		previouslyObservedConfig, errs := extractPreviouslyObservedConfig(existingConfig, configPaths...)
+
+		// get the apiserver config
+		apiServer, err := listers.APIServerLister.Get("cluster")
+
+		// if apiserver config is not found, it's not an error (it's optional), clear the observed config and observed resources
+		if errors.IsNotFound(err) {
+			glog.Warningf("apiservers.config.openshift.io/cluster: not found")
+			deleteObservedResources(resourceSync, resourceNames)
+			return nil, errs
+		}
+
+		// if something went wrong, keep the previously observed config and resources
+		if err != nil {
+			return previouslyObservedConfig, append(errs, err)
+		}
+
+		observedConfig, observedResources, errs := observeAPIServerConfig(apiServer, recorder, previouslyObservedConfig)
+
+		// default to deleting previous resources, and then merge in observed resources rules
+		resourceSyncRules := makeDeleteAllResourcesSyncRules(resourceNames...)
+		if err := mergo.Merge(&resourceSyncRules, &observedResources, mergo.WithOverride); err != nil {
+			glog.Warningf("merging resource sync rules failed: %v", err)
+		}
+
+		// sync observed resources
+		errs = append(errs, syncObservedResources(resourceSync, resourceSyncRules)...)
+
+		return observedConfig, errs
+	}
+}
+
+// makeDeleteAllResourcesSyncRules generates resource sync rules to delete the resources, specified by names, from the
+// operator namespace.
+func makeDeleteAllResourcesSyncRules(names ...string) map[string]*string {
+	resourceSyncRules := map[string]*string{}
+	deleteIndicator := ""
+	for _, name := range names {
+		resourceSyncRules[name] = &deleteIndicator
+	}
+	return resourceSyncRules
+}
+
+// makeIgnoreAllResourcesSyncRules generates resource sync rules to ignore the resources, specified by names, from the
+// operator namespace. This is useful if you need to, for example, leave all the previously observed resources as they
+// are.
+func makeIgnoreAllResourcesSyncRules(names ...string) map[string]*string {
+	resourceSyncRules := map[string]*string{}
+	for _, name := range names {
+		resourceSyncRules[name] = nil
+	}
+	return resourceSyncRules
+}
+
+// syncObservedResources synchronizes resource from the global user specified config namespace into the operator
+// namespace. The the entry keys in the syncRules should be the names of the resources to be synced into the operator
+// namespace. The corresponding values should be either the name of the resource to copy from the global user specified
+// config namespace to the operator's namespace on sync, an empty string to indicate that the resource should be deleted
+// on sync, or a nil to indicate that the resource should be left as-is on sync.
+func syncObservedResources(syncResource resourceSyncFunc, syncRules map[string]*string) []error {
+	var errs []error
+	for to, from := range syncRules {
+		if from != nil {
+			var source resourcesynccontroller.ResourceLocation
+			if len(*from) > 0 {
+				source = resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: *from}
+			}
+			destination := resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: to}
+			if err := syncResource(destination, source); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+// deleteObservedResources delete the resources, specified by names, from the operator namespace.
+func deleteObservedResources(syncFunc resourceSyncFunc, names []string) []error {
+	return syncObservedResources(syncFunc, makeDeleteAllResourcesSyncRules(names...))
+}
+
+// extractPreviouslyObservedConfig extracts the previously observed config from the existing config.
+func extractPreviouslyObservedConfig(existing map[string]interface{}, paths ...[]string) (map[string]interface{}, []error) {
+	var errs []error
+	previous := map[string]interface{}{}
+	for _, fields := range paths {
+		value, _, err := unstructured.NestedFieldCopy(existing, fields...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		err = unstructured.SetNestedField(previous, value, fields...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return previous, errs
+}

--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -20,13 +20,9 @@ import (
 )
 
 const (
-	userServingCertPublicCertFile            = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.crt"
-	userServingCertPrivateKeyFile            = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.key"
-	maxUserNamedCerts                        = 10
-	userServingCertResourceName              = "user-serving-cert"
-	namedUserServingCertResourceNameFormat   = "user-serving-cert-%03d"
-	namedUserServingCertPublicCertFileFormat = "/etc/kubernetes/static-pod-resources/secrets/%v/tls.crt"
-	namedUserServingCertPrivateKeyFileFormat = "/etc/kubernetes/static-pod-resources/secrets/%v/tls.key"
+	userServingCertPublicCertFile          = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.crt"
+	userServingCertPrivateKeyFile          = "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.key"
+	namedUserServingCertResourceNameFormat = "user-serving-cert-%03d"
 )
 
 var namedUserServingCertResourceNames = []string{
@@ -42,36 +38,51 @@ var namedUserServingCertResourceNames = []string{
 	fmt.Sprintf(namedUserServingCertResourceNameFormat, 9),
 }
 
+var maxUserNamedCerts = len(namedUserServingCertResourceNames)
+
+// syncActionRules rules define source resource names indexed by destination resource names.
+// Empty value means to delete the destination.
+type syncActionRules map[string]string
+
 // resourceSyncFunc syncs a resource from the source location to the destination location.
 type resourceSyncFunc func(destination, source resourcesynccontroller.ResourceLocation) error
 
 // observeAPIServerConfigFunc observes configuration and returns the observedConfig and a map describing a list of
 // resources to sync.
-type observeAPIServerConfigFunc func(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error)
+// It returns the observed config, sync rules and possibly an error. Nil sync rules mean to ignore all resources
+// in case of error. Otherwise, resources are deleted by default and the returned sync rules are taken as overrides of that.
+type observeAPIServerConfigFunc func(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, syncActionRules, []error)
 
 // ObserveUserClientCABundle returns an ObserveConfigFunc that observes a user managed certificate bundle containing
 // signers that will be recognized for incoming client certificates in addition to the operator managed signers.
-func ObserveUserClientCABundle() configobserver.ObserveConfigFunc {
-	return newAPIServerObserver(observeUserClientCABundle, [][]string{}, []string{"user-client-ca"}, corev1.ConfigMap{})
-}
+var ObserveUserClientCABundle configobserver.ObserveConfigFunc = (&apiServerObserver{
+	observerFunc:  observeUserClientCABundle,
+	configPaths:   [][]string{},
+	resourceNames: []string{"user-client-ca"},
+	resourceType:  corev1.ConfigMap{},
+}).observe
 
 // ObserveDefaultUserServingCertificate returns an ObserveConfigFunc that observes user managed TLS cert info for
 // serving secure traffic.
-func ObserveDefaultUserServingCertificate() configobserver.ObserveConfigFunc {
-	configPaths := [][]string{{"servingInfo", "certFile"}, {"servingInfo", "keyFile"}}
-	return newAPIServerObserver(observeDefaultUserServingCertificate, configPaths, []string{userServingCertResourceName}, corev1.ConfigMap{})
-}
+var ObserveDefaultUserServingCertificate configobserver.ObserveConfigFunc = (&apiServerObserver{
+	observerFunc:  observeDefaultUserServingCertificate,
+	configPaths:   [][]string{{"servingInfo", "certFile"}, {"servingInfo", "keyFile"}},
+	resourceNames: []string{"user-serving-cert"},
+	resourceType:  corev1.ConfigMap{},
+}).observe
 
 // ObserveNamedCertificates returns an ObserveConfigFunc that observes user managed TLS cert info for serving secure
 // traffic to specific hostnames.
-func ObserveNamedCertificates() configobserver.ObserveConfigFunc {
-	configPaths := [][]string{{"servingInfo", "namedCertificates"}}
-	return newAPIServerObserver(observeNamedCertificates, configPaths, namedUserServingCertResourceNames, corev1.Secret{})
-}
+var ObserveNamedCertificates configobserver.ObserveConfigFunc = (&apiServerObserver{
+	observerFunc:  observeNamedCertificates,
+	configPaths:   [][]string{{"servingInfo", "namedCertificates"}},
+	resourceNames: namedUserServingCertResourceNames,
+	resourceType:  corev1.Secret{},
+}).observe
 
 // observeUserClientCABundle observes a user managed ConfigMap containing a certificate bundle for the signers that will
 // be recognized for incoming client certificates in addition to the operator managed signers.
-func observeUserClientCABundle(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+func observeUserClientCABundle(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, syncActionRules, []error) {
 	configMapName := apiServer.Spec.ClientCA.Name
 	if len(configMapName) == 0 {
 		return nil, nil, nil // previously observed resource (if any) should be deleted
@@ -80,12 +91,12 @@ func observeUserClientCABundle(apiServer *configv1.APIServer, recorder events.Re
 	// config controller) into a common client CA bundle managed by the operator. As such, since the user managed client
 	// CA bundle is never explicitly referenced in the kube-apiserver config, the returned observed config will always
 	// be empty.
-	return nil, map[string]*string{"user-client-ca": &configMapName}, nil
+	return nil, syncActionRules{"user-client-ca": configMapName}, nil
 }
 
 // observeDefaultUserServingCertificate observes user managed Secret containing the default cert info for serving
 // secure traffic.
-func observeDefaultUserServingCertificate(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+func observeDefaultUserServingCertificate(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, syncActionRules, []error) {
 	var errs []error
 	servingCertSecretName := apiServer.Spec.ServingCerts.DefaultServingCertificate.Name
 	if len(servingCertSecretName) == 0 {
@@ -96,164 +107,152 @@ func observeDefaultUserServingCertificate(apiServer *configv1.APIServer, recorde
 	observedConfig := map[string]interface{}{}
 	certFile := fmt.Sprint(userServingCertPublicCertFile)
 	if err := unstructured.SetNestedField(observedConfig, certFile, "servingInfo", "certFile"); err != nil {
-		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(userServingCertResourceName), append(errs, err)
+		return previouslyObservedConfig, nil, append(errs, err)
 	}
 	keyFile := fmt.Sprint(userServingCertPrivateKeyFile)
 	if err := unstructured.SetNestedField(observedConfig, keyFile, "servingInfo", "keyFile"); err != nil {
-		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(userServingCertResourceName), append(errs, err)
+		return previouslyObservedConfig, nil, append(errs, err)
 	}
-	return observedConfig, map[string]*string{"user-serving-cert": &servingCertSecretName}, errs
+	return observedConfig, syncActionRules{"user-serving-cert": servingCertSecretName}, errs
 }
 
 // observeNamedCertificates observes user managed Secrets containing TLS cert info for serving secure traffic to
 // specific hostnames.
-func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, map[string]*string, []error) {
+func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Recorder, previouslyObservedConfig map[string]interface{}) (map[string]interface{}, syncActionRules, []error) {
 	var errs []error
-
 	observedConfig := map[string]interface{}{}
 
 	namedCertificates := apiServer.Spec.ServingCerts.NamedCertificates
 	if len(namedCertificates) > maxUserNamedCerts {
-		err := fmt.Errorf("apiservers.config.openshift.io/cluster: spec.servingCerts.namedCertificates cannot have more than %v entries", maxUserNamedCerts)
+		// TODO: This should be validation error, not operator error/event.
+		err := fmt.Errorf("spec.servingCerts.namedCertificates cannot have more than %d entries", maxUserNamedCerts)
 		recorder.Warningf("ObserveNamedCertificatesFailed", err.Error())
-		return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+		return previouslyObservedConfig, nil, append(errs, err)
 	}
 
 	// add the named cert info to the observed config. return the previously observed config on any error.
 	namedCertificatesPath := []string{"servingInfo", "namedCertificates"}
-	resourceSyncRules := map[string]*string{}
-	if len(namedCertificates) > 0 {
-		var observedNamedCertificates []interface{}
-		for index, namedCertificate := range namedCertificates {
-			observedNamedCertificate := map[string]interface{}{}
-			if len(namedCertificate.Names) > 0 {
-				if err := unstructured.SetNestedStringSlice(observedNamedCertificate, namedCertificate.Names, "names"); err != nil {
-					return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
-				}
+	resourceSyncRules := syncActionRules{}
+	var observedNamedCertificates []interface{}
+	for index, namedCertificate := range namedCertificates {
+		observedNamedCertificate := map[string]interface{}{}
+		if len(namedCertificate.Names) > 0 {
+			if err := unstructured.SetNestedStringSlice(observedNamedCertificate, namedCertificate.Names, "names"); err != nil {
+				return previouslyObservedConfig, nil, append(errs, err)
 			}
-			sourceSecretName := namedCertificate.ServingCertificate.Name
-			if len(sourceSecretName) == 0 {
-				err := fmt.Errorf("apiservers.config.openshift.io/cluster: spec.servingCerts.namedCertificates[%v].servingCertificate.name not found", index)
-				recorder.Warningf("ObserveNamedCertificatesFailed", err.Error())
-				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
-			}
-			// pick one of the available target resource names
-			targetSecretName := fmt.Sprintf(namedUserServingCertResourceNameFormat, index)
-
-			// add a sync rule to copy the user specified secret to the operator namespace
-			resourceSyncRules[targetSecretName] = &sourceSecretName
-
-			// add the named certificate to the observed config
-			certFile := fmt.Sprintf(namedUserServingCertPublicCertFileFormat, targetSecretName)
-			if err := unstructured.SetNestedField(observedNamedCertificate, certFile, "certFile"); err != nil {
-				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
-			}
-			keyFile := fmt.Sprintf(namedUserServingCertPrivateKeyFileFormat, targetSecretName)
-			if err := unstructured.SetNestedField(observedNamedCertificate, keyFile, "keyFile"); err != nil {
-				return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
-			}
-			observedNamedCertificates = append(observedNamedCertificates, observedNamedCertificate)
 		}
+		sourceSecretName := namedCertificate.ServingCertificate.Name
+		if len(sourceSecretName) == 0 {
+			err := fmt.Errorf("spec.servingCerts.namedCertificates[%d].servingCertificate.name cannot be empty", index)
+			recorder.Warningf("ObserveNamedCertificatesFailed", err.Error())
+			return previouslyObservedConfig, nil, append(errs, err)
+		}
+		// pick one of the available target resource names
+		targetSecretName := fmt.Sprintf(namedUserServingCertResourceNameFormat, index)
+
+		// add a sync rule to copy the user specified secret to the operator namespace
+		resourceSyncRules[targetSecretName] = sourceSecretName
+
+		// add the named certificate to the observed config
+		certFile := fmt.Sprintf("/etc/kubernetes/static-pod-resources/secrets/%s/tls.crt", targetSecretName)
+		if err := unstructured.SetNestedField(observedNamedCertificate, certFile, "certFile"); err != nil {
+			return previouslyObservedConfig, nil, append(errs, err)
+		}
+
+		keyFile := fmt.Sprintf("/etc/kubernetes/static-pod-resources/secrets/%s/tls.key", targetSecretName)
+		if err := unstructured.SetNestedField(observedNamedCertificate, keyFile, "keyFile"); err != nil {
+			return previouslyObservedConfig, nil, append(errs, err)
+		}
+
+		observedNamedCertificates = append(observedNamedCertificates, observedNamedCertificate)
+	}
+	if len(namedCertificates) > 0 {
 		if err := unstructured.SetNestedField(observedConfig, observedNamedCertificates, namedCertificatesPath...); err != nil {
-			return previouslyObservedConfig, makeIgnoreAllResourcesSyncRules(namedUserServingCertResourceNames...), append(errs, err)
+			return previouslyObservedConfig, nil, append(errs, err)
 		}
 	}
 
 	return observedConfig, resourceSyncRules, errs
 }
 
-// newAPIServerObserver returns an ObserveConfigFunc that observes configuration and resources.
-func newAPIServerObserver(observeAPIServerConfig observeAPIServerConfigFunc, configPaths [][]string, resourceNames []string, resourceType interface{}) configobserver.ObserveConfigFunc {
-	return func(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
-		listers := genericListers.(configobservation.Listers)
-		var errs []error
-
-		// pick the correct resource sync function
-		resourceSync := listers.ResourceSyncer().SyncSecret
-		if _, ok := resourceType.(corev1.ConfigMap); ok {
-			resourceSync = listers.ResourceSyncer().SyncConfigMap
-		}
-
-		// extract the previously observed config. capture, but don't react to, errors.
-		previouslyObservedConfig, errs := extractPreviouslyObservedConfig(existingConfig, configPaths...)
-
-		// get the apiserver config
-		apiServer, err := listers.APIServerLister.Get("cluster")
-
-		// if apiserver config is not found, it's not an error (it's optional), clear the observed config and observed resources
-		if errors.IsNotFound(err) {
-			glog.Warningf("apiservers.config.openshift.io/cluster: not found")
-			deleteObservedResources(resourceSync, resourceNames)
-			return nil, errs
-		}
-
-		// if something went wrong, keep the previously observed config and resources
-		if err != nil {
-			return previouslyObservedConfig, append(errs, err)
-		}
-
-		observedConfig, observedResources, errs := observeAPIServerConfig(apiServer, recorder, previouslyObservedConfig)
-
-		// default to deleting previous resources, and then merge in observed resources rules
-		resourceSyncRules := makeDeleteAllResourcesSyncRules(resourceNames...)
-		if err := mergo.Merge(&resourceSyncRules, &observedResources, mergo.WithOverride); err != nil {
-			glog.Warningf("merging resource sync rules failed: %v", err)
-		}
-
-		// sync observed resources
-		errs = append(errs, syncObservedResources(resourceSync, resourceSyncRules)...)
-
-		return observedConfig, errs
-	}
+type apiServerObserver struct {
+	observerFunc  observeAPIServerConfigFunc
+	configPaths   [][]string
+	resourceNames []string
+	resourceType  interface{}
 }
 
-// makeDeleteAllResourcesSyncRules generates resource sync rules to delete the resources, specified by names, from the
+func (o *apiServerObserver) observe(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	var errs []error
+
+	// pick the correct resource sync function
+	resourceSync := listers.ResourceSyncer().SyncSecret
+	if _, ok := o.resourceType.(corev1.ConfigMap); ok {
+		resourceSync = listers.ResourceSyncer().SyncConfigMap
+	}
+
+	previouslyObservedConfig, errs := extractPreviouslyObservedConfig(existingConfig, o.configPaths...)
+
+	apiServer, err := listers.APIServerLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		// no error, just clear the observed config and observed resources
+		glog.Warningf("apiservers.%s/cluster: %v", configv1.GroupName, err)
+		return nil, append(errs, syncObservedResources(resourceSync, deleteSyncRules(o.resourceNames...))...)
+	}
+
+	// if something went wrong, keep the previously observed config and resources
+	if err != nil {
+		glog.Warningf("error getting apiservers.%s/cluster: %v", configv1.GroupName, err)
+		return previouslyObservedConfig, append(errs, err)
+	}
+
+	observedConfig, observedResources, errs := o.observerFunc(apiServer, recorder, previouslyObservedConfig)
+
+	// if we get error during observation, skip the merging and return previous config and errors.
+	if len(errs) > 0 {
+		glog.Warningf("errors during apiservers.%s/cluster processing: %+v", configv1.GroupName, errs)
+		return previouslyObservedConfig, append(errs, errs...)
+	}
+
+	// default to deleting previous resources, and then merge in observed resources rules
+	resourceSyncRules := deleteSyncRules(o.resourceNames...)
+	if err := mergo.Merge(&resourceSyncRules, &observedResources, mergo.WithOverride); err != nil {
+		glog.Warningf("merging resource sync rules failed: %v", err)
+	}
+
+	errs = append(errs, syncObservedResources(resourceSync, resourceSyncRules)...)
+
+	return observedConfig, errs
+}
+
+// deleteSyncRules generates resource sync rules to delete the resources, specified by names, from the
 // operator namespace.
-func makeDeleteAllResourcesSyncRules(names ...string) map[string]*string {
-	resourceSyncRules := map[string]*string{}
-	deleteIndicator := ""
+func deleteSyncRules(names ...string) syncActionRules {
+	resourceSyncRules := syncActionRules{}
 	for _, name := range names {
-		resourceSyncRules[name] = &deleteIndicator
+		// empty string here means there is "from" anymore and we mark the "name" for deletion.
+		resourceSyncRules[name] = ""
 	}
 	return resourceSyncRules
 }
 
-// makeIgnoreAllResourcesSyncRules generates resource sync rules to ignore the resources, specified by names, from the
-// operator namespace. This is useful if you need to, for example, leave all the previously observed resources as they
-// are.
-func makeIgnoreAllResourcesSyncRules(names ...string) map[string]*string {
-	resourceSyncRules := map[string]*string{}
-	for _, name := range names {
-		resourceSyncRules[name] = nil
-	}
-	return resourceSyncRules
-}
-
-// syncObservedResources synchronizes resource from the global user specified config namespace into the operator
-// namespace. The the entry keys in the syncRules should be the names of the resources to be synced into the operator
-// namespace. The corresponding values should be either the name of the resource to copy from the global user specified
-// config namespace to the operator's namespace on sync, an empty string to indicate that the resource should be deleted
-// on sync, or a nil to indicate that the resource should be left as-is on sync.
-func syncObservedResources(syncResource resourceSyncFunc, syncRules map[string]*string) []error {
+// syncObservedResources copies or deletes resources, sources in GlobalUserSpecifiedConfigNamespace and destinations in OperatorNamespace namespace.
+// Errors are collected, i.e. it's not failing on first error.
+func syncObservedResources(syncResource resourceSyncFunc, syncRules syncActionRules) []error {
 	var errs []error
 	for to, from := range syncRules {
-		if from != nil {
-			var source resourcesynccontroller.ResourceLocation
-			if len(*from) > 0 {
-				source = resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: *from}
-			}
-			destination := resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: to}
-			if err := syncResource(destination, source); err != nil {
-				errs = append(errs, err)
-			}
+		var source resourcesynccontroller.ResourceLocation
+		if len(from) > 0 {
+			source = resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: from}
+		}
+		// if 'from' is empty, then it means we want to delete
+		destination := resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: to}
+		if err := syncResource(destination, source); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errs
-}
-
-// deleteObservedResources delete the resources, specified by names, from the operator namespace.
-func deleteObservedResources(syncFunc resourceSyncFunc, names []string) []error {
-	return syncObservedResources(syncFunc, makeDeleteAllResourcesSyncRules(names...))
 }
 
 // extractPreviouslyObservedConfig extracts the previously observed config from the existing config.
@@ -261,7 +260,10 @@ func extractPreviouslyObservedConfig(existing map[string]interface{}, paths ...[
 	var errs []error
 	previous := map[string]interface{}{}
 	for _, fields := range paths {
-		value, _, err := unstructured.NestedFieldCopy(existing, fields...)
+		value, found, err := unstructured.NestedFieldCopy(existing, fields...)
+		if !found {
+			continue
+		}
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -70,7 +70,7 @@ func TestObserveUserClientCABundle(t *testing.T) {
 				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
 				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
 			}
-			result, errs := ObserveUserClientCABundle()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			result, errs := ObserveUserClientCABundle(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
 			if len(errs) > 0 {
 				t.Errorf("Expected 0 errors, got %v.", len(errs))
 			}
@@ -141,7 +141,7 @@ func TestObserveDefaultServingCertificate(t *testing.T) {
 				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
 				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
 			}
-			result, errs := ObserveDefaultUserServingCertificate()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			result, errs := ObserveDefaultUserServingCertificate(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
 			if len(errs) > 0 {
 				t.Errorf("Expected 0 errors, got %v.", len(errs))
 			}
@@ -423,7 +423,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
 				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
 			}
-			result, errs := ObserveNamedCertificates()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			result, errs := ObserveNamedCertificates(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
 			if tc.expectErrs && len(errs) == 0 {
 				t.Error("Expected errors.", errs)
 			}

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -1,0 +1,510 @@
+package apiserver
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+)
+
+func TestObserveUserClientCABundle(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		config         *configv1.APIServer
+		existing       map[string]interface{}
+		expected       map[string]interface{}
+		expectedSynced map[string]string
+	}{
+		{
+			name:     "NoAPIServerConfig",
+			config:   nil,
+			existing: map[string]interface{}{},
+			expected: map[string]interface{}{},
+			expectedSynced: map[string]string{
+				"configmap/user-client-ca.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name:     "NoUserClientCARef",
+			config:   newAPIServerConfig(),
+			existing: map[string]interface{}{},
+			expected: map[string]interface{}{},
+			expectedSynced: map[string]string{
+				"configmap/user-client-ca.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name:     "HappyPath",
+			config:   newAPIServerConfig(withClientCA("happy")),
+			existing: map[string]interface{}{},
+			expected: map[string]interface{}{},
+			expectedSynced: map[string]string{
+				"configmap/user-client-ca.openshift-kube-apiserver-operator": "configmap/happy.openshift-config",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.config != nil {
+				if err := indexer.Add(tc.config); err != nil {
+					t.Fatal(err)
+				}
+			}
+			synced := map[string]string{}
+			listers := configobservation.Listers{
+				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
+				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
+			}
+			result, errs := ObserveUserClientCABundle()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			if len(errs) > 0 {
+				t.Errorf("Expected 0 errors, got %v.", len(errs))
+			}
+			if !equality.Semantic.DeepEqual(tc.expected, result) {
+				t.Errorf("did not expect observed config to be updated : %s", result)
+			}
+			if !equality.Semantic.DeepEqual(tc.expectedSynced, synced) {
+				t.Errorf("expected resources not synced: %s", diff.ObjectReflectDiff(tc.expectedSynced, synced))
+			}
+		})
+	}
+}
+
+func TestObserveDefaultServingCertificate(t *testing.T) {
+
+	existingConfig := map[string]interface{}{
+		"servingInfo": map[string]interface{}{
+			"certFile": "/etc/kubernetes/static-pod-resources/secrets/existing/tls.key",
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		config         *configv1.APIServer
+		existing       map[string]interface{}
+		expected       map[string]interface{}
+		expectedSynced map[string]string
+	}{
+		{
+			name:           "NoAPIServerConfig",
+			config:         nil,
+			existing:       existingConfig,
+			expected:       map[string]interface{}{},
+			expectedSynced: map[string]string{"configmap/user-serving-cert.openshift-kube-apiserver-operator": "DELETE"},
+		},
+		{
+			name:           "NoUserServingCertRef",
+			config:         newAPIServerConfig(),
+			existing:       existingConfig,
+			expected:       map[string]interface{}{},
+			expectedSynced: map[string]string{"configmap/user-serving-cert.openshift-kube-apiserver-operator": "DELETE"},
+		},
+		{
+			name:     "HappyPath",
+			config:   newAPIServerConfig(withDefaultSecret("happy")),
+			existing: existingConfig,
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.crt",
+					"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert/tls.key",
+				},
+			},
+			expectedSynced: map[string]string{
+				"configmap/user-serving-cert.openshift-kube-apiserver-operator": "configmap/happy.openshift-config",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.config != nil {
+				if err := indexer.Add(tc.config); err != nil {
+					t.Fatal(err)
+				}
+			}
+			synced := map[string]string{}
+			listers := configobservation.Listers{
+				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
+				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
+			}
+			result, errs := ObserveDefaultUserServingCertificate()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			if len(errs) > 0 {
+				t.Errorf("Expected 0 errors, got %v.", len(errs))
+			}
+			if !equality.Semantic.DeepEqual(tc.expected, result) {
+				t.Errorf("result does not match expected config: %s", diff.ObjectDiff(tc.expected, result))
+			}
+			if !equality.Semantic.DeepEqual(tc.expectedSynced, synced) {
+				t.Errorf("expected resources not synced: %s", diff.ObjectReflectDiff(tc.expectedSynced, synced))
+			}
+		})
+	}
+}
+
+func TestObserveNamedCertificates(t *testing.T) {
+
+	existingConfig := map[string]interface{}{
+		"servingInfo": map[string]interface{}{
+			"namedCertificates": []interface{}{
+				map[string]interface{}{
+					"certFile": "/etc/kubernetes/static-pod-resources/secrets/existing/tls.crt",
+					"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/existing/tls.key",
+					"names":    []interface{}{"existing"},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		config         *configv1.APIServer
+		existing       map[string]interface{}
+		expected       map[string]interface{}
+		expectErrs     bool
+		expectedSynced map[string]string
+	}{
+		{
+			name:     "NoAPIServerConfig",
+			config:   nil,
+			existing: existingConfig,
+			expected: map[string]interface{}{},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name:     "NoNamedCertificates",
+			config:   newAPIServerConfig(),
+			existing: existingConfig,
+			expected: map[string]interface{}{},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name: "NamedCertificateWithName",
+			config: newAPIServerConfig(
+				withCertificate(
+					withName("*.foo.org"),
+					withSecret("foo"),
+				),
+			),
+			existing: existingConfig,
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
+							"names":    []interface{}{"*.foo.org"},
+						},
+					},
+				},
+			},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "secret/foo.openshift-config",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name: "NamedCertificateWithoutName",
+			config: newAPIServerConfig(
+				withCertificate(
+					withSecret("foo"),
+				),
+			),
+			existing: existingConfig,
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
+						},
+					},
+				},
+			},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "secret/foo.openshift-config",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name: "NamedCertificateWithNames",
+			config: newAPIServerConfig(
+				withCertificate(
+					withName("*.foo.org"),
+					withName("foo.org"),
+					withName("*.bar.org"),
+					withSecret("foo"),
+				),
+			),
+			existing: existingConfig,
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
+							"names":    []interface{}{"*.foo.org", "foo.org", "*.bar.org"},
+						},
+					},
+				},
+			},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "secret/foo.openshift-config",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name: "NamedCertificates",
+			config: newAPIServerConfig(
+				withCertificate(
+					withName("one"),
+					withSecret("one"),
+				),
+				withCertificate(
+					withSecret("two"),
+				),
+				withCertificate(
+					withName("three"),
+					withName("tři"),
+					withSecret("three"),
+				),
+			),
+			existing: existingConfig,
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
+							"names":    []interface{}{"one"},
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-001/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-001/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-002/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-002/tls.key",
+							"names":    []interface{}{"three", "tři"},
+						},
+					},
+				},
+			},
+			expectedSynced: map[string]string{
+				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "secret/one.openshift-config",
+				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "secret/two.openshift-config",
+				"secret/user-serving-cert-002.openshift-kube-apiserver-operator": "secret/three.openshift-config",
+				"secret/user-serving-cert-003.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-004.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-005.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-006.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-007.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-008.openshift-kube-apiserver-operator": "DELETE",
+				"secret/user-serving-cert-009.openshift-kube-apiserver-operator": "DELETE",
+			},
+		},
+		{
+			name: "NamedCertificateNoSecretRef",
+			config: newAPIServerConfig(
+				withCertificate(
+					withName("*.foo.org"),
+				),
+			),
+			existing:   existingConfig,
+			expected:   existingConfig,
+			expectErrs: true,
+		},
+		{
+			name: "TooManyNamedCertificates",
+			config: newAPIServerConfig(
+				withCertificate(withName("000"), withSecret("000")),
+				withCertificate(withName("001"), withSecret("001")),
+				withCertificate(withName("002"), withSecret("002")),
+				withCertificate(withName("003"), withSecret("003")),
+				withCertificate(withName("004"), withSecret("004")),
+				withCertificate(withName("005"), withSecret("005")),
+				withCertificate(withName("006"), withSecret("006")),
+				withCertificate(withName("007"), withSecret("007")),
+				withCertificate(withName("008"), withSecret("008")),
+				withCertificate(withName("009"), withSecret("009")),
+				withCertificate(withName("010"), withSecret("010")),
+			),
+			existing:   existingConfig,
+			expected:   existingConfig,
+			expectErrs: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tc.config != nil {
+				if err := indexer.Add(tc.config); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var objs []runtime.Object
+			if tc.config != nil {
+				for _, nc := range tc.config.Spec.ServingCerts.NamedCertificates {
+					objs = append(objs, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nc.ServingCertificate.Name,
+							Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+						},
+						Data: map[string][]byte{
+							"tls.crt": []byte("FOO"),
+							"tls.key": []byte("BAR"),
+						},
+					})
+				}
+			}
+
+			synced := map[string]string{}
+			listers := configobservation.Listers{
+				APIServerLister: configlistersv1.NewAPIServerLister(indexer),
+				ResourceSync:    &mockResourceSyncer{t: t, synced: synced},
+			}
+			result, errs := ObserveNamedCertificates()(listers, events.NewInMemoryRecorder(t.Name()), tc.existing)
+			if tc.expectErrs && len(errs) == 0 {
+				t.Error("Expected errors.", errs)
+			}
+			if !tc.expectErrs && len(errs) > 0 {
+				t.Errorf("Expected 0 errors, got %v.", len(errs))
+				for _, err := range errs {
+					t.Log(err.Error())
+				}
+			}
+			if !equality.Semantic.DeepEqual(tc.expected, result) {
+				t.Errorf("result does not match expected config: %s", diff.ObjectDiff(tc.expected, result))
+			}
+			if !equality.Semantic.DeepEqual(tc.expectedSynced, synced) {
+				t.Errorf("expected resources not synced: %s", diff.ObjectReflectDiff(tc.expectedSynced, synced))
+			}
+		})
+	}
+
+}
+
+type mockResourceSyncer struct {
+	t      *testing.T
+	synced map[string]string
+}
+
+func (rs *mockResourceSyncer) SyncConfigMap(destination, source resourcesynccontroller.ResourceLocation) error {
+	if (source == resourcesynccontroller.ResourceLocation{}) {
+		rs.synced[fmt.Sprintf("configmap/%v.%v", destination.Name, destination.Namespace)] = "DELETE"
+	} else {
+		rs.synced[fmt.Sprintf("configmap/%v.%v", destination.Name, destination.Namespace)] = fmt.Sprintf("configmap/%v.%v", source.Name, source.Namespace)
+	}
+	return nil
+}
+
+func (rs *mockResourceSyncer) SyncSecret(destination, source resourcesynccontroller.ResourceLocation) error {
+	if (source == resourcesynccontroller.ResourceLocation{}) {
+		rs.synced[fmt.Sprintf("secret/%v.%v", destination.Name, destination.Namespace)] = "DELETE"
+	} else {
+		rs.synced[fmt.Sprintf("secret/%v.%v", destination.Name, destination.Namespace)] = fmt.Sprintf("secret/%v.%v", source.Name, source.Namespace)
+	}
+	return nil
+}
+
+func newAPIServerConfig(builders ...func(*configv1.APIServer)) *configv1.APIServer {
+	config := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+	for _, builder := range builders {
+		builder(config)
+	}
+	return config
+}
+
+func withCertificate(builders ...func(*configv1.APIServerNamedServingCert)) func(*configv1.APIServer) {
+	return func(apiserver *configv1.APIServer) {
+		certificate := &configv1.APIServerNamedServingCert{}
+		for _, builder := range builders {
+			builder(certificate)
+		}
+		apiserver.Spec.ServingCerts.NamedCertificates = append(apiserver.Spec.ServingCerts.NamedCertificates, *certificate)
+	}
+}
+
+func withName(name string) func(*configv1.APIServerNamedServingCert) {
+	return func(cert *configv1.APIServerNamedServingCert) {
+		cert.Names = append(cert.Names, name)
+	}
+}
+
+func withSecret(name string) func(*configv1.APIServerNamedServingCert) {
+	return func(cert *configv1.APIServerNamedServingCert) {
+		cert.ServingCertificate.Name = name
+	}
+}
+
+func withDefaultSecret(name string) func(*configv1.APIServer) {
+	return func(apiserver *configv1.APIServer) {
+		apiserver.Spec.ServingCerts.DefaultServingCertificate.Name = name
+	}
+}
+
+func withClientCA(name string) func(*configv1.APIServer) {
+	return func(apiserver *configv1.APIServer) {
+		apiserver.Spec.ClientCA.Name = name
+	}
+}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -6,15 +6,17 @@ import (
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/etcd"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/images"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/network"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/apiserver"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/etcd"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/images"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/network"
 )
 
 type ConfigObserver struct {
@@ -38,6 +40,7 @@ func NewConfigObserver(
 				ImageConfigLister: configInformer.Config().V1().Images().Lister(),
 				EndpointsLister:   kubeInformersForKubeSystemNamespace.Core().V1().Endpoints().Lister(),
 				ConfigmapLister:   kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Lister(),
+				APIServerLister:   configInformer.Config().V1().APIServers().Lister(),
 				ResourceSync:      resourceSyncer,
 				PreRunCachesSynced: []cache.InformerSynced{
 					operatorConfigInformers.Operator().V1().KubeAPIServers().Informer().HasSynced,
@@ -45,6 +48,7 @@ func NewConfigObserver(
 					kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
 					configInformer.Config().V1().Authentications().Informer().HasSynced,
 					configInformer.Config().V1().Images().Informer().HasSynced,
+					configInformer.Config().V1().APIServers().Informer().HasSynced,
 				},
 			},
 			etcd.ObserveStorageURLs,
@@ -53,6 +57,9 @@ func NewConfigObserver(
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,
 			auth.ObserveAuthMetadata,
+			apiserver.ObserveDefaultUserServingCertificate(),
+			apiserver.ObserveNamedCertificates(),
+			apiserver.ObserveUserClientCABundle(),
 		),
 	}
 
@@ -61,6 +68,7 @@ func NewConfigObserver(
 	kubeInformersForKubeSystemNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Images().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Authentications().Informer().AddEventHandler(c.EventHandler())
+	configInformer.Config().V1().APIServers().Informer().AddEventHandler(c.EventHandler())
 
 	return c
 }

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -57,9 +57,9 @@ func NewConfigObserver(
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,
 			auth.ObserveAuthMetadata,
-			apiserver.ObserveDefaultUserServingCertificate(),
-			apiserver.ObserveNamedCertificates(),
-			apiserver.ObserveUserClientCABundle(),
+			apiserver.ObserveDefaultUserServingCertificate,
+			apiserver.ObserveNamedCertificates,
+			apiserver.ObserveUserClientCABundle,
 		),
 	}
 

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -13,6 +13,7 @@ type Listers struct {
 	ImageConfigLister configlistersv1.ImageLister
 	EndpointsLister   corelistersv1.EndpointsLister
 	ConfigmapLister   corelistersv1.ConfigMapLister
+	APIServerLister   configlistersv1.APIServerLister
 
 	ResourceSync       resourcesynccontroller.ResourceSyncer
 	PreRunCachesSynced []cache.InformerSynced

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -15,17 +15,18 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/staticpod"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
+	"github.com/openshift/library-go/pkg/operator/status"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/targetconfigcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
-	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/staticpod"
-	"github.com/openshift/library-go/pkg/operator/staticpod/controller/revision"
-	"github.com/openshift/library-go/pkg/operator/status"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
 func RunOperator(ctx *controllercmd.ControllerContext) error {
@@ -161,6 +162,7 @@ var deploymentConfigMaps = []revision.RevisionResource{
 	{Name: "kubelet-serving-ca"},
 	{Name: "oauth-metadata", Optional: true},
 	{Name: "sa-token-signing-certs"},
+	{Name: "user-client-ca", Optional: true},
 }
 
 // deploymentSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
@@ -169,4 +171,15 @@ var deploymentSecrets = []revision.RevisionResource{
 	{Name: "etcd-client"},
 	{Name: "kubelet-client"},
 	{Name: "serving-cert"},
+	{Name: "user-serving-cert", Optional: true},
+	{Name: "user-serving-cert-000", Optional: true},
+	{Name: "user-serving-cert-001", Optional: true},
+	{Name: "user-serving-cert-002", Optional: true},
+	{Name: "user-serving-cert-003", Optional: true},
+	{Name: "user-serving-cert-004", Optional: true},
+	{Name: "user-serving-cert-005", Optional: true},
+	{Name: "user-serving-cert-006", Optional: true},
+	{Name: "user-serving-cert-007", Optional: true},
+	{Name: "user-serving-cert-008", Optional: true},
+	{Name: "user-serving-cert-009", Optional: true},
 }

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
-
 	"github.com/golang/glog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,14 +21,16 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 )
 
 const workQueueKey = "key"
@@ -229,6 +229,8 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
+		// this bundle is what a user uses to mint new client certs it directly manages
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "user-client-ca"},
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Building on https://github.com/openshift/cluster-kube-apiserver-operator/pull/230 while @sanchezl is out. 

Original PR description:

* User client-ca bundle cert synced to `user-client-ca` in the operator's namespace. No update to the observed config.
* User serving cert synced to `user-serving-cert` in the operator's namespace. No update to the observed config.
* Up to 10 user SNI/named certs synced to `user-serving-cert-nnn` in the operator's namespace. Updated observed config to pick them up.
* target controller will copy the user certs out of the operator's namespace if found (they are optional).
* target controller added user client ca bundle to combined final bundle.