### PR TITLE
serve using SNI and rotated certificates

### DIFF
--- a/bindata/bootkube/manifests/config.apiserver.yaml
+++ b/bindata/bootkube/manifests/config.apiserver.yaml
@@ -1,0 +1,4 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster

--- a/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
@@ -4,10 +4,10 @@ metadata:
   name: loadbalancer-serving-signer
   namespace: openshift-kube-apiserver-operator
   annotations:
-    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | notBefore }}
-    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | notAfter }}
-    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | issuer }}
+    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-lb-signer.crt" | notBefore }}
+    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-lb-signer.crt" | notAfter }}
+    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-lb-signer.crt" | issuer }}
 type: SecretTypeTLS
 data:
-  tls.crt: {{ .Assets | load "kube-apiserver-lb-host-ip-signer.crt" | base64 }}
-  tls.key: {{ .Assets | load "kube-apiserver-lb-host-ip-signer.key" | base64 }}
+  tls.crt: {{ .Assets | load "kube-apiserver-lb-signer.crt" | base64 }}
+  tls.key: {{ .Assets | load "kube-apiserver-lb-signer.key" | base64 }}

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -97,9 +97,9 @@ servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
+  certFile: /etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt
   clientCA: /etc/kubernetes/static-pod-resources/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
+  keyFile: /etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null
   requestTimeoutSeconds: 3600

--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -105,11 +105,11 @@ func observeDefaultUserServingCertificate(apiServer *configv1.APIServer, recorde
 	// generate an observed configuration that will configure the kube-apiserver to use the user managed default serving
 	// cert info instead of the operator managed default serving cert info.
 	observedConfig := map[string]interface{}{}
-	certFile := fmt.Sprint(userServingCertPublicCertFile)
+	certFile := userServingCertPublicCertFile
 	if err := unstructured.SetNestedField(observedConfig, certFile, "servingInfo", "certFile"); err != nil {
 		return previouslyObservedConfig, nil, append(errs, err)
 	}
-	keyFile := fmt.Sprint(userServingCertPrivateKeyFile)
+	keyFile := userServingCertPrivateKeyFile
 	if err := unstructured.SetNestedField(observedConfig, keyFile, "servingInfo", "keyFile"); err != nil {
 		return previouslyObservedConfig, nil, append(errs, err)
 	}
@@ -134,6 +134,18 @@ func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Rec
 	namedCertificatesPath := []string{"servingInfo", "namedCertificates"}
 	resourceSyncRules := syncActionRules{}
 	var observedNamedCertificates []interface{}
+
+	// these are always present in the config because we mint and rotate them ourselves.
+	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
+		"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key"})
+	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
+		"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key"})
+	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
+		"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key"})
+
 	for index, namedCertificate := range namedCertificates {
 		observedNamedCertificate := map[string]interface{}{}
 		if len(namedCertificate.Names) > 0 {
@@ -166,7 +178,8 @@ func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Rec
 
 		observedNamedCertificates = append(observedNamedCertificates, observedNamedCertificate)
 	}
-	if len(namedCertificates) > 0 {
+
+	if len(observedNamedCertificates) > 0 {
 		if err := unstructured.SetNestedField(observedConfig, observedNamedCertificates, namedCertificatesPath...); err != nil {
 			return previouslyObservedConfig, nil, append(errs, err)
 		}
@@ -183,6 +196,7 @@ type apiServerObserver struct {
 }
 
 func (o *apiServerObserver) observe(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	fmt.Printf("#### 2a\n")
 	listers := genericListers.(configobservation.Listers)
 	var errs []error
 

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -199,7 +199,24 @@ func TestObserveNamedCertificates(t *testing.T) {
 			name:     "NoNamedCertificates",
 			config:   newAPIServerConfig(),
 			existing: existingConfig,
-			expected: map[string]interface{}{},
+			expected: map[string]interface{}{
+				"servingInfo": map[string]interface{}{
+					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key",
+						},
+					},
+				},
+			},
 			expectedSynced: map[string]string{
 				"secret/user-serving-cert-000.openshift-kube-apiserver-operator": "DELETE",
 				"secret/user-serving-cert-001.openshift-kube-apiserver-operator": "DELETE",
@@ -225,6 +242,18 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key",
+						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -257,6 +286,18 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key",
+						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -291,6 +332,18 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key",
+						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -332,6 +385,18 @@ func TestObserveNamedCertificates(t *testing.T) {
 			expected: map[string]interface{}{
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-serving-cert-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/loadbalancer-serving-certkey/tls.key",
+						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/user-serving-cert-000/tls.key",
@@ -433,6 +498,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 					t.Log(err.Error())
 				}
 			}
+
 			if !equality.Semantic.DeepEqual(tc.expected, result) {
 				t.Errorf("result does not match expected config: %s", diff.ObjectDiff(tc.expected, result))
 			}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -186,7 +186,10 @@ var deploymentSecrets = []revision.RevisionResource{
 	{Name: "aggregator-client"},
 	{Name: "etcd-client"},
 	{Name: "kubelet-client"},
-	{Name: "serving-cert"},
+	{Name: "localhost-serving-cert-certkey"},
+	{Name: "service-network-serving-certkey"},
+	{Name: "loadbalancer-serving-certkey"},
+
 	{Name: "user-serving-cert", Optional: true},
 	{Name: "user-serving-cert-000", Optional: true},
 	{Name: "user-serving-cert-001", Optional: true},

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -124,6 +124,7 @@ func (c TargetConfigController) sync() error {
 	}
 	requiredPaths := [][]string{
 		{"serviceAccountPublicKeyFiles"},
+		{"servingInfo", "namedCertificates"},
 	}
 	for _, requiredPath := range requiredPaths {
 		_, found, _ := unstructured.NestedFieldNoCopy(existingConfig, requiredPath...)

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -174,9 +174,9 @@ servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.crt
+  certFile: /etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.crt
   clientCA: /etc/kubernetes/static-pod-resources/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/serving-cert/tls.key
+  keyFile: /etc/kubernetes/static-pod-resources/secrets/service-network-serving-certkey/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null
   requestTimeoutSeconds: 3600


### PR DESCRIPTION
Based on https://github.com/openshift/cluster-kube-apiserver-operator/pull/251/files

This ensures that we always serve using the certificates we rotate for their purposes and never with kube-ca certs.

