### PR TITLE
wrap existing client transport wrappers to avoid losing in-cluster config

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: efe02039dae0ebe86262fd427751b20c05b0c039aa473eb75445db14ac4b3ccd
-updated: 2019-04-09T16:31:19.277614021-04:00
+hash: 0ef6b2a70f28d69376b7a9610304d8fc53f51bb52cc83ed78d997fe78df04ba9
+updated: 2019-04-10T11:24:10.084541806-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -240,7 +240,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: 275768afc8f66b79aeb12debf94ffc85255104ad
+  version: 87f97e6c35f4e067e1c744b3013fd902c5baa4ad
   subpackages:
   - apps
   - apps/v1
@@ -305,7 +305,8 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 8feeb2216a12650b738e6199e27e3f6a5a77abe3
+  version: 1dfa94e49540140c4bdba0f0bc2ababf9cbad60e
+  repo: https://github.com/deads2k/library-go
   subpackages:
   - cmd/crd-schema-gen/generator
   - pkg/assets
@@ -321,6 +322,7 @@ imports:
   - pkg/crypto
   - pkg/operator/certrotation
   - pkg/operator/configobserver
+  - pkg/operator/configobserver/featuregates
   - pkg/operator/configobserver/network
   - pkg/operator/events
   - pkg/operator/management

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,8 @@ import:
 - package: github.com/openshift/client-go
   version: master
 - package: github.com/openshift/library-go
-  version: master
+  repo: https://github.com/deads2k/library-go
+  version: in-cluster
 - package: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
 - package: k8s.io/gengo/args

--- a/vendor/github.com/openshift/api/operator/v1/types_serviceca.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_serviceca.go
@@ -14,8 +14,10 @@ type ServiceCA struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// +required
+	//spec holds user settable values for configuration
 	Spec   ServiceCASpec   `json:"spec"`
 	// +optional
+	// status holds observed values from the cluster. They may not be overridden.
 	Status ServiceCAStatus `json:"status"`
 }
 

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -507,7 +507,9 @@ func (KubeSchedulerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ServiceCA = map[string]string{
-	"": "ServiceCA provides information to configure an operator to manage the service cert controllers",
+	"":       "ServiceCA provides information to configure an operator to manage the service cert controllers",
+	"spec":   "spec holds user settable values for configuration",
+	"status": "status holds observed values from the cluster. They may not be overridden.",
 }
 
 func (ServiceCA) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/library-go/glide.lock
+++ b/vendor/github.com/openshift/library-go/glide.lock
@@ -1,5 +1,5 @@
-hash: 1736e530e2f520e62cbada3a813317bb7112f3b7d1178696be8b041dfcea4e52
-updated: 2019-04-09T10:56:56.601559+02:00
+hash: 55a96b1eb411a76d43004d8b89db61a764449d4a8002ea38da1d759ce2328b53
+updated: 2019-04-10T11:59:13.917718+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -118,7 +118,7 @@ imports:
 - name: github.com/getsentry/raven-go
   version: 32a13797442ccb601b11761d74232773c1402d14
 - name: github.com/ghodss/yaml
-  version: c7ce16629ff4cd059ed96ed06419dd3856fd3577
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
   version: ef5f0afec364d3b9396b7b77b43dbe26bf1f8004
 - name: github.com/go-openapi/jsonreference
@@ -136,8 +136,6 @@ imports:
   - proto
   - protoc-gen-gogo/descriptor
   - sortkeys
-- name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
@@ -145,21 +143,19 @@ imports:
 - name: github.com/golang/protobuf
   version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
-  - jsonpb
   - proto
   - ptypes
   - ptypes/any
   - ptypes/duration
-  - ptypes/struct
   - ptypes/timestamp
 - name: github.com/gonum/blas
-  version: f22b278b28ac9805aadd613a754a60c35b24ae69
+  version: 37e82626499e1df7c54aeaba0959fd6e7e8dc1e4
   subpackages:
   - blas64
   - native
   - native/internal/math32
 - name: github.com/gonum/floats
-  version: c233463c7e827fd71a8cdb62dfda0e98f7c39ad5
+  version: f74b330d45c56584a6ea7a27f5c64ea2900631e9
 - name: github.com/gonum/graph
   version: 50b27dea7ebbfb052dfaf91681afc6fde28d8796
   subpackages:
@@ -174,17 +170,17 @@ imports:
   - internal/ordered
   - simple
 - name: github.com/gonum/internal
-  version: f884aa71402950fb2796dbea0d5aa9ef9cfad8ca
+  version: e57e4534cf9b3b00ef6c0175f59d8d2d34f60914
   subpackages:
   - asm/f32
   - asm/f64
 - name: github.com/gonum/lapack
-  version: e4cdc5a0bff924bb10be88482e635bd40429f65e
+  version: 5ed4b826becd1807e09377508f51756586d1a98c
   subpackages:
   - lapack64
   - native
 - name: github.com/gonum/matrix
-  version: c518dec07be9a636c38a4650e217be059b5952ec
+  version: dd6034299e4242c9f0ea36735e6d4264dfcb3f9f
   subpackages:
   - mat64
 - name: github.com/google/btree
@@ -212,11 +208,13 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/joho/godotenv
-  version: 5c0e6c6ab1a0a9ef0a8822cba3a05d62f7dad941
+  version: 6d367c18edf6ca7fd004efd6863e4c5728fa858e
 - name: github.com/json-iterator/go
   version: ab8a2e0c74be9d3be70b3184d9acc634935ded82
 - name: github.com/jteeuwen/go-bindata
   version: a0ff2567cfb70903282db057e799fd826784d41d
+- name: github.com/kr/fs
+  version: 1455def202f6e05b95cc7bfc7e8ae67ae5141eba
 - name: github.com/mailru/easyjson
   version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
@@ -236,7 +234,7 @@ imports:
 - name: github.com/NYTimes/gziphandler
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/openshift/api
-  version: 6d14d1b57953e4d5609e14361ab577b6be33a965
+  version: 275768afc8f66b79aeb12debf94ffc85255104ad
   subpackages:
   - apps
   - apps/v1
@@ -282,7 +280,7 @@ imports:
   - webconsole
   - webconsole/v1
 - name: github.com/openshift/client-go
-  version: 7cc0953bbbb7925e30232c056606d666942bb542
+  version: 53641229593ccc560f837da082350e91f51a76a5
   subpackages:
   - config/clientset/versioned
   - config/clientset/versioned/fake
@@ -300,11 +298,12 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pkg/profile
   version: f6fe06335df110bcf1ed6d4e852b760bfc15beee
+- name: github.com/pkg/sftp
+  version: 5bcd86d72480cb6de4bc5804f832e27855ba033f
 - name: github.com/prometheus/client_golang
   version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
   - prometheus
-  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:
@@ -324,7 +323,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/rogpeppe/go-internal
-  version: 438578804ca6f31be148c27683afc419ce47c06e
+  version: bb30e2a7ca3553a66c6a740eb5ebe72f9d35ef0e
   subpackages:
   - modfile
   - module
@@ -334,9 +333,10 @@ imports:
 - name: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
-  version: 588a75ec4f32903aa5e39a2619ba6a4631e28424
+  version: b28a7effac979219c2a2ed6205a4d70e4b1bcd02
   subpackages:
   - mem
+  - sftp
 - name: github.com/spf13/cobra
   version: c439c4fa093711d42e1b01acb1235b52004753c1
 - name: github.com/spf13/pflag
@@ -344,13 +344,20 @@ imports:
 - name: golang.org/x/crypto
   version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
-  - bcrypt
-  - blowfish
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - internal/chacha20
+  - internal/subtle
+  - poly1305
+  - ssh
   - ssh/terminal
 - name: golang.org/x/net
   version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - context
+  - html
+  - html/atom
   - http2
   - http2/hpack
   - idna
@@ -361,7 +368,10 @@ imports:
 - name: golang.org/x/oauth2
   version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
+  - google
   - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
@@ -392,7 +402,7 @@ imports:
   - go/ast/astutil
   - imports
 - name: google.golang.org/appengine
-  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
   - internal
   - internal/base
@@ -439,7 +449,7 @@ imports:
 - name: gopkg.in/natefinch/lumberjack.v2
   version: 20b71e5b60d756d3d2f80def009790325acc2b23
 - name: gopkg.in/yaml.v2
-  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
   version: 5cb15d34447165a97c76ed5a60e4e99c8a01ecfe
   subpackages:
@@ -478,7 +488,8 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apiextensions-apiserver
-  version: d002e88f6236312f0289d9d1deab106751718ff0
+  version: 6e2b3eb1b401beaf836f640f73f730f6da7aff2f
+  repo: https://github.com/openshift/kubernetes-apiextensions-apiserver
   subpackages:
   - pkg/apis/apiextensions
   - pkg/apis/apiextensions/v1beta1
@@ -815,7 +826,7 @@ imports:
   - util/retry
   - util/workqueue
 - name: k8s.io/gengo
-  version: 4242d8e6c5dba56827bb7bcf14ad11cda38f3991
+  version: e17681d19d3ac4837a019ece36c2a0ec31ffe985
   subpackages:
   - args
   - generator
@@ -841,8 +852,8 @@ imports:
   - pkg/util
   - pkg/util/proto
 - name: sigs.k8s.io/controller-tools
-  version: 43466124052c1a1aa7d8fd33624b00bc111fb7cf
-  repo: https://github.com/openshift/kubernetes-sigs-controller-tools.git
+  version: 4e23e49e5d401ca6ced86aa30262d0cf2488c504
+  repo: https://github.com/openshift/kubernetes-sigs-controller-tools
   subpackages:
   - pkg/crd/generator
   - pkg/crd/util

--- a/vendor/github.com/openshift/library-go/glide.yaml
+++ b/vendor/github.com/openshift/library-go/glide.yaml
@@ -5,8 +5,6 @@ import:
   version: kubernetes-1.13.4
 - package: k8s.io/apiserver
   version: kubernetes-1.13.4
-- package: k8s.io/apiextensions-apiserver
-  version: kubernetes-1.13.4
 - package: k8s.io/kube-aggregator
   version: kubernetes-1.13.4
 - package: k8s.io/client-go
@@ -17,11 +15,15 @@ import:
   version: master
 
 # crd-schema-gen
+  # TODO: we need to this to get nullable patch, but we will replace this with new repo soon.
+- package: k8s.io/apiextensions-apiserver
+  repo: https://github.com/openshift/kubernetes-apiextensions-apiserver
+  version: origin-4.1-kubernetes-1.13.4
 - package: sigs.k8s.io/controller-tools
-  version: 43466124052c1a1aa7d8fd33624b00bc111fb7cf
-  repo: https://github.com/openshift/kubernetes-sigs-controller-tools.git
+  repo: https://github.com/openshift/kubernetes-sigs-controller-tools
+  version: origin-4.1-kubernetes-1.13.4
 - package: k8s.io/gengo
-  version: 4242d8e6c5dba56827bb7bcf14ad11cda38f3991
+  version: e17681d19d3ac4837a019ece36c2a0ec31ffe985
 
 # sig-master - needed for file observer
 - package: github.com/sigma/go-inotify

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -172,7 +172,7 @@ func (b *ControllerBuilder) Run(config *unstructured.Unstructured, ctx context.C
 	}
 	controllerRef, err := events.GetControllerReferenceForCurrentPod(kubeClient, namespace, nil)
 	if err != nil {
-		panic(fmt.Sprintf("unable to obtain replicaset reference for events: %v", err))
+		klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 	}
 	eventRecorder := events.NewKubeRecorder(kubeClient.CoreV1().Events(namespace), b.componentName, controllerRef)
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_test.go
@@ -163,3 +163,24 @@ func TestGetControllerReferenceForCurrentPod(t *testing.T) {
 		t.Errorf("expected objectReference to be Deployment, got %q", objectReference.GroupVersionKind().String())
 	}
 }
+
+func TestGetControllerReferenceForCurrentPodFallbackNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	podNameEnvFunc = func() string {
+		return "test"
+	}
+
+	objectReference, err := GetControllerReferenceForCurrentPod(client, "test", nil)
+	if err == nil {
+		t.Fatalf("expected error: %v", err)
+	}
+
+	if objectReference.Name != "test" {
+		t.Errorf("expected objectReference name to be 'test', got %q", objectReference.Name)
+	}
+
+	if objectReference.GroupVersionKind().String() != "/v1, Kind=Namespace" {
+		t.Errorf("expected objectReference to be Namespace, got %q", objectReference.GroupVersionKind().String())
+	}
+}


### PR DESCRIPTION
testing https://github.com/openshift/library-go/pull/340

/hold