### PR TITLE
Increase minimum-shutdown-duration by 10s to 45s

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -45,7 +45,7 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 110 # bit more than 45s (minimal termination period) + 60s (apiserver graceful termination)
   volumes:
   - hostPath:
       path: {{ .SecretsHostPath }}

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -30,7 +30,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   minimal-shutdown-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  - 45s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
 auditConfig:

--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -88,7 +88,7 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 110 # bit more than 45s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -107,7 +107,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   minimal-shutdown-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  - 45s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
 auditConfig:
@@ -390,7 +390,7 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 110 # bit more than 45s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:


### PR DESCRIPTION
Rebase of https://github.com/openshift/cluster-kube-apiserver-operator/pull/412