### PR TITLE
squash init containers to one

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -9,21 +9,18 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: fix-audit-permissions
+    - name: setup
       terminationMessagePolicy: FallbackToLogsOnError
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
-    - name: wait-for-host-port
-      terminationMessagePolicy: FallbackToLogsOnError
-      image: ${IMAGE}
-      imagePullPolicy: IfNotPresent
-      command: ['/usr/bin/timeout', '105', '/bin/bash', '-c'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
+      command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
       args:
       - |
+        echo -n "Fixing audit permissions."
+        chmod 0700 /var/log/kube-apiserver
         echo -n "Waiting for port :6443 to be released."
         while [ -n "$(lsof -ni :6443)" ]; do
           echo -n "."

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -335,21 +335,18 @@ metadata:
     revision: "REVISION"
 spec:
   initContainers:
-    - name: fix-audit-permissions
+    - name: setup
       terminationMessagePolicy: FallbackToLogsOnError
       image: ${IMAGE}
       imagePullPolicy: IfNotPresent
-      command: ['/bin/sh', '-c', 'chmod 0700 /var/log/kube-apiserver']
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
-    - name: wait-for-host-port
-      terminationMessagePolicy: FallbackToLogsOnError
-      image: ${IMAGE}
-      imagePullPolicy: IfNotPresent
-      command: ['/usr/bin/timeout', '105', '/bin/bash', '-c'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
+      command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
       args:
       - |
+        echo -n "Fixing audit permissions."
+        chmod 0700 /var/log/kube-apiserver
         echo -n "Waiting for port :6443 to be released."
         while [ -n "$(lsof -ni :6443)" ]; do
           echo -n "."


### PR DESCRIPTION
Speed up starting the kube apiserver container by not running 2 init containers but only run 1 container.