### PR TITLE
bindata: add STATIC_POD_VERSION variable to kube-apiserver pod

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/pod.yaml
@@ -61,6 +61,13 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
+        value: REVISION
   - name: kube-apiserver-cert-syncer-REVISION
     env:
     - name: POD_NAME

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -363,6 +363,13 @@ spec:
         path: healthz
       initialDelaySeconds: 10
       timeoutSeconds: 10
+    env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
+        value: REVISION
   - name: kube-apiserver-cert-syncer-REVISION
     env:
     - name: POD_NAME


### PR DESCRIPTION
So inside apiserver we know which revision we run now for the sake of logging.