### PR TITLE
generate and maintain our own kube-apiserver-to-kubelet-signer

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -9,10 +9,10 @@ authConfig:
     clientCA: /etc/kubernetes/secrets/aggregator-signer.crt
 kubeletClientInfo:
   ca: /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
-  certFile: /etc/kubernetes/secrets/apiserver.crt # origin 3.11: master.kubelet-client.crt
-  keyFile: /etc/kubernetes/secrets/apiserver.key # origin 3.11: master.kubelet-client.key
+  certFile: /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.crt
+  keyFile: /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.key
 serviceAccountPublicKeyFiles:
-- /etc/kubernetes/secrets/service-account.pub # origin 3.11: serviceaccounts.public.key
+- /etc/kubernetes/secrets/service-account.pub
 servingInfo:
   certFile: /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   clientCA: /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
@@ -36,9 +36,9 @@ servingInfo:
     - certFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.crt
       keyFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.key
 storageConfig:
-  ca: /etc/kubernetes/secrets/{{.EtcdServingCA}} # origin 3.11: ca.crt
-  certFile: /etc/kubernetes/secrets/etcd-client.crt # origin 3.11: master.etcd-client.crt
-  keyFile: /etc/kubernetes/secrets/etcd-client.key # origin 3.11: master.etcd-client.key
+  ca: /etc/kubernetes/secrets/{{.EtcdServingCA}}
+  certFile: /etc/kubernetes/secrets/etcd-client.crt
+  keyFile: /etc/kubernetes/secrets/etcd-client.key
   urls: {{range .EtcdServerURLs}}
   - {{.}}{{end}}
 {{if .ServiceCIDR | len | ne 0}}

--- a/bindata/bootkube/manifests/configmap-sa-token-signing-certs.yaml
+++ b/bindata/bootkube/manifests/configmap-sa-token-signing-certs.yaml
@@ -1,3 +1,4 @@
+# this is written by the kcm-o, but we initialize here to cleanly handle the adoption case
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
+++ b/bindata/bootkube/manifests/secret-initial-kubelet-client.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: initial-kubelet-client
-  namespace: openshift-config
-type: SecretTypeTLS
-data:
-  tls.crt: {{ .Assets | load "apiserver.crt" | base64 }}
-  tls.key: {{ .Assets | load "apiserver.key" | base64 }}

--- a/bindata/bootkube/manifests/secret-kube-apiserver-to-kubelet-signer.yaml
+++ b/bindata/bootkube/manifests/secret-kube-apiserver-to-kubelet-signer.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-apiserver-to-kubelet-signer
+  namespace: openshift-kube-apiserver-operator
+  annotations:
+    "auth.openshift.io/certificate-not-before": {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | notBefore }}
+    "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | notAfter }}
+    "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | issuer }}
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | base64 }}
+  tls.key: {{ .Assets | load "kube-apiserver-to-kubelet-signer.key" | base64 }}

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -46,15 +46,6 @@ func NewResourceSyncController(
 		return nil, err
 	}
 
-	// this secret contains the client cert/key pair used to communicate to kubelets
-	// TODO this needs to rotate and we will consume it as input from the kubelet operator
-	if err := resourceSyncController.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kubelet-client"},
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "initial-kubelet-client"},
-	); err != nil {
-		return nil, err
-	}
-
 	// this ca bundle contains certs to verify the aggregator.  We copy it from the shared location to here.
 	if err := resourceSyncController.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "aggregator-client-ca"},

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -275,6 +275,8 @@ func manageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images
 		// this is from kube-controller-manager and indicates the ca-bundle.crt to verify their signatures (kubelet client certs)
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "csr-controller-ca"},
+		// this is from the installer and contains the value to verify the kube-apiserver communicating to the kubelet
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "kube-apiserver-to-kubelet-client-ca"},
 		// this bundle is what this operator uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "kube-control-plane-signer-ca"},
 		// this bundle is what a user uses to mint new client certs it directly manages


### PR DESCRIPTION
This removes the final kube-ca cert for real this time.

/hold

holding so that I can check to be sure we successfully collect pod logs