### PR TITLE
adopt signers from installer for rotating serving certs

### DIFF
--- a/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loadbalancer-serving-signer
+  namespace: openshift-kube-apiserver-operator
+  annotations:
+    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | notBefore }}
+    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | notAfter }}
+    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | issuer }}
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | base64 }}
+  tls.key: {{ .Assets | load "kube-apiserver-lb-host-ip-signer.key" | base64 }}

--- a/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: localhost-serving-signer
+  namespace: openshift-kube-apiserver-operator
+  annotations:
+    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | notBefore }}
+    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | notAfter }}
+    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | issuer }}
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "kube-apiserver-localhost-signer.crt" | base64 }}
+  tls.key: {{ .Assets | load "kube-apiserver-localhost-signer.key" | base64 }}

--- a/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: service-network-serving-signer
+  namespace: openshift-kube-apiserver-operator
+  annotations:
+    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | notBefore }}
+    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | notAfter }}
+    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | issuer }}
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "kube-apiserver-service-network-signer.crt" | base64 }}
+  tls.key: {{ .Assets | load "kube-apiserver-service-network-signer.key" | base64 }}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a25cc3f928d57d570b1fb82483d5db8fed46925d3a3696d7026eaa4404f269a6
-updated: 2019-02-21T11:02:51.736875033-05:00
+updated: 2019-02-21T16:11:08.300004163-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -296,7 +296,7 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 6467eab2ef6ec7ffdd67cd812e811cbbcd027c5c
+  version: 052c4104706cb9a67fc093cba11baf7980525109
   subpackages:
   - pkg/assets
   - pkg/config/client
@@ -427,7 +427,7 @@ imports:
   subpackages:
   - rate
 - name: golang.org/x/tools
-  version: a754db16a40a9d94359b6600b825419c0ca6f986
+  version: 83362c3779f5f48611068d488a03ea7bbaddc81e
   subpackages:
   - container/intsets
 - name: google.golang.org/appengine

--- a/vendor/github.com/openshift/library-go/pkg/assets/template.go
+++ b/vendor/github.com/openshift/library-go/pkg/assets/template.go
@@ -29,6 +29,9 @@ func base64encode(v []byte) string {
 }
 
 func notAfter(certBytes []byte) string {
+	if len(certBytes) == 0 {
+		return ""
+	}
 	certs, err := cert.ParseCertsPEM(certBytes)
 	if err != nil {
 		panic(err)
@@ -37,6 +40,9 @@ func notAfter(certBytes []byte) string {
 }
 
 func notBefore(certBytes []byte) string {
+	if len(certBytes) == 0 {
+		return ""
+	}
 	certs, err := cert.ParseCertsPEM(certBytes)
 	if err != nil {
 		panic(err)
@@ -45,6 +51,9 @@ func notBefore(certBytes []byte) string {
 }
 
 func issuer(certBytes []byte) string {
+	if len(certBytes) == 0 {
+		return ""
+	}
 	certs, err := cert.ParseCertsPEM(certBytes)
 	if err != nil {
 		panic(err)

--- a/vendor/golang.org/x/tools/go/gcexportdata/example_test.go
+++ b/vendor/golang.org/x/tools/go/gcexportdata/example_test.go
@@ -70,15 +70,15 @@ func ExampleRead() {
 // ExampleNewImporter demonstrates usage of NewImporter to provide type
 // information for dependencies when type-checking Go source code.
 func ExampleNewImporter() {
-	const src = `package myscanner
+	const src = `package myrpc
 
-// choosing a package that is unlikely to change across releases
-import "text/scanner"
+// choosing a package that doesn't change across releases
+import "net/rpc"
 
-const scanIdents = scanner.ScanIdents
+const defaultRPCPath = rpc.DefaultRPCPath
 `
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "myscanner.go", src, 0)
+	f, err := parser.ParseFile(fset, "myrpc.go", src, 0)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -86,13 +86,13 @@ const scanIdents = scanner.ScanIdents
 	packages := make(map[string]*types.Package)
 	imp := gcexportdata.NewImporter(fset, packages)
 	conf := types.Config{Importer: imp}
-	pkg, err := conf.Check("myscanner", fset, []*ast.File{f}, nil)
+	pkg, err := conf.Check("myrpc", fset, []*ast.File{f}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// object from imported package
-	pi := packages["text/scanner"].Scope().Lookup("ScanIdents")
+	pi := packages["net/rpc"].Scope().Lookup("DefaultRPCPath")
 	fmt.Printf("const %s.%s %s = %s // %s\n",
 		pi.Pkg().Path(),
 		pi.Name(),
@@ -102,7 +102,7 @@ const scanIdents = scanner.ScanIdents
 	)
 
 	// object in source package
-	twopi := pkg.Scope().Lookup("scanIdents")
+	twopi := pkg.Scope().Lookup("defaultRPCPath")
 	fmt.Printf("const %s %s = %s // %s\n",
 		twopi.Name(),
 		twopi.Type(),
@@ -112,8 +112,8 @@ const scanIdents = scanner.ScanIdents
 
 	// Output:
 	//
-	// const text/scanner.ScanIdents untyped int = 4 // $GOROOT/src/text/scanner/scanner.go:62:1
-	// const scanIdents untyped int = 4 // myscanner.go:6:7
+	// const net/rpc.DefaultRPCPath untyped string = "/_goRPC_" // $GOROOT/src/net/rpc/server.go:146:1
+	// const defaultRPCPath untyped string = "/_goRPC_" // myrpc.go:6:7
 }
 
 func slashify(posn token.Position) token.Position {

--- a/vendor/golang.org/x/tools/internal/lsp/cache/view.go
+++ b/vendor/golang.org/x/tools/internal/lsp/cache/view.go
@@ -197,6 +197,9 @@ type entry struct {
 }
 
 func (imp *importer) addImports(path string, pkg *packages.Package) error {
+	if _, ok := imp.packages[path]; ok {
+		return nil
+	}
 	imp.packages[path] = pkg
 	for importPath, importPkg := range pkg.Imports {
 		if err := imp.addImports(importPath, importPkg); err != nil {

--- a/vendor/golang.org/x/tools/internal/lsp/lsp_test.go
+++ b/vendor/golang.org/x/tools/internal/lsp/lsp_test.go
@@ -443,3 +443,31 @@ func (d definitions) collect(fset *token.FileSet, src, target packagestest.Range
 	loc := toProtocolLocation(fset, source.Range(src))
 	d[loc] = toProtocolLocation(fset, source.Range(target))
 }
+
+func TestBytesOffset(t *testing.T) {
+	tests := []struct {
+		text string
+		pos  protocol.Position
+		want int
+	}{
+		{text: `a𐐀b`, pos: protocol.Position{Line: 0, Character: 0}, want: 0},
+		{text: `a𐐀b`, pos: protocol.Position{Line: 0, Character: 1}, want: 1},
+		{text: `a𐐀b`, pos: protocol.Position{Line: 0, Character: 2}, want: 1},
+		{text: `a𐐀b`, pos: protocol.Position{Line: 0, Character: 3}, want: 5},
+		{text: `a𐐀b`, pos: protocol.Position{Line: 0, Character: 4}, want: -1},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 0, Character: 3}, want: 3},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 0, Character: 4}, want: -1},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 1, Character: 0}, want: 4},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 1, Character: 3}, want: 7},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 1, Character: 4}, want: -1},
+		{text: "aaa\nbbb\n", pos: protocol.Position{Line: 2, Character: 0}, want: -1},
+		{text: "aaa\nbbb\n\n", pos: protocol.Position{Line: 2, Character: 0}, want: 8},
+	}
+
+	for _, test := range tests {
+		got := bytesOffset([]byte(test.text), test.pos)
+		if got != test.want {
+			t.Errorf("want %d for %q(Line:%d,Character:%d), but got %d", test.want, test.text, int(test.pos.Line), int(test.pos.Character), got)
+		}
+	}
+}

--- a/vendor/golang.org/x/tools/internal/lsp/protocol/text.go
+++ b/vendor/golang.org/x/tools/internal/lsp/protocol/text.go
@@ -38,7 +38,7 @@ type TextDocumentContentChangeEvent struct {
 	/**
 	 * The range of the document that changed.
 	 */
-	Range Range `json:"range,omitempty"`
+	Range *Range `json:"range,omitempty"`
 
 	/**
 	 * The length of the range that got replaced.


### PR DESCRIPTION
This doesn't wire us to serve with these new certs, but it does establish adoption of signing certs so we can rotate in the future.

/assign @sttts 

To make this actually work, we need to turn the list of hostnames into a function and we need to re-sign when it changes.