### PR TITLE
provide ca bundle for trusting the kube-apiserver

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: initial-kube-apiserver-server-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "kube-ca.crt" | indent 4 }}
+

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -181,6 +181,10 @@ func createTargetConfig(c TargetConfigController, recorder events.Recorder, oper
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kubelet-serving-ca", err))
 	}
+	_, _, err = manageKubeAPIServerCABundle(c.configMapLister, c.kubeClient.CoreV1(), recorder)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-server-ca", err))
+	}
 
 	if len(errors) > 0 {
 		condition := operatorv1.OperatorCondition{
@@ -262,6 +266,28 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "managed-kube-apiserver-client-ca-bundle"},
 		// this bundle is what a user uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "user-client-ca"},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
+}
+
+func manageKubeAPIServerCABundle(lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kube-apiserver-server-ca"},
+		lister,
+		nil, // TODO remove this
+		nil, // TODO remove this
+		// this is from the installer and contains the value they think we should have
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-kube-apiserver-server-ca"},
+		// this bundle is what this operator uses to mint loadbalancers certs
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "loadbalancer-serving-ca"},
+		// this bundle is what this operator uses to mint localhost certs
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "localhost-serving-ca"},
+		// this bundle is what a user uses to mint service-network certs
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "service-network-serving-ca"},
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
We need to provide a cabundle for trusting the kube-apiserver since we're minting certificates.

