### PR TITLE
extend minimum duration

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -31,7 +31,7 @@ apiServerArguments:
   feature-gates:
   - PersistentLocalVolumes=false # disable local volumes for 4.0, owned by sig-storage/hekumar@redhat.com
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge
+  - 35s # give SDN some time to converge
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -108,7 +108,7 @@ apiServerArguments:
   feature-gates:
   - PersistentLocalVolumes=false # disable local volumes for 4.0, owned by sig-storage/hekumar@redhat.com
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge
+  - 35s # give SDN some time to converge
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
extend the shutdown duration to catch iptables updates.  This is long and will reduce the rollout rate, so we really want https://github.com/openshift/cluster-kube-apiserver-operator/pull/308 to help speed us back up/