### PR TITLE
manifests: operator is system-cluster-critical priority

### DIFF
--- a/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
@@ -60,5 +60,6 @@ spec:
           name: kube-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists


### PR DESCRIPTION
specifies system-cluster-critical priority for operator.

blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217