### PR TITLE
remove dependency on the service-ca from kube-apiserver

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/svc.yaml
+++ b/bindata/v3.11.0/kube-apiserver/svc.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: openshift-kube-apiserver
   name: apiserver
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
 spec:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -199,7 +199,6 @@ var CertConfigMaps = []revision.RevisionResource{
 
 var CertSecrets = []revision.RevisionResource{
 	{Name: "aggregator-client"},
-	{Name: "serving-cert"},
 	{Name: "localhost-serving-cert-certkey"},
 	{Name: "service-network-serving-certkey"},
 	{Name: "external-loadbalancer-serving-certkey"},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -437,7 +437,6 @@ metadata:
   namespace: openshift-kube-apiserver
   name: apiserver
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
     prometheus.io/scrape: "true"
     prometheus.io/scheme: https
 spec:


### PR DESCRIPTION
I can't find where this serving-cert is used, but it creates a dependency on the service-ca which can lead to instability.

/assign @sanchezl 