### PR TITLE
Update library-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 318a34f93be123023d3c25d1e9d077924d191e34f6e499923ca74d4727271303
-updated: 2019-05-02T11:26:13.252385+02:00
+updated: 2019-05-03T14:44:03.105393+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -301,7 +301,7 @@ imports:
   - operator/informers/externalversions/operator/v1
   - operator/listers/operator/v1
 - name: github.com/openshift/library-go
-  version: 1255cd1766a03ded97b3afdc1990d04be168d967
+  version: 30efb8b70b661872bd0fd9de4ae37f61815bf161
   subpackages:
   - cmd/crd-schema-gen/generator
   - pkg/assets

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -11,15 +11,17 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
+	"k8s.io/klog"
 
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
 	"github.com/openshift/library-go/pkg/config/configdefaults"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/serviceability"
@@ -51,22 +53,42 @@ func NewControllerCommandConfig(componentName string, version version.Info, star
 
 // NewCommand returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
 // leader election and other "normal" behaviors.
+// Deprecated: Use the NewCommandWithContext instead, this is here to be less disturbing for existing usages.
 func (c *ControllerCommandConfig) NewCommand() *cobra.Command {
+	return c.NewCommandWithContext(context.TODO())
+
+}
+
+// NewCommandWithContext returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
+// leader election and other "normal" behaviors.
+// The context passed will be passed down to controller loops and observers and cancelled on SIGTERM and SIGINT signals.
+func (c *ControllerCommandConfig) NewCommandWithContext(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			// boiler plate for the "normal" command
 			rand.Seed(time.Now().UTC().UnixNano())
 			logs.InitLogs()
+
+			// handle SIGTERM and SIGINT by cancelling the context.
+			shutdownCtx, cancel := context.WithCancel(ctx)
+			shutdownHandler := server.SetupSignalHandler()
+			go func() {
+				defer cancel()
+				<-shutdownHandler
+				klog.Infof("Received SIGTERM or SIGINT signal, shutting down controller.")
+			}()
+
 			defer logs.FlushLogs()
 			defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), c.version)()
 			defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
 			serviceability.StartProfiler()
 
 			if err := c.basicFlags.Validate(); err != nil {
 				klog.Fatal(err)
 			}
 
-			if err := c.StartController(context.Background()); err != nil {
+			if err := c.StartController(shutdownCtx); err != nil {
 				klog.Fatal(err)
 			}
 		},

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
@@ -92,8 +93,10 @@ func (c *cloudProviderObserver) ObserveCloudProviderNames(genericListers configo
 		Namespace: sourceCloudConfigNamespace,
 		Name:      sourceCloudConfigMap,
 	}
-	// we set cloudprovider configmap values only for vsphere.
-	if cloudProvider != "vsphere" {
+
+	// we set cloudprovider configmap values only for some cloud providers.
+	validCloudProviders := sets.NewString("azure", "vsphere")
+	if !validCloudProviders.Has(cloudProvider) {
 		sourceCloudConfigMap = ""
 	}
 
@@ -143,6 +146,7 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 		cloudProvider = "azure"
 	case configv1.VSpherePlatformType:
 		cloudProvider = "vsphere"
+	case configv1.BareMetalPlatformType:
 	case configv1.LibvirtPlatformType:
 	case configv1.OpenStackPlatformType:
 		// TODO(flaper87): Enable this once we've figured out a way to write the cloud provider config in the master nodes

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider_test.go
@@ -56,6 +56,9 @@ func TestObserveCloudProviderNames(t *testing.T) {
 		expected:           "azure",
 		cloudProviderCount: 1,
 	}, {
+		platform:           configv1.BareMetalPlatformType,
+		cloudProviderCount: 0,
+	}, {
 		platform:           configv1.LibvirtPlatformType,
 		cloudProviderCount: 0,
 	}, {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -49,7 +49,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
-	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from")
+	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
 	return cmd
@@ -102,6 +102,10 @@ func (o *CertSyncControllerOptions) Complete() error {
 	kubeConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfigFile, nil)
 	if err != nil {
 		return err
+	}
+
+	if len(o.Namespace) == 0 && len(os.Getenv("POD_NAMESPACE")) > 0 {
+		o.Namespace = os.Getenv("POD_NAMESPACE")
 	}
 
 	protoKubeConfig := rest.CopyConfig(kubeConfig)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -215,7 +215,7 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 		for filename, content := range secret.Data {
 			// TODO fix permissions
 			klog.Infof("Writing secret manifest %q ...", path.Join(contentDir, filename))
-			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0644); err != nil {
+			if err := ioutil.WriteFile(path.Join(contentDir, filename), content, 0600); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
* library-go#386: Specify no cloud provider for the baremetal platform
* library-go#387: Handle TERM and INT signals gracefully in operators
* library-go#390: Only acccept cloud config files for certain providers
* library-go#391: Make installer pods save secrets using 0600
* library-go#385: Default namespace to POD_NAMESPACE env var in certsync po