### PR TITLE
Fix log spamming by auth and apiserver observer

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -197,7 +197,6 @@ func (o *apiServerObserver) observe(genericListers configobserver.Listers, recor
 	apiServer, err := listers.APIServerLister.Get("cluster")
 	if errors.IsNotFound(err) {
 		// no error, just clear the observed config and observed resources
-		glog.Warningf("apiservers.%s/cluster: %v", configv1.GroupName, err)
 		return nil, append(errs, syncObservedResources(resourceSync, deleteSyncRules(o.resourceNames...))...)
 	}
 

--- a/pkg/operator/configobservation/auth/auth_metadata.go
+++ b/pkg/operator/configobservation/auth/auth_metadata.go
@@ -62,7 +62,7 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 	case len(authConfig.Status.IntegratedOAuthMetadata.Name) > 0 && authConfig.Spec.Type == v1.AuthenticationTypeIntegratedOAuth:
 		statusConfigMap = authConfig.Status.IntegratedOAuthMetadata.Name
 	default:
-		glog.V(2).Infof("no integrated oauth metadata configmap observed from status")
+		glog.V(5).Infof("no integrated oauth metadata configmap observed from status")
 	}
 
 	// Spec configMap takes precedence over Status.
@@ -74,7 +74,7 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 		sourceConfigMap = statusConfigMap
 		sourceNamespace = managedNamespace
 	default:
-		glog.Warningf("no authentication config metadata specified")
+		glog.V(5).Infof("no authentication config metadata specified")
 	}
 
 	// Sync the user or status-specified configMap to the well-known resting place that corresponds to the oauthMetadataFile path.


### PR DESCRIPTION
First commit removes log spam from the auth observer and second from the apiserver config observer (when the "cluster" is not found, we produce errors every N seconds, making logs unreadable).