### PR TITLE
use the new installer certs to serve

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -216,7 +216,7 @@ func NewCertRotationController(
 		},
 		certrotation.TargetRotation{
 			Namespace: operatorclient.TargetNamespace,
-			Name:      "loadbalancer-serving-certkey",
+			Name:      "external-loadbalancer-serving-certkey",
 			Validity:  30 * rotationDay,
 			Refresh:   15 * rotationDay,
 			CertCreator: &certrotation.ServingRotation{

--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -142,10 +142,9 @@ func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Rec
 	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
 		"certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
 		"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key"})
-	// TODO I don't think the kubelets trust the new signer
-	//observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
-	//	"certFile": "/etc/kubernetes/static-pod-certs/secrets/loadbalancer-serving-certkey/tls.crt",
-	//	"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/loadbalancer-serving-certkey/tls.key"})
+	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
+		"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key"})
 
 	for index, namedCertificate := range namedCertificates {
 		observedNamedCertificate := map[string]interface{}{}

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -210,6 +210,10 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
 						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key",
+						},
 					},
 				},
 			},
@@ -245,6 +249,10 @@ func TestObserveNamedCertificates(t *testing.T) {
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
@@ -287,6 +295,10 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.key",
 						},
@@ -327,6 +339,10 @@ func TestObserveNamedCertificates(t *testing.T) {
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
@@ -376,6 +392,10 @@ func TestObserveNamedCertificates(t *testing.T) {
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
+						},
+						map[string]interface{}{
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -211,7 +211,7 @@ var CertSecrets = []revision.RevisionResource{
 	{Name: "serving-cert"},
 	{Name: "localhost-serving-cert-certkey"},
 	{Name: "service-network-serving-certkey"},
-	{Name: "loadbalancer-serving-certkey"},
+	{Name: "external-loadbalancer-serving-certkey"},
 
 	{Name: "user-serving-cert", Optional: true},
 	{Name: "user-serving-cert-000", Optional: true},

--- a/test/e2e/user_certs_test.go
+++ b/test/e2e/user_certs_test.go
@@ -91,6 +91,7 @@ func TestNamedCertificates(t *testing.T) {
 	defaultServingCertSerialNumber := serialNumberOfCertificateFromSecretOrFail(t, kubeClient, "openshift-kube-apiserver", "serving-cert")
 	localhostServingCertSerialNumber := serialNumberOfCertificateFromSecretOrFail(t, kubeClient, "openshift-kube-apiserver", "localhost-serving-cert-certkey")
 	serviceServingCertSerialNumber := serialNumberOfCertificateFromSecretOrFail(t, kubeClient, "openshift-kube-apiserver", "service-network-serving-certkey")
+	externalLoadBalancerCertSerialNumber := serialNumberOfCertificateFromSecretOrFail(t, kubeClient, "openshift-kube-apiserver", "external-loadbalancer-serving-certkey")
 
 	// execute test cases
 	testCases := []struct {
@@ -156,7 +157,7 @@ func TestNamedCertificates(t *testing.T) {
 		{
 			name:                 "LoadBalancerHostname",
 			serverName:           getAPIServiceHostNameOrFail(t, configClient),
-			expectedSerialNumber: defaultServingCertSerialNumber,
+			expectedSerialNumber: externalLoadBalancerCertSerialNumber,
 		},
 		{
 			name:                 "UnknownServerHostname",


### PR DESCRIPTION
switch to the specific kube-apiserver serving certs for serving the API.