### PR TITLE
Increase minimal-shutdown-duration to 35s to cope with slowly converging SDN

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -30,7 +30,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge
+  - 35s # give SDN some time to converge
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
 auditConfig:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -108,7 +108,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   minimal-shutdown-duration:
-  - 3s # give SDN some time to converge
+  - 35s # give SDN some time to converge
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
 auditConfig:


### PR DESCRIPTION
Rebase of https://github.com/openshift/cluster-kube-apiserver-operator/pull/318.

Necessary to make https://github.com/openshift/installer/pull/1421 effective. 5 seconds is not enough for the ELB to notice an issue and to update, 35s should.

@wking @abhinavdahiya 