### PR TITLE
trust the kubeconfig signers from the installer

### DIFF
--- a/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-kubeconfig-client-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "admin-kubeconfig-ca-bundle.crt" | indent 4 }}
+

--- a/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-bootstrap-client-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "kube-ca.crt" | indent 4 }}
+

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -250,6 +250,11 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		nil, // TODO remove this
 		// this is from the installer and contains the value they think we should have
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-client-ca"},
+		// this is from the installer and contains the value to verify the admin.kubeconfig user
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
+		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images
+		// TODO the MCO should take care of rotating this.
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "node-bootstrap-client-ca"},
 		// this is from kube-controller-manager and indicates the ca-bundle.crt to verify their signatures (kubelet client certs)
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages


### PR DESCRIPTION
After this, we should be able switch to the knew admin.kubeconfig file and remove the deprecated one.