### PR TITLE
require storage URLs before installing

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -1,0 +1,114 @@
+package targetconfigcontroller
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsRequiredConfigPresent(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        string
+		expectedError string
+	}{
+		{
+			name: "unparseable",
+			config: `{
+		 "servingInfo": {
+		}
+		`,
+			expectedError: "error parsing config",
+		},
+		{
+			name:          "empty",
+			config:        ``,
+			expectedError: "no observedConfig",
+		},
+		{
+			name: "nil-storage-urls",
+			config: `{
+		 "servingInfo": {
+		   "namedCertificates": [
+		     {
+		       "certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
+		       "keyFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"
+		     }
+		   ]
+		 },
+		 "storageConfig": {
+		   "urls": null
+		 }
+		}
+		`,
+			expectedError: "storageConfig.urls null in config",
+		},
+		{
+			name: "missing-storage-urls",
+			config: `{
+		 "servingInfo": {
+		   "namedCertificates": [
+		     {
+		       "certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
+		       "keyFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"
+		     }
+		   ]
+		 },
+		 "storageConfig": {
+		   "urls": []
+		 }
+		}
+		`,
+			expectedError: "storageConfig.urls empty in config",
+		},
+		{
+			name: "empty-string-storage-urls",
+			config: `{
+  "servingInfo": {
+    "namedCertificates": [
+      {
+        "certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
+        "keyFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"
+      }
+    ]
+  },
+  "storageConfig": {
+    "urls": ""
+  }
+}
+`,
+			expectedError: "storageConfig.urls empty in config",
+		},
+		{
+			name: "good",
+			config: `{
+		 "servingInfo": {
+		   "namedCertificates": [
+		     {
+		       "certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
+		       "keyFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"
+		     }
+		   ]
+		 },
+		 "storageConfig": {
+		   "urls": [ "val" ]
+		 }
+		}
+		`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := isRequiredConfigPresent([]byte(test.config))
+			switch {
+			case actual == nil && len(test.expectedError) == 0:
+			case actual == nil && len(test.expectedError) != 0:
+				t.Fatal(actual)
+			case actual != nil && len(test.expectedError) == 0:
+				t.Fatal(actual)
+			case actual != nil && len(test.expectedError) != 0 && !strings.Contains(actual.Error(), test.expectedError):
+				t.Fatal(actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Installing before this was available caused us to use the wrong etcd location, which led to debugging.  This would prevent us from rolling out and give a good message.

Also, we should make this check generic, turns out there's a fair amount to it.

/assign @sttts 