### PR TITLE
use dynamic reloading of certs to avoid rolling out new deployment versions

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -18,8 +18,8 @@ admissionPluginConfig:
     location: ""
 aggregatorConfig:
   proxyClientInfo:
-    certFile: /etc/kubernetes/static-pod-resources/secrets/aggregator-client/tls.crt
-    keyFile: /etc/kubernetes/static-pod-resources/secrets/aggregator-client/tls.key
+    certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
+    keyFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
 apiServerArguments:
   storage-backend:
   - etcd3
@@ -66,7 +66,7 @@ auditConfig:
 authConfig:
   oauthMetadataFile: ""
   requestHeader:
-    clientCA: /etc/kubernetes/static-pod-resources/configmaps/aggregator-client-ca/ca-bundle.crt
+    clientCA: /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
     clientCommonNames:
     - kube-apiserver-proxy
     - system:kube-apiserver-proxy
@@ -95,7 +95,7 @@ servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
   certFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.crt
-  clientCA: /etc/kubernetes/static-pod-resources/configmaps/client-ca/ca-bundle.crt
+  clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   keyFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -177,29 +177,29 @@ var revisionConfigMaps = []revision.RevisionResource{
 	{Name: "oauth-metadata", Optional: true},
 
 	// these need to removed, but if we remove them now, the cluster will die because we don't reload them yet
-	{Name: "aggregator-client-ca"},
-	{Name: "client-ca"},
 	{Name: "etcd-serving-ca"},
 	{Name: "initial-sa-token-signing-certs", Optional: true},
 	{Name: "kube-apiserver-server-ca", Optional: true},
 	{Name: "kube-controller-manager-sa-token-signing-certs", Optional: true},
 	{Name: "kubelet-serving-ca"},
-	{Name: "user-client-ca", Optional: true},
 }
 
 // revisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.
 var revisionSecrets = []revision.RevisionResource{
 	// these need to removed, but if we remove them now, the cluster will die because we don't reload them yet
-	{Name: "aggregator-client"},
 	{Name: "etcd-client"},
+	// this is needed so that the cert syncer itself can request certs.  It uses localhost
 	{Name: "kube-apiserver-cert-syncer-client-cert-key"},
 	{Name: "kubelet-client"},
 }
 
-var CertConfigMaps = []revision.RevisionResource{}
+var CertConfigMaps = []revision.RevisionResource{
+	{Name: "aggregator-client-ca"},
+	{Name: "client-ca"},
+}
 
 var CertSecrets = []revision.RevisionResource{
-	// this is needed so that the cert syncer itself can request certs.  It uses the service network.
+	{Name: "aggregator-client"},
 	{Name: "serving-cert"},
 	{Name: "user-serving-cert", Optional: true},
 	{Name: "user-serving-cert-000", Optional: true},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -96,8 +96,8 @@ admissionPluginConfig:
     location: ""
 aggregatorConfig:
   proxyClientInfo:
-    certFile: /etc/kubernetes/static-pod-resources/secrets/aggregator-client/tls.crt
-    keyFile: /etc/kubernetes/static-pod-resources/secrets/aggregator-client/tls.key
+    certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
+    keyFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
 apiServerArguments:
   storage-backend:
   - etcd3
@@ -144,7 +144,7 @@ auditConfig:
 authConfig:
   oauthMetadataFile: ""
   requestHeader:
-    clientCA: /etc/kubernetes/static-pod-resources/configmaps/aggregator-client-ca/ca-bundle.crt
+    clientCA: /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
     clientCommonNames:
     - kube-apiserver-proxy
     - system:kube-apiserver-proxy
@@ -173,7 +173,7 @@ servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
   certFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.crt
-  clientCA: /etc/kubernetes/static-pod-resources/configmaps/client-ca/ca-bundle.crt
+  clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   keyFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null


### PR DESCRIPTION
since https://github.com/openshift/origin/pull/22229 merged, we can reload most

We need https://github.com/openshift/origin/pull/22239 to reload the aggregator client

/hold