### PR TITLE
Make kube-apiserver audit log permissions more restrictive on start

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -12,7 +12,7 @@ spec:
     - name: fix-audit-permissions
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
+      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/audit.log']
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -336,7 +336,7 @@ spec:
     - name: fix-audit-permissions
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
+      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/audit.log']
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir


### PR DESCRIPTION
While the directory permissions are limited on starting the
openshift-kube-apiserver pod; this also initiates the audit logs
permissions to a more secure 0600.

This makes the underlying library (lumberjack) reuse these permissions
throughout the deployment, instead of keeping using the 0644 which was
the default.

Note that the file permissions in the directory were already providing
protection from accessing those files. This merely promotes good
patterns for the log files.