### PR TITLE
Revision hotlooping e2e test

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,15 +1,22 @@
 package e2e
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	operatorversionedclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
 
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
 )
 
@@ -36,4 +43,83 @@ func TestOperandImageVersion(t *testing.T) {
 		}
 	}
 	require.Fail(t, "operator kube-apiserver image version not found")
+}
+
+func TestRevisionLimits(t *testing.T) {
+	kubeConfig, err := test.NewClientConfigForTest()
+	require.NoError(t, err)
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	operatorConfigClient, err := operatorversionedclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	operatorConfigInformers := operatorv1informers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
+	operatorClient := &operatorclient.OperatorClient{
+		Informers: operatorConfigInformers,
+		Client:    operatorConfigClient.OperatorV1(),
+	}
+
+	// Get current revision limits
+	operatorSpec, _, _, err := operatorClient.GetStaticPodOperatorStateWithQuorum()
+	require.NoError(t, err)
+
+	totalRevisionLimit := operatorSpec.SucceededRevisionLimit + operatorSpec.FailedRevisionLimit
+	if operatorSpec.SucceededRevisionLimit == 0 {
+		totalRevisionLimit += 5
+	}
+	if operatorSpec.FailedRevisionLimit == 0 {
+		totalRevisionLimit += 5
+	}
+
+	revisions, err := getRevisionStatuses(kubeClient)
+	require.NoError(t, err)
+
+	// Check if revisions are being quickly created to test for operator hotlooping
+	changes := 0
+	pollsWithoutChanges := 0
+	lastRevisionCount := len(revisions)
+	err = wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		newRevisions, err := getRevisionStatuses(kubeClient)
+		require.NoError(t, err)
+
+		// If there are more revisions than the total allowed Failed and Succeeded revisions, then there must be some that
+		// are InProgress or Unknown (since these do not count toward failed or succeeded), which could indicate zombie revisions.
+		// Check total+1 to account for possibly a current new revision that just hasn't pruned off the oldest one yet.
+		if len(newRevisions) > int(totalRevisionLimit)+1 {
+			t.Errorf("more revisions (%v) than total allowed (%v): %+v", len(revisions), totalRevisionLimit, revisions)
+		}
+
+		// No revisions in the last 30 seconds probably means we're not rapidly creating new ones and can return
+		if len(newRevisions)-lastRevisionCount == 0 {
+			pollsWithoutChanges += 1
+			if pollsWithoutChanges >= 30 {
+				return true, nil
+			}
+		} else {
+			pollsWithoutChanges = 0
+		}
+		changes += len(newRevisions) - lastRevisionCount
+		if changes >= 20 {
+			return true, fmt.Errorf("too many new revisions created, possible hotlooping detected")
+		}
+		lastRevisionCount = len(newRevisions)
+		return false, nil
+	})
+	require.NoError(t, err)
+}
+
+func getRevisionStatuses(kubeClient *kubernetes.Clientset) (map[string]string, error) {
+	configMaps, err := kubeClient.CoreV1().ConfigMaps(operatorclient.TargetNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return map[string]string{}, err
+	}
+	revisions := map[string]string{}
+	for _, configMap := range configMaps.Items {
+		if !strings.HasPrefix(configMap.Name, "revision-status-") {
+			continue
+		}
+		if revision, ok := configMap.Data["revision"]; ok {
+			revisions[revision] = configMap.Data["status"]
+		}
+	}
+	return revisions, nil
 }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1699471

When operators hotloop creating new revisions, old revisions get their status stuck `InProgress` which doesn't count them toward the Failed/Succeeded revision limits, allowing revision counts to get very high. This tries to check a couple things:

1. That the revision count isn't higher than the sum of the failed/succeeded limits. This would indicate InProgress revisions (of which there shouldn't ever be more than 1)
2. That revisions aren't being rapidly created, by polling and tracking new revisions created. 30 seconds or so of no new revisions is probably good enough to see that we're not currently hotlooping
3. If 20 revisions have been created, we've got too much

`#2` and `#3` are kind of redundant, so if either one is preferred we can remove the other.

Any feedback on this approach appreciated. If this goes through we can work on adding similar tests to other operators