### PR TITLE
Set minimal-shutdown-duration to 3s

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -30,6 +30,8 @@ apiServerArguments:
   - "true"
   feature-gates:
   - PersistentLocalVolumes=false # disable local volumes for 4.0, owned by sig-storage/hekumar@redhat.com
+  minimal-shutdown-duration:
+  - 3s # give SDN some time to converge
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -107,6 +107,8 @@ apiServerArguments:
   - "true"
   feature-gates:
   - PersistentLocalVolumes=false # disable local volumes for 4.0, owned by sig-storage/hekumar@redhat.com
+  minimal-shutdown-duration:
+  - 3s # give SDN some time to converge
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
The SDN needs some time to converge when endpoints change. This minimal shutdown time delay the actual shutdown (and stop of serving) to avoid that race.