### PR TITLE
explain where kube-apiserver resources come from

### DIFF
--- a/pkg/operator/reactionchain/interfaces.go
+++ b/pkg/operator/reactionchain/interfaces.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Resources interface {
+	Add(resource Resource)
 	Dump() []string
 	AllResources() []Resource
 	Resource(coordinates ResourceCoordinates) Resource
@@ -19,6 +20,22 @@ type ResourceCoordinates struct {
 	Resource  string
 	Namespace string
 	Name      string
+}
+
+func NewConfigMap(namespace, name string) Resource {
+	return NewResource(NewCoordinates("", "configmaps", namespace, name))
+}
+
+func NewSecret(namespace, name string) Resource {
+	return NewResource(NewCoordinates("", "secrets", namespace, name))
+}
+
+func NewOperator(name string) Resource {
+	return NewResource(NewCoordinates("config.openshift.io", "clusteroperators", "", name))
+}
+
+func NewConfig(resource string) Resource {
+	return NewResource(NewCoordinates("config.openshift.io", resource, "", "cluster"))
 }
 
 func NewCoordinates(group, resource, namespace, name string) ResourceCoordinates {
@@ -39,6 +56,7 @@ func (c ResourceCoordinates) String() string {
 }
 
 type Resource interface {
+	Add(resources Resources) Resource
 	From(Resource) Resource
 	Note(note string) Resource
 
@@ -70,6 +88,11 @@ func NewSource(coordinates ResourceCoordinates, sources []Resource) *SimpleSourc
 
 func (r *SimpleSource) Coordinates() ResourceCoordinates {
 	return r.coordinates
+}
+
+func (s *SimpleSource) Add(resources Resources) Resource {
+	resources.Add(s)
+	return s
 }
 
 func (s *SimpleSource) From(source Resource) Resource {


### PR DESCRIPTION
This adds a command to the `cluster-kube-apiserver-operator` that explains where resources come from by building a digraph where nodes are resources and edges represent logical flow.  The roots are

1. Payload
2. Installer
3. User

Here is the state we're in today:

![resources 1](https://user-images.githubusercontent.com/8225098/52966512-77772d00-3375-11e9-8bb4-759b0588ede7.png)
