### PR TITLE
Fix copy operation to create proper /manifests/ dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN mkdir -p /usr/share/bootkube/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/* /usr/share/bootkube/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
-COPY manifests/*.yaml /manifests
-COPY manifests/image-references /manifests
+COPY manifests/*.yaml /manifests/
+COPY manifests/image-references /manifests/
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,6 +8,6 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 RUN mkdir -p /usr/share/bootkube/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/* /usr/share/bootkube/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
-COPY manifests/*.yaml /manifests
-COPY manifests/image-references /manifests
+COPY manifests/*.yaml /manifests/
+COPY manifests/image-references /manifests/
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-apiserver-operator/pull/354/commits/0bd73e26498bf2244f65ca0a9fba05ddbdc8ae4c broke manifests copying, this uses the proper format for copying dir contents.

/assign @sttts @smarterclayton 