### PR TITLE
Remove cluster api dependency

### DIFF
--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -1,0 +1,111 @@
+package render
+
+import (
+	"reflect"
+	"testing"
+)
+
+var (
+	expectedClusterCIDR = []string{"10.128.0.0/14"}
+	expectedServiceCIDR = []string{"172.30.0.0/16"}
+	clusterAPIConfig    = `
+apiVersion: machine.openshift.io/v1beta1
+kind: Cluster
+metadata:
+  creationTimestamp: null
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.128.0.0/14
+    serviceDomain: ""
+    services:
+      cidrBlocks:
+        - 172.30.0.0/16
+  providerSpec: {}
+status: {}
+`
+	networkConfig = `
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+  networkType: OpenShiftSDN
+  serviceNetwork:
+    - 172.30.0.0/16
+status: {}
+`
+)
+
+func TestDiscoverCIDRsFromNetwork(t *testing.T) {
+	renderConfig := TemplateData{
+		LockHostPath:   "",
+		EtcdServerURLs: []string{""},
+		EtcdServingCA:  "",
+	}
+	if err := discoverCIDRsFromNetwork([]byte(networkConfig), &renderConfig); err != nil {
+		t.Errorf("failed discoverCIDRs: %v", err)
+	}
+	if !reflect.DeepEqual(renderConfig.ClusterCIDR, expectedClusterCIDR) {
+		t.Errorf("Got: %v, expected: %v", renderConfig.ClusterCIDR, expectedClusterCIDR)
+	}
+	if !reflect.DeepEqual(renderConfig.ServiceCIDR, expectedServiceCIDR) {
+		t.Errorf("Got: %v, expected: %v", renderConfig.ServiceCIDR, expectedServiceCIDR)
+	}
+}
+
+func TestDiscoverCIDRsFromClusterAPI(t *testing.T) {
+	renderConfig := TemplateData{
+		LockHostPath:   "",
+		EtcdServerURLs: []string{""},
+		EtcdServingCA:  "",
+	}
+	if err := discoverCIDRsFromClusterAPI([]byte(clusterAPIConfig), &renderConfig); err != nil {
+		t.Errorf("failed discoverCIDRs: %v", err)
+	}
+	if !reflect.DeepEqual(renderConfig.ClusterCIDR, expectedClusterCIDR) {
+		t.Errorf("Got: %v, expected: %v", renderConfig.ClusterCIDR, expectedClusterCIDR)
+	}
+	if !reflect.DeepEqual(renderConfig.ServiceCIDR, expectedServiceCIDR) {
+		t.Errorf("Got: %v, expected: %v", renderConfig.ServiceCIDR, expectedServiceCIDR)
+	}
+}
+
+func TestDiscoverCIDRs(t *testing.T) {
+	testCase := []struct {
+		config []byte
+	}{
+		{
+			config: []byte(networkConfig),
+		},
+		{
+			config: []byte(clusterAPIConfig),
+		},
+	}
+
+	for _, tc := range testCase {
+		renderConfig := TemplateData{
+			LockHostPath:   "",
+			EtcdServerURLs: []string{""},
+			EtcdServingCA:  "",
+		}
+
+		if err := discoverCIDRs(tc.config, &renderConfig); err != nil {
+			t.Errorf("failed to discoverCIDRs: %v", err)
+		}
+
+		if !reflect.DeepEqual(renderConfig.ClusterCIDR, expectedClusterCIDR) {
+			t.Errorf("Got: %v, expected: %v", renderConfig.ClusterCIDR, expectedClusterCIDR)
+		}
+		if !reflect.DeepEqual(renderConfig.ServiceCIDR, expectedServiceCIDR) {
+			t.Errorf("Got: %v, expected: %v", renderConfig.ServiceCIDR, expectedServiceCIDR)
+		}
+	}
+}


### PR DESCRIPTION
Fix https://jira.coreos.com/browse/CLOUD-357
Remove dependency with cluster api cluster object:
- discoverIPs from network config
- fallback to discover from cluster api object

Also fixes an issue that was shadowing the returned err https://github.com/openshift/cluster-kube-apiserver-operator/pull/351/files#diff-5e45df1052a09901f6732e8a838541ebL206

Once we get this in we need to do the same for the controller manager.
Then we can merge https://github.com/openshift/installer/pull/1449
Then we can remove the fallback to discover from cluster api object
