### PR TITLE
certoperator: fix incorrect use of infrastructure.config.openshift.io API

### DIFF
--- a/pkg/operator/certrotationcontroller/externalloadbalancer.go
+++ b/pkg/operator/certrotationcontroller/externalloadbalancer.go
@@ -18,6 +18,7 @@ func (c *CertRotationController) syncExternalLoadBalancerHostnames() error {
 	hostname := infrastructureConfig.Status.APIServerURL
 	hostname = strings.Replace(hostname, "https://", "", 1)
 	hostname = hostname[0:strings.LastIndex(hostname, ":")]
+	hostname = strings.Replace(hostname, "api-int.", "api.", 1)
 
 	klog.V(2).Infof("syncing external loadbalancer hostnames: %v", hostname)
 	c.externalLoadBalancer.setHostnames([]string{hostname})

--- a/pkg/operator/certrotationcontroller/internalloadbalancer.go
+++ b/pkg/operator/certrotationcontroller/internalloadbalancer.go
@@ -18,7 +18,6 @@ func (c *CertRotationController) syncInternalLoadBalancerHostnames() error {
 	hostname := infrastructureConfig.Status.APIServerURL
 	hostname = strings.Replace(hostname, "https://", "", 1)
 	hostname = hostname[0:strings.LastIndex(hostname, ":")]
-	hostname = strings.Replace(hostname, "api.", "api-int.", 1)
 
 	klog.V(2).Infof("syncing internal loadbalancer hostnames: %v", hostname)
 	c.internalLoadBalancer.setHostnames([]string{hostname})


### PR DESCRIPTION
The `.status.apiServerURL` [1] states the this value can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.
Therefore, this will be set to `api-int.$cluster_domain` as that is URL that should be used by the LB consumers of apiserver.

currently the external serving cert controller is using this value to generate the certificate, when it should be the one doing the replace magic from [2] and not the internal serving cert controller and which causes wrong certificate generation
when we finally switch to `api-int` [3]:

```console
$ oc get secrets -n openshift-kube-apiserver external-loadbalancer-serving-certkey -oyaml
apiVersion: v1
data:
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYekNDQWtlZ0F3SUJBZ0lJYzJwVFVHSWw3Mmd3RFFZSktvWklodmNOQVFFTEJRQXdOekVTTUJBR0ExVUUKQ3hNSmIzQmxibk5vYVdaME1TRXdId1lEVlFRREV4aHJkV0psTFdGd2FYTmxjblpsY2kxc1lpMXphV2R1WlhJdwpIaGNOTVRrd05ERTNNak0xT0RNeVdoY05NVGt3TlRFM01qTTFPRE16V2pBbk1TVXdJd1lEVlFRREV4eGhjR2t0CmFXNTBMbUZrWVdocGVXRXRNQzUwZEM1MFpYTjBhVzVuTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEEKTUlJQkNnS0NBUUVBb293WHNVMW51TWRMSkhneUVWNTZXZmpTSDVCdmpqQ3c4eGJWYTVKNlRPUDhOTWVPaEtuOAowRVF6VDYzTTdQdTFtdlhqVmJ5T1JlcWZhL3Y4ZXJjdzIwS1liUDY3QXoyY2JrUXplUmpuVUVsVC8yU2hYa1E2CkVhS3Y4VGM4dlM3SFRhYkZTZVRmTW5RWHhNT0FOUDRyTW51NmpLUmw3aC90WU5Jck1xZFB3YUJaK0UyOWpBSW0KR0VaSUdCWDJWLy9Vb0hyK05vM2hHL0c1Ykdua3JhaUdUYkhTSjdQcExoNGJFYmFPTWlJWmR3K215WEtvS2ZScQo5SkVKd3llTDNueUNlQVQ1Y0tDa0NGZTR0eDQvcGMweTdQYmtHTmJzMG8yaHpMTkhHdTBNYVgwV2NYZkdObnhvCno4Y1p0S0ZGNjdaT25ZSGRtdGErVStjNWllcHZLTkJzY1FJREFRQUJvMzh3ZlRBT0JnTlZIUThCQWY4RUJBTUMKQmFBd0V3WURWUjBsQkF3d0NnWUlLd1lCQlFVSEF3RXdEQVlEVlIwVEFRSC9CQUl3QURBZkJnTlZIU01FR0RBVwpnQlNFQ09ZaFdUNDZObTdCOGQ0cHdYbEpQUXpDa3pBbkJnTlZIUkVFSURBZWdoeGhjR2t0YVc1MExtRmtZV2hwCmVXRXRNQzUwZEM1MFpYTjBhVzVuTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCbUVIOXQ5dGZDOXBMSVVXQUUKakE0dHBsZXpLVi9LR0ppZVh1dW5Td0NKU0FiNUcyclBMallVRGRRa0pJeks4cHdtNW1oMys2Vzd3bEo4ZVhWaAptVVJWT1RHNUlKQkkzdk1RT0hwWkt6YjY3a0ZZajVleSs3U2FmNjdKZzJ2L0lxS09QdmpVeU9VcUd6ckFWanI5Cm5FM2g3cVNwQXRYZk50Mk5IOGxuMTVKNFlsN1hhZkd6cGppUVZ2UVdBUHpoSnYxc2ZRVElpc0lSb2FvK2ZCUEcKRmtLcDUxRXRvc0xvbmtYRFZ5UGdzQVR4MW5jU2RvRE94WWhueXJteWEyT0Q2MVlMSDloalpjY2lENzBMdTVnOApFcUhrenhCL1F3S0JzbFdDUkNxYktpWkRVd0UvcWtEMmVST0NiS0hLckVKME8wWEVHVCtNRk1wU1RYcWIyaDA5CjhUV3IKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQotLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS0KTUlJRE1qQ0NBaHFnQXdJQkFnSUliRHFHUFpCdlk0a3dEUVlKS29aSWh2Y05BUUVMQlFBd056RVNNQkFHQTFVRQpDeE1KYjNCbGJuTm9hV1owTVNFd0h3WURWUVFERXhocmRXSmxMV0Z3YVhObGNuWmxjaTFzWWkxemFXZHVaWEl3CkhoY05NVGt3TkRFM01qTTBPREExV2hjTk1qa3dOREUwTWpNME9EQTFXakEzTVJJd0VBWURWUVFMRXdsdmNHVnUKYzJocFpuUXhJVEFmQmdOVkJBTVRHR3QxWW1VdFlYQnBjMlZ5ZG1WeUxXeGlMWE5wWjI1bGNqQ0NBU0l3RFFZSgpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPL1E0b3hYTjVvYkJ4WEptR3ZuOWkrRWpJRzJWN0RxCnFrTFFqMHU5STdnUDFMV3dEUE4rcUtFRWwzZnJjTGl2d0EvdTd5MlJ2Z0gxcDByRmFEUmhPYnBDWHU0VVN2aUYKLzVJZjl3dzFvMGlDRlNCczFmQm9GMERTNE1kMWc3cnhCVzVlTDlNVllsMGU1QzB0YkNVc3BWamkyNnR5K0dTWgpKNlRYVS9idEErV044STNnOUhQUHRZcnRLVVpycnBCUFpTWDNjZWxIWDlDczRFaDdFdXdrRFR6T2N4VGRsMUdoCjB4U1V5bE9lOU92eVVNVWM3SHpOS29QMGlRZE9scXNwL0ZvNjFwdHBOM0xUS1FCWUU5VUR2SUNFZ1NscXlzWFMKR3I1UzU0cFVMYzdva21LaXVLc0lkK0ZYWDd5STFGQTY1VVFUZDJOc2sweTFJNTF4VGp3LzN3OENBd0VBQWFOQwpNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGSVFJCjVpRlpQam8yYnNIeDNpbkJlVWs5RE1LVE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ1dSdVpTaURaYjQ4NzcKNmZhVWpvQTg5eld5Rm15L0VodTBURFpSSTFTSElaQjhmM1FINGlMdEhzMU53VGZDcU5XSTNOeFNxQ0Ntdmx6ZAp0ZGppVjdPUkxRZjc3WVVWdU9ZclF2M0RuK2ozcmZ1dCtoSzMyM3hjTDdYbXBpRnRIUXhac2NQZ2JqaUd1dS9XCmdhYlZBOXF3MWUxQit3b25UWlY0YWM1bjJ5N1QxbzdoeWE3WnY5RWJ5RFp3cnJPN2NBSmJjWS9pUDJnM0pnMG4KS0hJT2FVSnRZZjF0RDNCSWhzWVIzL0tQVStLU0lyQ2R3Y0ptbXYyZ1V5eGJLTzlFb2QyU2R0RDRJZEVKVTNobQpFUjhkcmFFK3Y5MzJHVHZYWWYwRUFOdHExam5ycFRxajNIVUFMajVZTm1UdE5DQTVEdHhWa2xaZ0I4RkJpdS9NCitjNmJ3UjJVCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
  tls.key: ....
kind: Secret
metadata:
  annotations:
    auth.openshift.io/certificate-hostnames: api-int.adahiya-0.tt.testing
    auth.openshift.io/certificate-issuer: kube-apiserver-lb-signer
    auth.openshift.io/certificate-not-after: 2019-05-17T23:58:33Z
    auth.openshift.io/certificate-not-before: 2019-04-17T23:58:32Z
  creationTimestamp: 2019-04-17T23:58:37Z
  labels:
    auth.openshift.io/managed-certificate-type: target
  name: external-loadbalancer-serving-certkey
  namespace: openshift-kube-apiserver
  resourceVersion: "2560"
  selfLink: /api/v1/namespaces/openshift-kube-apiserver/secrets/external-loadbalancer-serving-certkey
  uid: b783479c-616c-11e9-8bba-52fdfc072182
type: kubernetes.io/tls

$ xclip -sel c -o | base64 -d | openssl x509 -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 8316551266602184552 (0x736a53506225ef68)
    Signature Algorithm: sha256WithRSAEncryption
        Issuer: OU = openshift, CN = kube-apiserver-lb-signer
        Validity
            Not Before: Apr 17 23:58:32 2019 GMT
            Not After : May 17 23:58:33 2019 GMT
        Subject: CN = api-int.adahiya-0.tt.testing
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Authority Key Identifier:
                keyid:84:08:E6:21:59:3E:3A:36:6E:C1:F1:DE:29:C1:79:49:3D:0C:C2:93
            X509v3 Subject Alternative Name:
                DNS:api-int.adahiya-0.tt.testing
```

This commit moves the replace magic [2] from internal to external serving cert controller.

[1]: https://github.com/openshift/api/blob/13b403bfb6ce84ddc053bd3b401b5d67bf175efa/config/v1/types_infrastructure.go#L55-L58
[2]: https://github.com/openshift/cluster-kube-apiserver-operator/pull/405
[3]: https://github.com/openshift/installer/pull/1633

/cc @sjenning 