### PR TITLE
Add kube-scheduler group

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	"github.com/pborman/uuid"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
@@ -131,7 +132,7 @@ func NewCertRotationController(
 			Validity:          1 * 4 * time.Hour,
 			RefreshPercentage: 0.5,
 			ClientRotation: &certrotation.ClientRotation{
-				UserInfo: &user.DefaultInfo{Name: "system:kube-scheduler"},
+				UserInfo: &user.DefaultInfo{Name: "system:kube-scheduler", Groups: []string{user.KubeScheduler}, UID: uuid.NewRandom().String()},
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),


### PR DESCRIPTION
While working on https://github.com/openshift/cluster-kube-scheduler-operator/pull/62, I realized that, we are not populating groups and UID fields for `DefaultInfo` struct. I think we need to have the group when we are generating certs here:

https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go#L754-#L756

/cc @deads2k @sttts 