### PR TITLE
re-enable SNI e2e tests

### DIFF
--- a/test/e2e/user_certs_test.go
+++ b/test/e2e/user_certs_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestNamedCertificates(t *testing.T) {
-	t.Skip("fails proper detection of change")
 
 	// create a root certificate authority crypto materials
 	rootCA := test.NewCertificateAuthorityCertificate(t, nil)


### PR DESCRIPTION
Re-enable the SNI/Named Certificates test, providing an alternate method of waiting for the configuration to take effect.