### PR TITLE
fix flaky e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
 .PHONY: test-e2e
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
+test-e2e: GO_TEST_FLAGS += -v
 test-e2e: test-unit
 
 update-codegen-crds:

--- a/test/library/cluster_operator.go
+++ b/test/library/cluster_operator.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,10 +19,11 @@ func WaitForKubeAPIServerClusterOperatorAvailableNotProgressingNotDegraded(t *te
 	err := wait.Poll(WaitPollInterval, WaitPollTimeout, func() (bool, error) {
 		clusterOperator, err := client.ClusterOperators().Get("kube-apiserver", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			t.Logf("ClusterOperator/kube-apiserver does not yet exist.")
+			fmt.Println("ClusterOperator/kube-apiserver does not yet exist.")
 			return false, nil
 		}
 		if err != nil {
+			fmt.Println("Unable to retrieve ClusterOperator/kube-apiserver:", err)
 			return false, err
 		}
 		conditions := clusterOperator.Status.Conditions
@@ -29,7 +31,7 @@ func WaitForKubeAPIServerClusterOperatorAvailableNotProgressingNotDegraded(t *te
 		notProgressing := clusteroperatorhelpers.IsStatusConditionPresentAndEqual(conditions, configv1.OperatorProgressing, configv1.ConditionFalse)
 		notDegraded := clusteroperatorhelpers.IsStatusConditionPresentAndEqual(conditions, configv1.OperatorDegraded, configv1.ConditionFalse)
 		done := available && notProgressing && notDegraded
-		t.Logf("ClusterOperator/kube-apiserver: Available: %v  Progressing: %v  Degraded: %v", available, !notProgressing, !notDegraded)
+		fmt.Printf("ClusterOperator/kube-apiserver: Available: %v  Progressing: %v  Degraded: %v\n", available, !notProgressing, !notDegraded)
 		return done, nil
 	})
 	if err != nil {


### PR DESCRIPTION
The `TestNamedCertificates` e2e test occasionally timeouts waiting for changes to take effect. This PR works around that by:
* looping on the first test until it passes, showing that at least one kube-apiserver is running with the configuration to be tested
* Then looping on each subsequent test until it passes (just in case it takes a couple of tries to hit the updated kube-apiserver). 