### PR TITLE
stop serving oauth config

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -11,8 +11,6 @@ kubeletClientInfo:
   ca: /etc/kubernetes/secrets/kube-ca.crt # origin 3.11: ca.crt
   certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.kubelet-client.crt
   keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.kubelet-client.key
-oauthConfig:
-  masterCA: /etc/kubernetes/secrets/root-ca.crt # origin 3.11: ca.crt
 serviceAccountPublicKeyFiles:
 - /etc/kubernetes/secrets/service-account.pub # origin 3.11: serviceaccounts.public.key
 servingInfo:

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -11,8 +11,6 @@ kubeletClientInfo:
   ca: /var/run/configmaps/kubelet-serving-ca/ca-bundle.crt
   certFile: /var/run/secrets/kubelet-client/tls.crt
   keyFile: /var/run/secrets/kubelet-client/tls.key
-oauthConfig:
-  masterCA: /var/run/configmaps/client-ca/ca-bundle.crt
 serviceAccountPublicKeyFiles:
 - /var/run/configmaps/sa-token-signing-certs/ca-bundle.crt
 servingInfo:

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -88,23 +88,6 @@ kubeletClientInfo:
   certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
   port: 10250
-oauthConfig:
-  alwaysShowProviderSelection: false
-  assetPublicURL: # To be filled
-  grantConfig:
-    method: auto
-    serviceAccountMethod: prompt
-  masterCA: /etc/kubernetes/secrets/root-ca.crt
-  masterPublicURL: # To be filled
-  masterURL: # To be filled
-  sessionConfig:
-    sessionMaxAgeSeconds: 300
-    sessionName: ssn
-    sessionSecretsFile: ""
-  templates: null
-  tokenConfig:
-    accessTokenMaxAgeSeconds: 86400
-    authorizeTokenMaxAgeSeconds: 300
 projectConfig:
   defaultNodeSelector: ""
 servicesNodePortRange: 30000-32767

--- a/pkg/operator/targetconfigcontroller/config_restriction.go
+++ b/pkg/operator/targetconfigcontroller/config_restriction.go
@@ -1,0 +1,5 @@
+package targetconfigcontroller
+
+func RemoveConfig(dst, src interface{}, currentPath string) (interface{}, error) {
+	return dst, nil
+}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -209,7 +209,11 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 func manageKubeAPIServerConfig(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, operatorConfig *operatorv1.KubeAPIServer) (*corev1.ConfigMap, bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/cm.yaml"))
 	defaultConfig := v311_00_assets.MustAsset("v3.11.0/kube-apiserver/defaultconfig.yaml")
-	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, defaultConfig, operatorConfig.Spec.ObservedConfig.Raw, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)
+	specialMergeRules := map[string]resourcemerge.MergeFunc{
+		".oauthConfig": RemoveConfig,
+	}
+
+	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", specialMergeRules, defaultConfig, operatorConfig.Spec.ObservedConfig.Raw, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -165,23 +165,6 @@ kubeletClientInfo:
   certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
   port: 10250
-oauthConfig:
-  alwaysShowProviderSelection: false
-  assetPublicURL: # To be filled
-  grantConfig:
-    method: auto
-    serviceAccountMethod: prompt
-  masterCA: /etc/kubernetes/secrets/root-ca.crt
-  masterPublicURL: # To be filled
-  masterURL: # To be filled
-  sessionConfig:
-    sessionMaxAgeSeconds: 300
-    sessionName: ssn
-    sessionSecretsFile: ""
-  templates: null
-  tokenConfig:
-    accessTokenMaxAgeSeconds: 86400
-    authorizeTokenMaxAgeSeconds: 300
 projectConfig:
   defaultNodeSelector: ""
 servicesNodePortRange: 30000-32767


### PR DESCRIPTION
requires https://github.com/openshift/origin/pull/22054

This removes the oauthConfig and makes it impossible to specify one via our operator.  

@openshift/sig-master 