### PR TITLE
don't wait for healthz on recovery-apiserver and don't destroy on shutdown

### DIFF
--- a/pkg/cmd/recoveryapiserver/create.go
+++ b/pkg/cmd/recoveryapiserver/create.go
@@ -1,15 +1,11 @@
 package recoveryapiserver
 
 import (
-	"context"
 	"fmt"
 	"path"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog"
-
-	"k8s.io/client-go/tools/watch"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/recovery"
 )
@@ -72,15 +68,6 @@ func (o *CreateOptions) Validate() error {
 }
 
 func (o *CreateOptions) Run() error {
-	ctx, cancel := watch.ContextWithOptionalTimeout(context.TODO(), 0 /*infinity*/)
-	defer cancel()
-
-	signalHandler := server.SetupSignalHandler()
-	go func() {
-		<-signalHandler
-		cancel()
-	}()
-
 	recoveryApiserver := &recovery.Apiserver{
 		PodManifestDir:        o.PodManifestDir,
 		StaticPodResourcesDir: o.StaticPodResourcesDir,
@@ -90,26 +77,10 @@ func (o *CreateOptions) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create recovery apiserver: %v", err)
 	}
-	// destroy the server when we're done
-	defer func() {
-		if err := recoveryApiserver.Destroy(); err != nil {
-			klog.Errorf("failed to destroy the recovery apiserver")
-		}
-	}()
 
 	kubeconfigPath := path.Join(recoveryApiserver.GetRecoveryResourcesDir(), recovery.AdminKubeconfigFileName)
-	klog.Infof("Waiting for recovery apiserver to be healthy.")
+	klog.Infof("To access the server.")
 	klog.Infof("    export KUBECONFIG=%s", kubeconfigPath)
-	klog.Infof("to access the server.")
-
-	err = recoveryApiserver.WaitForHealthz(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to wait for recovery apiserver to be ready: %v", err)
-	}
-	klog.Infof("Recovery apiserver is up.")
-
-	<-ctx.Done()
-	klog.Infof("Exit requested.")
 
 	return nil
 }


### PR DESCRIPTION
Eliminates all waiting, just creates manifests and exits to avoid hangs, timeouts, failures on usage, weird blocking behavior for a create when usage of the thing is not controlled.