### PR TITLE
audit-policy: exclude /readyz

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -58,6 +58,7 @@ auditConfig:
       - "/api*" # Wildcard matching.
       - "/version"
       - "/healthz"
+      - "/readyz"
     # A catch-all rule to log all other requests at the Metadata level.
     - level: Metadata
       # Long-running requests like watches that fall under this rule will not

--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -20,7 +20,7 @@ spec:
     - name: wait-for-host-port
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['/usr/bin/timeout', '100', "/bin/bash", "-c"] # 60 sec for graceful termination, 35 for minimum-termination-duration
+      command: ['/usr/bin/timeout', '100', '/bin/bash', '-c'] # 60 sec for graceful termination, 35 for minimum-termination-duration
       args:
       - |
         echo -n "Waiting for port :6443 to be released."

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -223,9 +223,15 @@ func managePod(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, o
 	required := resourceread.ReadPodV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/pod.yaml"))
 	// TODO: If the image pull spec is not specified, the "${IMAGE}" will be used as value and the pod will fail to start.
 	if len(imagePullSpec) > 0 {
-		required.Spec.Containers[0].Image = imagePullSpec
-		if len(required.Spec.InitContainers) > 0 {
-			required.Spec.InitContainers[0].Image = imagePullSpec
+		for i := range required.Spec.Containers {
+			if required.Spec.Containers[i].Image == "${IMAGE}" {
+				required.Spec.Containers[i].Image = imagePullSpec
+			}
+		}
+		for i := range required.Spec.InitContainers {
+			if required.Spec.InitContainers[i].Image == "${IMAGE}" {
+				required.Spec.InitContainers[i].Image = imagePullSpec
+			}
 		}
 	}
 	if len(operatorImagePullSpec) > 0 {

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -136,6 +136,7 @@ auditConfig:
       - "/api*" # Wildcard matching.
       - "/version"
       - "/healthz"
+      - "/readyz"
     # A catch-all rule to log all other requests at the Metadata level.
     - level: Metadata
       # Long-running requests like watches that fall under this rule will not

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -337,10 +337,21 @@ spec:
     - name: fix-audit-permissions
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
+      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
+    - name: wait-for-host-port
+      image: ${IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ['/usr/bin/timeout', '100', '/bin/bash', '-c'] # 60 sec for graceful termination, 35 for minimum-termination-duration
+      args:
+      - |
+        echo -n "Waiting for port :6443 to be released."
+        while [ -n "$(lsof -ni :6443)" ]; do
+          echo -n "."
+          sleep 1
+        done
   containers:
   - name: kube-apiserver-REVISION
     image: ${IMAGE}


### PR DESCRIPTION
And update bindata. Why was that not caught through verify?