### PR TITLE
 Bug 1705649 : Cluster with halted master did not reschedule operators after 5m of being down

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -65,4 +65,14 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
       tolerations:
-      - operator: Exists
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 


### PR DESCRIPTION
As of now, because of infinite tolerations against all the possible taints, we are seeing that operators are not getting evicted from nodes that have NoExecute taint on them. This PR tightens the conditions around which can be pods can be scheduled/evicted. The downside is there is a very good chance that pods would be evicted from nodes that have certain conditions like disk-pressure, memory-pressure, taints added by other controllers(operators) etc. So, please make sure that this change is ok with your operator/operand before merging this PR.

/cc @sjenning @smarterclayton