### PR TITLE
Recovery apiserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,6 @@ COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY manifests/*.yaml /manifests
 COPY manifests/image-references /manifests
 LABEL io.openshift.release.operator true
+# FIXME: entrypoint shouldn't be bash but the binary (needs fixing the chain)
+# ENTRYPOINT ["/usr/bin/cluster-kube-apiserver-operator"]
+

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -11,3 +11,5 @@ COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY manifests/*.yaml /manifests
 COPY manifests/image-references /manifests
 LABEL io.openshift.release.operator true
+# FIXME: entrypoint shouldn't be bash but the binary (needs fixing the chain)
+# ENTRYPOINT ["/usr/bin/cluster-kube-apiserver-operator"]

--- a/bindata/v3.11.0/kube-apiserver/recovery-config.yaml
+++ b/bindata/v3.11.0/kube-apiserver/recovery-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: kubecontrolplane.config.openshift.io/v1
+kind: KubeAPIServerConfig
+apiServerArguments:
+  storage-backend:
+  - etcd3
+  storage-media-type:
+  - application/vnd.kubernetes.protobuf
+servingInfo:
+  bindAddress: 127.0.0.1:7443
+  bindNetwork: tcp4
+  certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key
+  clientCA: /etc/kubernetes/static-pod-resources/serving-ca.crt
+storageConfig:
+  keyFile: /etc/kubernetes/static-pod-resources/etcd-client.key
+  certFile: /etc/kubernetes/static-pod-resources/etcd-client.crt
+  ca: /etc/kubernetes/static-pod-resources/etcd-serving-ca-bundle.crt
+  storagePrefix: openshift.io
+  urls:
+  - "https://localhost:2379"
+
+# Make hypershift happy.
+# (Everything bellow this line is just to provide some certs file
+# because hypershift tries to read those even if you don't want to set them up.)
+authConfig:
+  oauthMetadataFile: ""
+  requestHeader:
+    clientCA: /etc/kubernetes/static-pod-resources/serving-ca.crt
+serviceAccountPublicKeyFiles:
+- /etc/kubernetes/static-pod-resources/serving-ca.crt
+kubeletClientInfo:
+  ca: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key
+aggregatorConfig:
+  proxyClientInfo:
+    certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+    keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key

--- a/bindata/v3.11.0/kube-apiserver/recovery-pod.yaml
+++ b/bindata/v3.11.0/kube-apiserver/recovery-pod.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: kube-apiserver-recovery
+  labels:
+    revision: "recovery"
+spec:
+  containers:
+  - name: kube-apiserver-recovery
+    image: "{{ .KubeApiserverImage }}"
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["hypershift", "openshift-kube-apiserver"]
+    args:
+    - --config=/etc/kubernetes/static-pod-resources/config.yaml
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 150m
+    ports:
+    - containerPort: 7443
+    volumeMounts:
+    - mountPath: /etc/kubernetes/static-pod-resources
+      name: resource-dir
+  terminationGracePeriodSeconds: 0
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: "Exists"
+  volumes:
+  - hostPath:
+      path: "{{ .ResourceDir }}"
+    name: resource-dir

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 
 	operatorcmd "github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/recoveryapiserver"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/render"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/resourcegraph"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator"
@@ -62,6 +63,7 @@ func NewOperatorCommand() *cobra.Command {
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
+	cmd.AddCommand(recoveryapiserver.NewCommand())
 
 	return cmd
 }

--- a/pkg/cmd/recoveryapiserver/create.go
+++ b/pkg/cmd/recoveryapiserver/create.go
@@ -1,0 +1,117 @@
+package recoveryapiserver
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog"
+
+	"k8s.io/client-go/tools/watch"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/recovery"
+)
+
+type CreateOptions struct {
+	Options
+
+	StaticPodResourcesDir string
+	Timeout               time.Duration
+	Wait                  bool
+}
+
+func NewCreateCommand() *cobra.Command {
+	o := &CreateOptions{
+		Options:               NewDefaultOptions(),
+		StaticPodResourcesDir: "/etc/kubernetes/static-pod-resources",
+		Timeout:               5 * time.Minute,
+		Wait:                  true,
+	}
+
+	cmd := &cobra.Command{
+		Use: "create",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	cmd.Flags().DurationVar(&o.Timeout, "timeout", o.Timeout, "startup timeout, 0 means infinite")
+	cmd.Flags().BoolVar(&o.Wait, "wait", o.Wait, "wait for recovery apiserver to become ready")
+
+	return cmd
+}
+
+func (o *CreateOptions) Complete() error {
+	err := o.Options.Complete()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *CreateOptions) Validate() error {
+	err := o.Options.Validate()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *CreateOptions) Run() error {
+	ctx, cancel := watch.ContextWithOptionalTimeout(context.TODO(), o.Timeout)
+	defer cancel()
+
+	signalHandler := server.SetupSignalHandler()
+	go func() {
+		<-signalHandler
+		cancel()
+	}()
+
+	recoveryApiserver := &recovery.Apiserver{
+		PodManifestDir:        o.PodManifestDir,
+		StaticPodResourcesDir: o.StaticPodResourcesDir,
+	}
+
+	err := recoveryApiserver.Create()
+	if err != nil {
+		return fmt.Errorf("failed to create recovery apiserver: %v", err)
+	}
+
+	kubeconfigPath := path.Join(recoveryApiserver.GetRecoveryResourcesDir(), recovery.AdminKubeconfigFileName)
+	klog.Infof("system:admin kubeconfig written to %q", kubeconfigPath)
+
+	if !o.Wait {
+		return nil
+	}
+
+	klog.Infof("Waiting for recovery apiserver to come up.")
+	err = recoveryApiserver.WaitForHealthz(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for recovery apiserver to be ready: %v", err)
+	}
+	klog.Infof("Recovery apiserver is up.")
+
+	return nil
+}

--- a/pkg/cmd/recoveryapiserver/destroy.go
+++ b/pkg/cmd/recoveryapiserver/destroy.go
@@ -1,0 +1,74 @@
+package recoveryapiserver
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/recovery"
+)
+
+type DestroyOptions struct {
+	Options
+}
+
+func NewDestroyCommand() *cobra.Command {
+	o := &DestroyOptions{
+		Options: NewDefaultOptions(),
+	}
+
+	cmd := &cobra.Command{
+		Use: "destroy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Complete()
+			if err != nil {
+				return err
+			}
+
+			err = o.Validate()
+			if err != nil {
+				return err
+			}
+
+			err = o.Run()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func (o *DestroyOptions) Complete() error {
+	err := o.Options.Complete()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *DestroyOptions) Validate() error {
+	err := o.Options.Validate()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *DestroyOptions) Run() error {
+	apiserver := &recovery.Apiserver{
+		PodManifestDir: o.PodManifestDir,
+	}
+
+	err := apiserver.Destroy()
+	if err != nil {
+		return fmt.Errorf("failed to destroy recovery apiserver: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/recoveryapiserver/lib.go
+++ b/pkg/cmd/recoveryapiserver/lib.go
@@ -1,0 +1,20 @@
+package recoveryapiserver
+
+// Options are shared by other subcommands
+type Options struct {
+	PodManifestDir string
+}
+
+func NewDefaultOptions() Options {
+	return Options{
+		PodManifestDir: "/etc/kubernetes/manifests",
+	}
+}
+
+func (o *Options) Complete() error {
+	return nil
+}
+
+func (o *Options) Validate() error {
+	return nil
+}

--- a/pkg/cmd/recoveryapiserver/recoveryapiserver.go
+++ b/pkg/cmd/recoveryapiserver/recoveryapiserver.go
@@ -1,0 +1,16 @@
+package recoveryapiserver
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "recovery-apiserver",
+	}
+
+	cmd.AddCommand(NewCreateCommand())
+	cmd.AddCommand(NewDestroyCommand())
+
+	return cmd
+}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -6,6 +6,8 @@
 // bindata/v3.11.0/kube-apiserver/ns.yaml
 // bindata/v3.11.0/kube-apiserver/pod-cm.yaml
 // bindata/v3.11.0/kube-apiserver/pod.yaml
+// bindata/v3.11.0/kube-apiserver/recovery-config.yaml
+// bindata/v3.11.0/kube-apiserver/recovery-pod.yaml
 // bindata/v3.11.0/kube-apiserver/svc.yaml
 // DO NOT EDIT!
 
@@ -431,6 +433,112 @@ func v3110KubeApiserverPodYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v3110KubeApiserverRecoveryConfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
+kind: KubeAPIServerConfig
+apiServerArguments:
+  storage-backend:
+  - etcd3
+  storage-media-type:
+  - application/vnd.kubernetes.protobuf
+servingInfo:
+  bindAddress: 127.0.0.1:7443
+  bindNetwork: tcp4
+  certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key
+  clientCA: /etc/kubernetes/static-pod-resources/serving-ca.crt
+storageConfig:
+  keyFile: /etc/kubernetes/static-pod-resources/etcd-client.key
+  certFile: /etc/kubernetes/static-pod-resources/etcd-client.crt
+  ca: /etc/kubernetes/static-pod-resources/etcd-serving-ca-bundle.crt
+  storagePrefix: openshift.io
+  urls:
+  - "https://localhost:2379"
+
+# Make hypershift happy.
+# (Everything bellow this line is just to provide some certs file
+# because hypershift tries to read those even if you don't want to set them up.)
+authConfig:
+  oauthMetadataFile: ""
+  requestHeader:
+    clientCA: /etc/kubernetes/static-pod-resources/serving-ca.crt
+serviceAccountPublicKeyFiles:
+- /etc/kubernetes/static-pod-resources/serving-ca.crt
+kubeletClientInfo:
+  ca: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+  keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key
+aggregatorConfig:
+  proxyClientInfo:
+    certFile: /etc/kubernetes/static-pod-resources/serving-ca.crt
+    keyFile: /etc/kubernetes/static-pod-resources/serving-ca.key
+`)
+
+func v3110KubeApiserverRecoveryConfigYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverRecoveryConfigYaml, nil
+}
+
+func v3110KubeApiserverRecoveryConfigYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverRecoveryConfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/recovery-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v3110KubeApiserverRecoveryPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: kube-apiserver-recovery
+  labels:
+    revision: "recovery"
+spec:
+  containers:
+  - name: kube-apiserver-recovery
+    image: "{{ .KubeApiserverImage }}"
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["hypershift", "openshift-kube-apiserver"]
+    args:
+    - --config=/etc/kubernetes/static-pod-resources/config.yaml
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 150m
+    ports:
+    - containerPort: 7443
+    volumeMounts:
+    - mountPath: /etc/kubernetes/static-pod-resources
+      name: resource-dir
+  terminationGracePeriodSeconds: 0
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: "Exists"
+  volumes:
+  - hostPath:
+      path: "{{ .ResourceDir }}"
+    name: resource-dir
+`)
+
+func v3110KubeApiserverRecoveryPodYamlBytes() ([]byte, error) {
+	return _v3110KubeApiserverRecoveryPodYaml, nil
+}
+
+func v3110KubeApiserverRecoveryPodYaml() (*asset, error) {
+	bytes, err := v3110KubeApiserverRecoveryPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/kube-apiserver/recovery-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v3110KubeApiserverSvcYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
@@ -517,13 +625,15 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"v3.11.0/kube-apiserver/cm.yaml":            v3110KubeApiserverCmYaml,
-	"v3.11.0/kube-apiserver/defaultconfig.yaml": v3110KubeApiserverDefaultconfigYaml,
-	"v3.11.0/kube-apiserver/kubeconfig-cm.yaml": v3110KubeApiserverKubeconfigCmYaml,
-	"v3.11.0/kube-apiserver/ns.yaml":            v3110KubeApiserverNsYaml,
-	"v3.11.0/kube-apiserver/pod-cm.yaml":        v3110KubeApiserverPodCmYaml,
-	"v3.11.0/kube-apiserver/pod.yaml":           v3110KubeApiserverPodYaml,
-	"v3.11.0/kube-apiserver/svc.yaml":           v3110KubeApiserverSvcYaml,
+	"v3.11.0/kube-apiserver/cm.yaml":              v3110KubeApiserverCmYaml,
+	"v3.11.0/kube-apiserver/defaultconfig.yaml":   v3110KubeApiserverDefaultconfigYaml,
+	"v3.11.0/kube-apiserver/kubeconfig-cm.yaml":   v3110KubeApiserverKubeconfigCmYaml,
+	"v3.11.0/kube-apiserver/ns.yaml":              v3110KubeApiserverNsYaml,
+	"v3.11.0/kube-apiserver/pod-cm.yaml":          v3110KubeApiserverPodCmYaml,
+	"v3.11.0/kube-apiserver/pod.yaml":             v3110KubeApiserverPodYaml,
+	"v3.11.0/kube-apiserver/recovery-config.yaml": v3110KubeApiserverRecoveryConfigYaml,
+	"v3.11.0/kube-apiserver/recovery-pod.yaml":    v3110KubeApiserverRecoveryPodYaml,
+	"v3.11.0/kube-apiserver/svc.yaml":             v3110KubeApiserverSvcYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -569,13 +679,15 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"v3.11.0": {nil, map[string]*bintree{
 		"kube-apiserver": {nil, map[string]*bintree{
-			"cm.yaml":            {v3110KubeApiserverCmYaml, map[string]*bintree{}},
-			"defaultconfig.yaml": {v3110KubeApiserverDefaultconfigYaml, map[string]*bintree{}},
-			"kubeconfig-cm.yaml": {v3110KubeApiserverKubeconfigCmYaml, map[string]*bintree{}},
-			"ns.yaml":            {v3110KubeApiserverNsYaml, map[string]*bintree{}},
-			"pod-cm.yaml":        {v3110KubeApiserverPodCmYaml, map[string]*bintree{}},
-			"pod.yaml":           {v3110KubeApiserverPodYaml, map[string]*bintree{}},
-			"svc.yaml":           {v3110KubeApiserverSvcYaml, map[string]*bintree{}},
+			"cm.yaml":              {v3110KubeApiserverCmYaml, map[string]*bintree{}},
+			"defaultconfig.yaml":   {v3110KubeApiserverDefaultconfigYaml, map[string]*bintree{}},
+			"kubeconfig-cm.yaml":   {v3110KubeApiserverKubeconfigCmYaml, map[string]*bintree{}},
+			"ns.yaml":              {v3110KubeApiserverNsYaml, map[string]*bintree{}},
+			"pod-cm.yaml":          {v3110KubeApiserverPodCmYaml, map[string]*bintree{}},
+			"pod.yaml":             {v3110KubeApiserverPodYaml, map[string]*bintree{}},
+			"recovery-config.yaml": {v3110KubeApiserverRecoveryConfigYaml, map[string]*bintree{}},
+			"recovery-pod.yaml":    {v3110KubeApiserverRecoveryPodYaml, map[string]*bintree{}},
+			"svc.yaml":             {v3110KubeApiserverSvcYaml, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/pkg/recovery/apiserver.go
+++ b/pkg/recovery/apiserver.go
@@ -1,0 +1,374 @@
+package recovery
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/template"
+	"time"
+
+	"github.com/ghodss/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/crypto"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/v311_00_assets"
+)
+
+const (
+	KubeApiserverStaticPodFileName = "kube-apiserver-pod.yaml"
+	RecoveryPodFileName            = "recovery-kube-apiserver-pod.yaml"
+	RecoveryCofigFileName          = "config.yaml"
+	AdminKubeconfigFileName        = "admin.kubeconfig"
+
+	RecoveryPodAsset    = "v3.11.0/kube-apiserver/recovery-pod.yaml"
+	RecoveryConfigAsset = "v3.11.0/kube-apiserver/recovery-config.yaml"
+)
+
+type Apiserver struct {
+	PodManifestDir        string
+	ResourceDirPath       string
+	StaticPodResourcesDir string
+	recoveryResourcesDir  string
+
+	kubeApiserverStaticPod *corev1.Pod
+	restConfig             *rest.Config
+	kubeClientSet          *kubernetes.Clientset
+}
+
+func (s *Apiserver) GetRecoveryResourcesDir() string {
+	return s.recoveryResourcesDir
+}
+
+func (s *Apiserver) RestConfig() (*rest.Config, error) {
+	if s.restConfig == nil {
+		return nil, errors.New("no rest config is set yet")
+	}
+
+	return s.restConfig, nil
+}
+
+func (s *Apiserver) KubeConfig() (*clientcmdapiv1.Config, error) {
+	restConfig, err := s.RestConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientcmdapiv1.Config{
+		APIVersion: "v1",
+		Clusters: []clientcmdapiv1.NamedCluster{
+			{
+				Name: "recovery",
+				Cluster: clientcmdapiv1.Cluster{
+					CertificateAuthority: restConfig.CAFile,
+					Server:               restConfig.Host,
+				},
+			},
+		},
+		Contexts: []clientcmdapiv1.NamedContext{
+			{
+				Name: "admin",
+				Context: clientcmdapiv1.Context{
+					Cluster:  "recovery",
+					AuthInfo: "admin",
+				},
+			},
+		},
+		CurrentContext: "admin",
+		AuthInfos: []clientcmdapiv1.NamedAuthInfo{
+			{
+				Name: "admin",
+				AuthInfo: clientcmdapiv1.AuthInfo{
+					ClientCertificateData: restConfig.CertData,
+					ClientKeyData:         restConfig.KeyData,
+				},
+			},
+		},
+	}, nil
+}
+
+func (s *Apiserver) GetKubeClientset() (*kubernetes.Clientset, error) {
+	if s.kubeClientSet != nil {
+		return s.kubeClientSet, nil
+	}
+
+	restConfig, err := s.RestConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes clientset: %v", err)
+	}
+
+	s.kubeClientSet = kubeClientset
+
+	return s.kubeClientSet, nil
+}
+
+func (s *Apiserver) recoveryPod() (*corev1.Pod, error) {
+	// Create the manifest to run recovery apiserver
+	recoveryPodTemplateBytes, err := v311_00_assets.Asset(RecoveryPodAsset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find internal recovery pod asset %q: %v", RecoveryPodAsset, err)
+	}
+
+	// Process the template
+	t, err := template.New("recovery-pod-template").Parse(string(recoveryPodTemplateBytes))
+	if err != nil {
+		return nil, fmt.Errorf("fail to parse internal recovery pod template %q: %v", RecoveryPodAsset, err)
+	}
+
+	var kubeApiserverImage string
+	for _, container := range s.kubeApiserverStaticPod.Spec.Containers {
+		if regexp.MustCompile("^kube-apiserver-[a-zA-Z0-9]+$").MatchString(container.Name) {
+			kubeApiserverImage = container.Image
+		}
+	}
+	if len(kubeApiserverImage) == 0 {
+		return nil, errors.New("failed to find kube-apiserver image")
+	}
+
+	recoveryPodBuffer := bytes.NewBuffer(nil)
+	err = t.Execute(recoveryPodBuffer, struct {
+		KubeApiserverImage string
+		ResourceDir        string
+	}{
+		KubeApiserverImage: kubeApiserverImage,
+		ResourceDir:        s.recoveryResourcesDir,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fail to execute internal recovery pod template %q: %v", RecoveryPodAsset, err)
+	}
+
+	recoveryPodObj, err := runtime.Decode(Codecs.UniversalDecoder(corev1.SchemeGroupVersion), recoveryPodBuffer.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode internal recovery pod %q: %v", RecoveryPodAsset, err)
+	}
+
+	recoveryPod, ok := recoveryPodObj.(*corev1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("unsupported type: internal recovery pod is not type *corev1.Pod but %T", recoveryPod)
+	}
+
+	return recoveryPod, nil
+}
+
+func (s *Apiserver) Create() error {
+	kubeApiserverManifestPath := filepath.Join(s.PodManifestDir, KubeApiserverStaticPodFileName)
+	var err error
+	s.kubeApiserverStaticPod, err = ReadManifestToV1Pod(kubeApiserverManifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to read kube-apiserver pod manifest at %q: %v", kubeApiserverManifestPath, err)
+	}
+
+	s.ResourceDirPath, err = GetVolumeHostPathPath("resource-dir", s.kubeApiserverStaticPod.Spec.Volumes)
+	if err != nil {
+		return fmt.Errorf("failed to find resource-dir: %v", err)
+	}
+
+	s.recoveryResourcesDir = filepath.Join(s.StaticPodResourcesDir, "recovery-kube-apiserver-pod")
+	err = os.Mkdir(s.recoveryResourcesDir, 755)
+	if err != nil {
+		if os.IsExist(err) {
+			klog.Errorf("Recovery dir %q already exist. Please use `recovery-apiserver destroy` command or remove the dir manually.", s.recoveryResourcesDir)
+		}
+		return fmt.Errorf("failed to create recovery dir %q: %v", s.recoveryResourcesDir, err)
+	}
+
+	// Copy certs for accessing etcd
+	for src, dest := range map[string]string{
+		"secrets/etcd-client/tls.key":              "etcd-client.key",
+		"secrets/etcd-client/tls.crt":              "etcd-client.crt",
+		"configmaps/etcd-serving-ca/ca-bundle.crt": "etcd-serving-ca-bundle.crt",
+	} {
+		err = copyFile(filepath.Join(s.ResourceDirPath, src), filepath.Join(s.recoveryResourcesDir, dest))
+		if err != nil {
+			return err
+		}
+	}
+
+	// We are creating only temporary certificates to start the recovery apiserver.
+	// A week seem reasonably high for a debug session, while it is easy to create a new one.
+	certValidity := 7 * 24 * time.Hour
+	klog.Infof("Recovery apiserver certificates will be valid for %v", certValidity)
+
+	// Create root CA
+	rootCaConfig, err := crypto.MakeSelfSignedCAConfigForDuration("localhost", certValidity)
+	if err != nil {
+		return fmt.Errorf("failed to create root-signer CA: %v", err)
+	}
+
+	servingCaCertPath := filepath.Join(s.recoveryResourcesDir, "serving-ca.crt")
+	err = rootCaConfig.WriteCertConfigFile(servingCaCertPath, filepath.Join(s.recoveryResourcesDir, "serving-ca.key"))
+	if err != nil {
+		return fmt.Errorf("failed to write root-signer files: %v", err)
+	}
+
+	// Create config for recovery apiserver
+	recoveryConfigBytes, err := v311_00_assets.Asset(RecoveryConfigAsset)
+	if err != nil {
+		return fmt.Errorf("fail to find internal recovery config asset %q: %v", RecoveryConfigAsset, err)
+	}
+
+	recoveryConfigPath := filepath.Join(s.recoveryResourcesDir, RecoveryCofigFileName)
+	err = ioutil.WriteFile(recoveryConfigPath, recoveryConfigBytes, 644)
+	if err != nil {
+		return fmt.Errorf("failed to write recovery config %q: %v", recoveryConfigPath, err)
+	}
+
+	recoveryPod, err := s.recoveryPod()
+	if err != nil {
+		return fmt.Errorf("failed to create recovery pod: %v", err)
+	}
+
+	recoveryPodBytes, err := yaml.Marshal(recoveryPod)
+	if err != nil {
+		return fmt.Errorf("failed to marshal recovery pod: %v", err)
+	}
+
+	recoveryPodManifestPath := filepath.Join(s.PodManifestDir, RecoveryPodFileName)
+	err = ioutil.WriteFile(recoveryPodManifestPath, recoveryPodBytes, 644)
+	if err != nil {
+		return fmt.Errorf("failed to write recovery pod manifest %q: %v", recoveryPodManifestPath, err)
+	}
+
+	// Create client cert
+	ca := crypto.CA{
+		Config:          rootCaConfig,
+		SerialGenerator: &crypto.RandomSerialGenerator{},
+	}
+
+	// Create client certificates for system:admin
+	// (Reuse the serving CA as client CA, this is fine for shortlived localhost recovery apiserver.)
+	clientCert, err := ca.MakeClientCertificateForDuration(&user.DefaultInfo{Name: "system:admin"}, certValidity)
+	if err != nil {
+		return fmt.Errorf("failed to create client certificate: %v", err)
+	}
+
+	clientCertBytes, clientKeyBytes, err := clientCert.GetPEMBytes()
+
+	s.restConfig = &rest.Config{
+		Host: "https://localhost:7443",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAFile:   servingCaCertPath,
+			CertData: clientCertBytes,
+			KeyData:  clientKeyBytes,
+		},
+	}
+
+	kubeconfig, err := s.KubeConfig()
+	if err != nil {
+		return fmt.Errorf("failed to create kubeconfig: %v", err)
+	}
+
+	kubeconfigBytes, err := yaml.Marshal(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal kubeconfig: %v", err)
+	}
+
+	kubeconfigPath := filepath.Join(s.recoveryResourcesDir, AdminKubeconfigFileName)
+	err = ioutil.WriteFile(kubeconfigPath, kubeconfigBytes, 600)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig %q: %v", kubeconfigPath, err)
+	}
+
+	return nil
+}
+
+func (s *Apiserver) WaitForHealthz(ctx context.Context) error {
+	// We don't have to worry about connecting to an old, terminating apiserver
+	// as our client certs are unique to this instance
+
+	kubeClientset, err := s.GetKubeClientset()
+	if err != nil {
+		return err
+	}
+
+	return wait.PollUntil(500*time.Millisecond, func() (bool, error) {
+		req := kubeClientset.RESTClient().Get().AbsPath("/healthz")
+
+		klog.V(1).Infof("Waiting for recovery apiserver to come up at %q", req.URL())
+
+		_, err = req.DoRaw()
+		if err != nil {
+			klog.V(5).Infof("apiserver returned error: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	}, ctx.Done())
+}
+
+func (s *Apiserver) Destroy() error {
+	recoveryPodManifestPath := filepath.Join(s.PodManifestDir, RecoveryPodFileName)
+
+	recoveryPod, err := ReadManifestToV1Pod(recoveryPodManifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to decode file %q: %v", recoveryPodManifestPath, err)
+	}
+
+	resourceDirPath, err := GetVolumeHostPathPath("resource-dir", recoveryPod.Spec.Volumes)
+	if err != nil {
+		return fmt.Errorf("failed to find resource-dir volume for pod manifest %q: %v", recoveryPodManifestPath, err)
+	}
+
+	klog.Infof("Deleting resource-dir %q", resourceDirPath)
+	err = os.RemoveAll(resourceDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove recovery pod manifest %q: %v", recoveryPodManifestPath, err)
+	}
+
+	klog.Infof("Deleting recovery pod manifest %q", recoveryPodManifestPath)
+	err = os.Remove(recoveryPodManifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove recovery pod manifest %q: %v", recoveryPodManifestPath, err)
+	}
+
+	return nil
+}
+
+func copyFile(src, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open file %q: %v", src, err)
+	}
+	defer srcFile.Close()
+
+	srcFileInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file %q: %v", src, err)
+	}
+
+	if srcFileInfo.IsDir() {
+		return fmt.Errorf("can't copy file %q because it is a directory", src)
+	}
+
+	destFile, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, srcFileInfo.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("failed to open file %q: %v", dest, err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy file %q into %q: %v", src, dest, err)
+	}
+
+	return nil
+}

--- a/pkg/recovery/apiserver_test.go
+++ b/pkg/recovery/apiserver_test.go
@@ -1,0 +1,136 @@
+package recovery
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func TestApiserverRecoveryPod(t *testing.T) {
+	const image = "hypershift:latest"
+
+	tt := []struct {
+		name          string
+		apiserver     *Apiserver
+		expectedPod   *corev1.Pod
+		expectedError error
+	}{
+		{
+			name: "",
+			apiserver: &Apiserver{
+				recoveryResourcesDir: "/tmp/static-pod-resources/recovery-kube-apiserver-pod",
+				kubeApiserverStaticPod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "kube-apiserver-cert-syncer-42",
+								Image: "not the image you were looking for",
+							},
+							{
+								Name:  "kube-apiserver-42",
+								Image: image,
+							},
+							{
+								Name:  "kube-apiserver-cert-syncer-41",
+								Image: "not the image you were looking for",
+							},
+						},
+					},
+				},
+			},
+			expectedPod: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-recovery",
+					Namespace: "openshift-kube-apiserver",
+					Labels: map[string]string{
+						"revision": "recovery",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "kube-apiserver-recovery",
+							Image:   image,
+							Command: []string{"hypershift", "openshift-kube-apiserver"},
+							Args:    []string{"--config=/etc/kubernetes/static-pod-resources/config.yaml"},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 7443,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "resource-dir",
+									MountPath: "/etc/kubernetes/static-pod-resources",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("150m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "resource-dir",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/tmp/static-pod-resources/recovery-kube-apiserver-pod",
+								},
+							},
+						},
+					},
+					PriorityClassName:             "system-node-critical",
+					HostNetwork:                   true,
+					TerminationGracePeriodSeconds: int64Ptr(0),
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pod, err := tc.apiserver.recoveryPod()
+			if !reflect.DeepEqual(tc.expectedError, err) {
+				t.Fatalf("expected error %v, got %v", tc.expectedError, err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedPod, pod) {
+				t.Error(spew.Sprintf(
+					"expected %#+v\n"+
+						"got %#+v     \n"+
+						"diff: %s",
+					tc.expectedPod,
+					pod,
+					diff.ObjectReflectDiff(tc.expectedPod, pod),
+				))
+			}
+		})
+	}
+}

--- a/pkg/recovery/helpers.go
+++ b/pkg/recovery/helpers.go
@@ -1,0 +1,118 @@
+package recovery
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+)
+
+var (
+	Scheme = runtime.NewScheme()
+	Codecs = serializer.NewCodecFactory(Scheme)
+)
+
+func init() {
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(corev1.AddToScheme(Scheme))
+}
+
+func ReadManifestToV1Pod(manifestPath string) (*corev1.Pod, error) {
+	f, err := os.OpenFile(manifestPath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %v", manifestPath, err)
+	}
+	defer f.Close()
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %v", manifestPath, err)
+	}
+
+	obj, err := runtime.Decode(Codecs.UniversalDecoder(corev1.SchemeGroupVersion), buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode file %q: %v", manifestPath, err)
+	}
+
+	// TODO: support conversions if the object is in different but convertible version
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("unsupported type: kubeApiserverStaticPodManifest is not type *corev1.Pod but %T", obj)
+	}
+
+	return pod, nil
+}
+
+func GetVolumeHostPathPath(volumeName string, volumes []corev1.Volume) (string, error) {
+	for _, volume := range volumes {
+		if volume.Name == volumeName {
+			if volume.HostPath == nil {
+				return "", errors.New("volume doesn't have hostPath set")
+			}
+			if volume.HostPath.Path == "" {
+				return "", errors.New("volume hostPath shall not be empty")
+			}
+
+			return volume.HostPath.Path, nil
+		}
+	}
+
+	return "", fmt.Errorf("volume %q not found", volumeName)
+}
+
+func EnsureFileContent(filePath string, data []byte) error {
+	exists := true
+	mode := os.FileMode(600) // default mode
+
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			exists = false
+		} else {
+			return fmt.Errorf("failed to stat file %q: %v", filePath, err)
+		}
+	}
+
+	if exists {
+		if fileInfo.IsDir() {
+			return fmt.Errorf("file %q is a directory", filePath)
+		}
+
+		fileBytes, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %q: %v", filePath, err)
+		}
+
+		if bytes.Equal(fileBytes, data) {
+			klog.V(1).Infof("%q already contains the same content", filePath)
+			return nil
+		}
+
+		backupFilePath := filePath + time.Now().Format(".1989-12-01-23-59-59")
+		err = os.Rename(filePath, backupFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to rename the file %q into %q: %v", filePath, backupFilePath, err)
+		}
+
+		mode = fileInfo.Mode().Perm()
+	}
+
+	err = ioutil.WriteFile(filePath, data, mode)
+	if err != nil {
+		return fmt.Errorf("failed to write content into %q: %v", filePath, err)
+	}
+
+	return nil
+}

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -13,8 +15,12 @@ func TestYamlCorrectness(t *testing.T) {
 	readAllYaml("../../manifests/", t)
 	readAllYaml("../../bindata/", t)
 }
+
 func readAllYaml(path string, t *testing.T) {
-	manifests, err := assets.New(path, render.TemplateData{}, assets.OnlyYaml)
+	// TODO: validate also recovery manifest but they take different template and are covered by unit tests
+	manifests, err := assets.New(path, render.TemplateData{}, func(info os.FileInfo) bool {
+		return assets.OnlyYaml(info) && !strings.HasPrefix(info.Name(), "recovery-")
+	})
 	if err != nil {
 		t.Errorf("Unexpected error reading manifests from %s: %v", path, err)
 	}


### PR DESCRIPTION
built on @tnozicka's #448 .  I removed the timeout and wait flags, leaving us with a command 

`cluster-kube-apiserver-operator recovery-apiserver create` that launches a localhost recovery-apiserver, indicates the kubeconfig file: `/etc/kubernetes/static-pod-resources/recovery-kube-apiserver-pod/admin.kubeconfig` which can be used for access.

I tested locally and this appears to work fine.