### PR TITLE
Fix csr-signer location to target namespace

### DIFF
--- a/pkg/cmd/regeneratecerts/regenerate_certificates.go
+++ b/pkg/cmd/regeneratecerts/regenerate_certificates.go
@@ -303,7 +303,7 @@ func (o *Options) Run() error {
 		{
 			objectType:  secretsType,
 			name:        "csr-signer",
-			namespace:   kubecontrollermanageroperatorclient.OperatorNamespace,
+			namespace:   kubecontrollermanageroperatorclient.TargetNamespace,
 			toplevelDir: kubeControllerManagerResourceDir,
 		},
 


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-apiserver-operator/pull/469 has fixed the csr-signer certificate format, but it forgot to use the new file

/cc @deads2k @soltysh 