### PR TITLE
initial e2e-operator tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,9 @@ origin-release:
 	@echo "  docker push $(IMAGE_ORG)/origin-release:latest"
 	@echo "  docker push $(IMAGE_ORG)/origin-cluster-kube-apiserver-operator"
 	@echo "  OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(IMAGE_ORG)/origin-release:latest bin/openshift-install cluster --log-level=debug"
+
+GO_TEST_PACKAGES :=./pkg/... ./cmd/...
+
+.PHONY: test-e2e
+test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
+test-e2e: test-unit

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
+)
+
+func TestOperatorNamespace(t *testing.T) {
+	kubeConfig, err := test.NewClientConfigForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	coreV1Client := corev1.NewForConfigOrDie(kubeConfig)
+	_, err = coreV1Client.Namespaces().Get("openshift-kube-apiserver-operator", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/library/client.go
+++ b/test/library/client.go
@@ -1,0 +1,19 @@
+package library
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewClientConfigForTest returns a config configured to connect to the api server
+func NewClientConfigForTest() (*rest.Config, error) {
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{})
+	config, err := clientConfig.ClientConfig()
+	if err == nil {
+		fmt.Printf("Found configuration for host %v.\n", config.Host)
+	}
+	return config, err
+}


### PR DESCRIPTION
An initial structure for running e2e tests.
* Added `./test/library` for library/framework code.
* Added `./test/e2e` for tests.
* Added a make target `test-e2e` intended to be executed by CI. e.g :
```console
$ make test-e2e JUNITFILE=/tmp/artifacts/unit_report.xml
```
* See https://github.com/openshift/release/pull/3000