### PR TITLE
update deployment for upgrade and install-gather

### DIFF
--- a/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_06_deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: kube-apiserver-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: kube-apiserver-operator
@@ -18,7 +20,7 @@ spec:
     spec:
       serviceAccountName: kube-apiserver-operator
       containers:
-      - name: operator
+      - name: kube-apiserver-operator
         image: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
for upgrades, we need to have deployment strategy recreate on our operators in case they are ever scaled. We don't want to ever get a lease for new and later get a lease for old.

We need a distinct operator container to make install-gather happy at the moment.

@openshift/sig-master