### PR TITLE
Add node-selector to namespace

### DIFF
--- a/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   name: openshift-kube-apiserver
   labels:
     openshift.io/run-level: "0"

--- a/bindata/bootkube/manifests/00_openshift-kube-apiserver-operator-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-apiserver-operator-ns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/bindata/v3.11.0/kube-apiserver/ns.yaml
+++ b/bindata/v3.11.0/kube-apiserver/ns.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-kube-apiserver
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_10_kube-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_10_kube-apiserver-operator_00_namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -255,6 +255,8 @@ var _v3110KubeApiserverNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-kube-apiserver
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
 `)


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR.

/cc @deads2k @sjenning 