### PR TITLE
manifests: label certificate manifests as managed

### DIFF
--- a/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: admin-kubeconfig-client-ca
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "admin-kubeconfig-ca-bundle.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: csr-controller-ca
   namespace: openshift-config-managed
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kubelet-client-ca-bundle.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-client-ca.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: initial-client-ca
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: initial-kube-apiserver-server-ca
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-sa-token-signing-certs.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: initial-sa-token-signing-certs
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "service-account.pub" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-temporary-kube-apiserver-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-temporary-kube-apiserver-client-ca.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: initial-temporary-client-ca
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
   namespace: openshift-kube-apiserver-operator
 data:
   ca-bundle.crt: |

--- a/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: node-bootstrap-client-ca
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": ca-bundle
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kube-ca.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/secret-aggregator-client-signer.yaml
+++ b/bindata/bootkube/manifests/secret-aggregator-client-signer.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: aggregator-client-signer
   namespace: openshift-kube-apiserver-operator
+  labels:
+    "auth.openshift.io/managed-certificate-type": signer
   annotations:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "aggregator-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "aggregator-signer.crt" | notAfter }}

--- a/bindata/bootkube/manifests/secret-control-plane-client-signer.yaml
+++ b/bindata/bootkube/manifests/secret-control-plane-client-signer.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: kube-control-plane-signer
   namespace: openshift-kube-apiserver-operator
+  labels:
+    "auth.openshift.io/managed-certificate-type": signer
   annotations:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-control-plane-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-control-plane-signer.crt" | notAfter }}

--- a/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
+++ b/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: initial-kubelet-client
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": target
 type: SecretTypeTLS
 data:
   tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
+++ b/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: initial-serving-cert
   namespace: openshift-config
+  labels:
+    "auth.openshift.io/managed-certificate-type": target
 type: SecretTypeTLS
 data:
   tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: loadbalancer-serving-signer
   namespace: openshift-kube-apiserver-operator
+  labels:
+    "auth.openshift.io/managed-certificate-type": signer
   annotations:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-lb-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-lb-signer.crt" | notAfter }}

--- a/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: localhost-serving-signer
   namespace: openshift-kube-apiserver-operator
+  labels:
+    "auth.openshift.io/managed-certificate-type": signer
   annotations:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | notAfter }}

--- a/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: service-network-serving-signer
   namespace: openshift-kube-apiserver-operator
+  labels:
+    "auth.openshift.io/managed-certificate-type": signer
   annotations:
     "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | notBefore }}
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | notAfter }}


### PR DESCRIPTION
This adds label to all certificates we get from the installer in bootstrap. It allows them to show up in prometheus (so we don't have to wait for the rotated certs to rotate) and also allows to query them in the system.