### PR TITLE
remove kube-ca certs from kas-o

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -14,9 +14,9 @@ kubeletClientInfo:
 serviceAccountPublicKeyFiles:
 - /etc/kubernetes/secrets/service-account.pub # origin 3.11: serviceaccounts.public.key
 servingInfo:
-  certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.server.crt
+  certFile: /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   clientCA: /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
-  keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.server.key
+  keyFile: /etc/kubernetes/secrets/kube-apiserver-service-network-server.key
   namedCertificates:
     - names:
       - "kubernetes"

--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-serving-ca.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: initial-kube-apiserver-server-ca
-  namespace: openshift-config
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "kube-ca.crt" | indent 4 }}
-

--- a/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-node-bootstrap-client-ca.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: node-bootstrap-client-ca
-  namespace: openshift-config
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "kube-ca.crt" | indent 4 }}
-

--- a/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
+++ b/bindata/bootkube/manifests/secret-initial-serving-cert.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: initial-serving-cert
-  namespace: openshift-config
-type: SecretTypeTLS
-data:
-  tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}
-  tls.key: {{ .Assets | load "apiserver.key" | base64 }}

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -96,9 +96,9 @@ servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.crt
+  certFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.key
+  keyFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null
   requestTimeoutSeconds: 3600

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -63,15 +63,6 @@ func NewResourceSyncController(
 		return nil, err
 	}
 
-	// this secret contains the serving cert/key pair for the kube-apiserver
-	// TODO this will logically become two secrets: one for the ELB/default, another for the loopback and service network
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "serving-cert"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-serving-cert"},
-	); err != nil {
-		return nil, err
-	}
-
 	// this ca bundle contains certs to verify the aggregator.  We copy it from the shared location to here.
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "aggregator-client-ca"},

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -279,8 +279,6 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		// this is from the installer and contains the value to verify the admin.kubeconfig user
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
 		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images
-		// TODO the MCO should take care of rotating this.
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "node-bootstrap-client-ca"},
 		// this is from kube-controller-manager and indicates the ca-bundle.crt to verify their signatures (kubelet client certs)
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
@@ -301,8 +299,6 @@ func manageKubeAPIServerCABundle(lister corev1listers.ConfigMapLister, client co
 		lister,
 		nil, // TODO remove this
 		nil, // TODO remove this
-		// this is from the installer and contains the value they think we should have
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-kube-apiserver-server-ca"},
 		// this bundle is what this operator uses to mint loadbalancers certs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "loadbalancer-serving-ca"},
 		// this bundle is what this operator uses to mint localhost certs

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -174,9 +174,9 @@ servicesSubnet: 10.3.0.0/16 # ServiceCIDR
 servingInfo:
   bindAddress: 0.0.0.0:6443
   bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.crt
+  certFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
   clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-certs/secrets/serving-cert/tls.key
+  keyFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
   maxRequestsInFlight: 1200
   namedCertificates: null
   requestTimeoutSeconds: 3600


### PR DESCRIPTION
The kube-ca is nearly dead.  We can switch our serving-certs now that the kubelets/MCO are updated.

/assign @mfojtik 