### PR TITLE
switch to constrained CSR signer for kubelet verification

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -8,7 +8,7 @@ authConfig:
   requestHeader:
     clientCA: /etc/kubernetes/secrets/aggregator-signer.crt
 kubeletClientInfo:
-  ca: /etc/kubernetes/secrets/kube-ca.crt # origin 3.11: ca.crt
+  ca: /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
   certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.kubelet-client.crt
   keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.kubelet-client.key
 serviceAccountPublicKeyFiles:

--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,9 +1,5 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
-kubeletClientInfo:
-  ca: /var/run/configmaps/kubelet-serving-ca/ca-bundle.crt
-  certFile: /var/run/secrets/kubelet-client/tls.crt
-  keyFile: /var/run/secrets/kubelet-client/tls.key
 serviceAccountPublicKeyFiles:
 - /var/run/configmaps/sa-token-signing-certs/ca-bundle.crt
 servingInfo:

--- a/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: openshift-config-managed
 data:
   ca-bundle.crt: |
-    {{ .Assets | load "kubelet-signer.crt" | indent 4 }}
+    {{ .Assets | load "kubelet-client-ca-bundle.crt" | indent 4 }}
 


### PR DESCRIPTION
kube-ca shouldn't be used and this switches us to the one the installer wires

/assign @sanchezl 