### PR TITLE
remove resources we no longer use

### DIFF
--- a/bindata/bootkube/manifests/config.apiserver.yaml
+++ b/bindata/bootkube/manifests/config.apiserver.yaml
@@ -1,5 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: APIServer
-metadata:
-  name: cluster
-spec: {}

--- a/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
@@ -1,3 +1,4 @@
+# this matches what the installer uses to create the admin.kubeconfig.  We must always honor this as a client or the admin.kubeconfig will become invalid
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
@@ -1,3 +1,4 @@
+# this is written by the kcm-o, but we initialize here to cleanly handle the adoption case
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bindata/bootkube/manifests/configmap-initial-kube-apiserver-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-kube-apiserver-client-ca.yaml
@@ -1,9 +1,0 @@
-# the MCO appears to be relying on this in some weird way that breaks if you ever update it.
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: initial-client-ca
-  namespace: openshift-config
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "kube-apiserver-complete-server-ca-bundle.crt" | indent 4 }}

--- a/bindata/bootkube/manifests/configmap-initial-temporary-kube-apiserver-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-initial-temporary-kube-apiserver-client-ca.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: initial-temporary-client-ca
-  namespace: openshift-kube-apiserver-operator
-data:
-  ca-bundle.crt: |
-    {{ .Assets | load "kube-apiserver-complete-client-ca-bundle.crt" | indent 4 }}
-

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -271,8 +271,6 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
 		lister,
-		// this is from the installer and contains the value they think we should have
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "initial-temporary-client-ca"},
 		// this is from the installer and contains the value to verify the admin.kubeconfig user
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
 		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images


### PR DESCRIPTION
Multiple refactors have led to confusing cruft that has a long life on our clusters.  This removes that we don't use or honor

