### PR TITLE
add test for operand image version

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -3,20 +3,37 @@ package e2e
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
 )
 
 func TestOperatorNamespace(t *testing.T) {
 	kubeConfig, err := test.NewClientConfigForTest()
-	if err != nil {
-		t.Fatal(err)
+	require.NoError(t, err)
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	_, err = kubeClient.CoreV1().Namespaces().Get("openshift-kube-apiserver-operator", metav1.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestOperandImageVersion(t *testing.T) {
+	kubeConfig, err := test.NewClientConfigForTest()
+	require.NoError(t, err)
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	operator, err := configClient.ClusterOperators().Get("kube-apiserver", metav1.GetOptions{})
+	require.NoError(t, err)
+	for _, operandVersion := range operator.Status.Versions {
+		if operandVersion.Name == "kube-apiserver" {
+			require.Regexp(t, `^1\.\d*\.\d*`, operandVersion.Version)
+			return
+		}
 	}
-	coreV1Client := corev1.NewForConfigOrDie(kubeConfig)
-	_, err = coreV1Client.Namespaces().Get("openshift-kube-apiserver-operator", metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Fail(t, "operator kube-apiserver image version not found")
 }


### PR DESCRIPTION
Ensure that OPERAND_IMAGE_VERSION is substituted properly.
See https://github.com/openshift/cluster-kube-apiserver-operator/pull/366