### PR TITLE
stop trying to use generation without observedgeneration

### DIFF
--- a/test/library/library.go
+++ b/test/library/library.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	WaitPollInterval = time.Second
-	WaitPollTimeout  = 10 * time.Minute
+	WaitPollTimeout  = 5 * time.Minute
 )
 
 // GenerateNameForTest generates a name of the form `prefix + test name + random string` that


### PR DESCRIPTION
We never set observedgeneration (oops), which means that trying to use generation is inexact at best.  I think we're rolling out and somehow not seeing the transitions.  This reduces the precision of the check, but may improve stability.