### PR TITLE
add trust for new admin kubeconfig client-ca

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-admin-kubeconfig-client-ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-kubeconfig-client-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "admin-kubeconfig-signer.crt" | indent 4 }}
+

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -254,11 +254,13 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		nil, // TODO remove this
 		// this is from the installer and contains the value they think we should have
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-client-ca"},
+		// this is from the installer and admin kubeconfig client ca
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
 		// this is from kube-controller-manager and indicates the ca-bundle.crt to verify their signatures (kubelet client certs)
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
-		// this bundle is what a user uses to mint new client certs it directly manages
+		// this bundle is what a user uses to mint new client certs it directly manages.  We copy it into operator namespace for a consistent name.
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "user-client-ca"},
 	)
 	if err != nil {


### PR DESCRIPTION
pulls the admin client-ca.crt from installer and sets it up to be included in the client-ca for our server.