### PR TITLE
use a specified IP for localhost

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -137,6 +137,11 @@ func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Rec
 
 	// these are always present in the config because we mint and rotate them ourselves.
 	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
+		"names": []interface{}{
+			"localhost",
+			"127.0.0.1",
+			"::1",
+		},
 		"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 		"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"})
 	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -203,6 +203,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
 						map[string]interface{}{
+							"names":    []interface{}{"localhost", "127.0.0.1", "::1"},
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key",
 						},
@@ -239,6 +240,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
 						map[string]interface{}{
+							"names":    []interface{}{"localhost", "127.0.0.1", "::1"},
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key",
 						},
@@ -279,6 +281,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
 						map[string]interface{}{
+							"names":    []interface{}{"localhost", "127.0.0.1", "::1"},
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key",
 						},
@@ -321,6 +324,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
 						map[string]interface{}{
+							"names":    []interface{}{"localhost", "127.0.0.1", "::1"},
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key",
 						},
@@ -370,6 +374,7 @@ func TestObserveNamedCertificates(t *testing.T) {
 				"servingInfo": map[string]interface{}{
 					"namedCertificates": []interface{}{
 						map[string]interface{}{
+							"names":    []interface{}{"localhost", "127.0.0.1", "::1"},
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key",
 						},

--- a/test/e2e/user_certs_test.go
+++ b/test/e2e/user_certs_test.go
@@ -151,7 +151,7 @@ func TestNamedCertificates(t *testing.T) {
 		{
 			name:                 "Localhost 127.0.0.1",
 			serverName:           "127.0.0.1",
-			expectedSerialNumber: defaultServingCertSerialNumber,
+			expectedSerialNumber: localhostServingCertSerialNumber,
 		},
 		{
 			name:                 "LoadBalancerHostname",


### PR DESCRIPTION
IPs didn't appear to be discovered from the cert, let's see if it is properly used when directly specified.