### PR TITLE
certrotationcontroller: prevent panic when setting loadbalancer hostname

### DIFF
--- a/pkg/operator/certrotationcontroller/externalloadbalancer.go
+++ b/pkg/operator/certrotationcontroller/externalloadbalancer.go
@@ -16,6 +16,10 @@ func (c *CertRotationController) syncExternalLoadBalancerHostnames() error {
 		return err
 	}
 	hostname := infrastructureConfig.Status.APIServerURL
+	if len(hostname) == 0 {
+		klog.Warningf("Failed to set external loadbalancer: APIServerURL is not set")
+		return nil
+	}
 	hostname = strings.Replace(hostname, "https://", "", 1)
 	hostname = hostname[0:strings.LastIndex(hostname, ":")]
 

--- a/pkg/operator/certrotationcontroller/internalloadbalancer.go
+++ b/pkg/operator/certrotationcontroller/internalloadbalancer.go
@@ -16,6 +16,11 @@ func (c *CertRotationController) syncInternalLoadBalancerHostnames() error {
 		return err
 	}
 	hostname := infrastructureConfig.Status.APIServerInternalURL
+	// if hostname is not set do not panic with slice bounds out of range
+	if len(hostname) == 0 {
+		klog.Warningf("Failed to set internal loadbalancer: APIServerInternalURL is not set")
+		return nil
+	}
 	hostname = strings.Replace(hostname, "https://", "", 1)
 	hostname = hostname[0:strings.LastIndex(hostname, ":")]
 


### PR DESCRIPTION
Prevent panic that somehow occur during the operator graceful shutdown.

`
Shutting down CertRotation\npanic: runtime error: slice bounds out of range\n\ngoroutine 657 [running]:\ngithub.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller.(*CertRotationController).syncInternalLoadBalancerHostnames(0xc0001692c0, 0x0, 0x0)\n    /go/src/github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller/internalloadbalancer.go:20 +0x254\ngithub.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller.(*CertRotationController).WaitForReady(0xc0001692c0, 0xc0000b3680)\n    /go/src/github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller/certrotationcontroller.go:467 +0x18a\ngithub.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller.(*CertRotationController).Run(0xc0001692c0, 0x1, 0xc0000b3680)\n    /go/src/github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller/certrotationcontroller.go:492 +0xa9\ncreated by github.com/openshift/cluster-kube-apiserver-operator/pkg/operator.RunOperator\n    /go/src/github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/starter.go:163 +0x119c\n
`