### PR TITLE
operator: remove openshift prefix from pod name

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
-  name: openshift-kube-apiserver
+  name: kube-apiserver
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"
@@ -10,7 +10,7 @@ metadata:
   deletionGracePeriodSeconds: 65 # a bit more than the kube-apiserver shutdown timeout of 60 sec
 spec:
   containers:
-  - name: openshift-kube-apiserver
+  - name: kube-apiserver-REVISION
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -101,7 +101,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	staticPodControllers := staticpod.NewControllers(
 		operatorclient.TargetNamespace,
-		"openshift-kube-apiserver",
+		"kube-apiserver",
 		"kube-apiserver-pod",
 		[]string{"cluster-kube-apiserver-operator", "installer"},
 		[]string{"cluster-kube-apiserver-operator", "prune"},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -298,7 +298,7 @@ var _v3110KubeApiserverPodYaml = []byte(`apiVersion: v1
 kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
-  name: openshift-kube-apiserver
+  name: kube-apiserver
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"
@@ -306,7 +306,7 @@ metadata:
   deletionGracePeriodSeconds: 65 # a bit more than the kube-apiserver shutdown timeout of 60 sec
 spec:
   containers:
-  - name: openshift-kube-apiserver
+  - name: kube-apiserver-REVISION
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
We need https://github.com/openshift/installer/pull/1253 to support this transition.

In addition to changing the pod names, this also add revision suffix into pod container name, so it is clear in artifacts which revision the collected logs belonged to.

/hold