### PR TITLE
Add audit policy ConfigMap observer

### DIFF
--- a/pkg/operator/configobservation/audit/observe_audit_policy.go
+++ b/pkg/operator/configobservation/audit/observe_audit_policy.go
@@ -1,0 +1,74 @@
+package audit
+
+import (
+	gojson "encoding/json"
+	"fmt"
+
+	yaml2 "sigs.k8s.io/yaml"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+)
+
+const policyConfigMapName = "audit-policy"
+
+// ObserveAuditPolicy observes the openshift-config/audit-policy ConfigMap and merges it into the kube-apiserver config.
+func ObserveAuditPolicy(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	errs := []error{}
+	prevObservedConfig := map[string]interface{}{}
+
+	// copy non-empty .auditConfig.policyConfiguration from existingConfig to prevObservedConfig
+	policyPath := []string{"auditConfig", "policyConfiguration"}
+	existingPolicy, _, err := unstructured.NestedFieldNoCopy(existingConfig, policyPath...)
+	if err != nil {
+		return prevObservedConfig, append(errs, err)
+	}
+	if existingPolicy != nil {
+		if err := unstructured.SetNestedField(prevObservedConfig, existingPolicy, policyPath...); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	observedConfig := map[string]interface{}{}
+
+	// get optional openshift-config/audit-policy file, fallback to default config (i.e. observed config unset)
+	policyConfigMap, err := listers.ConfigmapLister.ConfigMaps(operatorclient.GlobalUserSpecifiedConfigNamespace).Get(policyConfigMapName)
+	switch {
+	case errors.IsNotFound(err):
+		// switch back to default policy by leaving observedConfig empty
+	case err != nil:
+		// we had an error, return what we had before and exit. this really shouldn't happen
+		return prevObservedConfig, append(errs, err)
+	case len(policyConfigMap.Data["policy.yaml"]) > 0:
+		// TODO: maybe verify config here
+		var newPolicy interface{}
+		if bs, err := yaml2.YAMLToJSON([]byte(policyConfigMap.Data["policy.yaml"])); err != nil {
+			return prevObservedConfig, append(errs, fmt.Errorf("invalid policy.yaml file in ConfigMap %s/%s: %v", operatorclient.GlobalUserSpecifiedConfigNamespace, policyConfigMapName, err))
+		} else if err := gojson.Unmarshal(bs, &newPolicy); err != nil {
+			return prevObservedConfig, append(errs, fmt.Errorf("invalid policy.yaml file in ConfigMap %s/%s: %v", operatorclient.GlobalUserSpecifiedConfigNamespace, policyConfigMapName, err))
+		}
+
+		if newPolicy != nil {
+			if err := unstructured.SetNestedField(observedConfig, newPolicy, policyPath...); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	default:
+		// we had an error, return what we had before and exit. this really shouldn't happen
+		return prevObservedConfig, append(errs, fmt.Errorf("no policy.yaml file found in ConfigMap %s/%s", operatorclient.GlobalUserSpecifiedConfigNamespace, policyConfigMapName))
+	}
+
+	if !equality.Semantic.DeepEqual(existingPolicy, observedConfig) && len(errs) == 0 {
+		recorder.Eventf("ObserveAuditPolicy", "auditConfig.policyConfiguration changed to new content of %s/%s ConfigMap", operatorclient.GlobalUserSpecifiedConfigNamespace, policyConfigMapName)
+	}
+
+	return observedConfig, errs
+}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,18 +1,19 @@
 package configobservercontroller
 
 import (
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"k8s.io/client-go/tools/cache"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/apiserver"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/audit"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/etcd"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/images"
@@ -82,6 +83,7 @@ func NewConfigObserver(
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,
+			audit.ObserveAuditPolicy,
 		),
 	}
 

--- a/pkg/operator/targetconfigcontroller/config_restriction.go
+++ b/pkg/operator/targetconfigcontroller/config_restriction.go
@@ -3,3 +3,7 @@ package targetconfigcontroller
 func RemoveConfig(dst, src interface{}, currentPath string) (interface{}, error) {
 	return dst, nil
 }
+
+func ReplaceConfig(dst, src interface{}, currentPath string) (interface{}, error) {
+	return src, nil
+}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -208,7 +208,8 @@ func manageKubeAPIServerConfig(client coreclientv1.ConfigMapsGetter, recorder ev
 	configMap := resourceread.ReadConfigMapV1OrDie(v311_00_assets.MustAsset("v3.11.0/kube-apiserver/cm.yaml"))
 	defaultConfig := v311_00_assets.MustAsset("v3.11.0/kube-apiserver/defaultconfig.yaml")
 	specialMergeRules := map[string]resourcemerge.MergeFunc{
-		".oauthConfig": RemoveConfig,
+		".oauthConfig":                     RemoveConfig,
+		".auditConfig.policyConfiguration": ReplaceConfig,
 	}
 
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", specialMergeRules, defaultConfig, operatorConfig.Spec.ObservedConfig.Raw, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)


### PR DESCRIPTION
This adds an observer of the openshift-config/audit-policy ConfigMap. It is supposed to contain a audit.k8s.io/v1beta1.Policy file. It is syntactically validated to be valid YAML, not that it can be decoded into a Policy struct (the API server will do that).

This PR does not add central configuration of other settings like audit webhooks.