### PR TITLE
move SCC initialization to kas-o

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.json
@@ -1,0 +1,49 @@
+{
+  "allowHostDirVolumePlugin": false,
+  "allowHostIPC": false,
+  "allowHostNetwork": false,
+  "allowHostPID": false,
+  "allowHostPorts": false,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "RunAsAny"
+  },
+  "groups": [
+    "system:cluster-admins"
+  ],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID."
+    },
+    "creationTimestamp": null,
+    "name": "anyuid"
+  },
+  "priority": 10,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "MKNOD"
+  ],
+  "runAsUser": {
+    "type": "RunAsAny"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.json
@@ -1,0 +1,51 @@
+{
+  "allowHostDirVolumePlugin": true,
+  "allowHostIPC": true,
+  "allowHostNetwork": true,
+  "allowHostPID": true,
+  "allowHostPorts": true,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "MustRunAs"
+  },
+  "groups": [],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "hostaccess allows access to all host namespaces but still requires pods to be run with a UID and SELinux context that are allocated to the namespace. WARNING: this SCC allows host access to namespaces, file systems, and PIDS.  It should only be used by trusted pods.  Grant with caution."
+    },
+    "creationTimestamp": null,
+    "name": "hostaccess"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "KILL",
+    "MKNOD",
+    "SETUID",
+    "SETGID"
+  ],
+  "runAsUser": {
+    "type": "MustRunAsRange"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "hostPath",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.json
@@ -1,0 +1,51 @@
+{
+  "allowHostDirVolumePlugin": true,
+  "allowHostIPC": false,
+  "allowHostNetwork": false,
+  "allowHostPID": false,
+  "allowHostPorts": false,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "RunAsAny"
+  },
+  "groups": [],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "hostmount-anyuid provides all the features of the\nrestricted SCC but allows host mounts and any UID by a pod.  This is primarily\nused by the persistent volume recycler. WARNING: this SCC allows host file\nsystem access as any UID, including UID 0.  Grant with caution."
+    },
+    "creationTimestamp": null,
+    "name": "hostmount-anyuid"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "MKNOD"
+  ],
+  "runAsUser": {
+    "type": "RunAsAny"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [
+    "system:serviceaccount:openshift-infra:pv-recycler-controller"
+  ],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "hostPath",
+    "nfs",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.json
@@ -1,0 +1,50 @@
+{
+  "allowHostDirVolumePlugin": false,
+  "allowHostIPC": false,
+  "allowHostNetwork": true,
+  "allowHostPID": false,
+  "allowHostPorts": true,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "MustRunAs"
+  },
+  "groups": [],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "hostnetwork allows using host networking and host ports but still requires pods to be run with a UID and SELinux context that are allocated to the namespace."
+    },
+    "creationTimestamp": null,
+    "name": "hostnetwork"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "KILL",
+    "MKNOD",
+    "SETUID",
+    "SETGID"
+  ],
+  "runAsUser": {
+    "type": "MustRunAsRange"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "MustRunAs"
+  },
+  "users": [],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.json
@@ -1,0 +1,50 @@
+{
+  "allowHostDirVolumePlugin": false,
+  "allowHostIPC": false,
+  "allowHostNetwork": false,
+  "allowHostPID": false,
+  "allowHostPorts": false,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "RunAsAny"
+  },
+  "groups": [],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.  The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    },
+    "creationTimestamp": null,
+    "name": "nonroot"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "KILL",
+    "MKNOD",
+    "SETUID",
+    "SETGID"
+  ],
+  "runAsUser": {
+    "type": "MustRunAsNonRoot"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-privileged.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-privileged.json
@@ -1,0 +1,55 @@
+{
+  "allowHostDirVolumePlugin": true,
+  "allowHostIPC": true,
+  "allowHostNetwork": true,
+  "allowHostPID": true,
+  "allowHostPorts": true,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": true,
+  "allowedCapabilities": [
+    "*"
+  ],
+  "allowedUnsafeSysctls": [
+    "*"
+  ],
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "RunAsAny"
+  },
+  "groups": [
+    "system:cluster-admins",
+    "system:nodes",
+    "system:masters"
+  ],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context.  WARNING: this is the most relaxed SCC and should be used only for cluster administration. Grant with caution."
+    },
+    "creationTimestamp": null,
+    "name": "privileged"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": null,
+  "runAsUser": {
+    "type": "RunAsAny"
+  },
+  "seLinuxContext": {
+    "type": "RunAsAny"
+  },
+  "seccompProfiles": [
+    "*"
+  ],
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [
+    "system:admin",
+    "system:serviceaccount:openshift-infra:build-controller"
+  ],
+  "volumes": [
+    "*"
+  ]
+}

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-restricted.json
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-restricted.json
@@ -1,0 +1,52 @@
+{
+  "allowHostDirVolumePlugin": false,
+  "allowHostIPC": false,
+  "allowHostNetwork": false,
+  "allowHostPID": false,
+  "allowHostPorts": false,
+  "allowPrivilegeEscalation": true,
+  "allowPrivilegedContainer": false,
+  "allowedCapabilities": null,
+  "apiVersion": "security.openshift.io/v1",
+  "defaultAddCapabilities": null,
+  "fsGroup": {
+    "type": "MustRunAs"
+  },
+  "groups": [
+    "system:authenticated"
+  ],
+  "kind": "SecurityContextConstraints",
+  "metadata": {
+    "annotations": {
+      "kubernetes.io/description": "restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users."
+    },
+    "creationTimestamp": null,
+    "name": "restricted"
+  },
+  "priority": null,
+  "readOnlyRootFilesystem": false,
+  "requiredDropCapabilities": [
+    "KILL",
+    "MKNOD",
+    "SETUID",
+    "SETGID"
+  ],
+  "runAsUser": {
+    "type": "MustRunAsRange"
+  },
+  "seLinuxContext": {
+    "type": "MustRunAs"
+  },
+  "supplementalGroups": {
+    "type": "RunAsAny"
+  },
+  "users": [],
+  "volumes": [
+    "configMap",
+    "downwardAPI",
+    "emptyDir",
+    "persistentVolumeClaim",
+    "projected",
+    "secret"
+  ]
+}


### PR DESCRIPTION
We now have a CRD for SCC, which means we can initialize this early.