### PR TITLE
trust csr signer to serve kubelets

### DIFF
--- a/bindata/bootkube/manifests/configmap-initial-kubelet-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kubelet-serving-ca.yaml
@@ -6,4 +6,5 @@ metadata:
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}
+    {{ .Assets | load "kubelet-csr-signer.crt" | indent 4 }}
 


### PR DESCRIPTION
in order to use the new short-lived CSR, we have to trust it to serve kubelets.