### PR TITLE
Bug 1710293 - Don't explicitly set storagePrefix to use the default value

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -108,7 +108,6 @@ storageConfig:
   ca: /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
-  storagePrefix: openshift.io
   urls: null
 userAgentMatchingConfig:
   defaultRejectionMessage: ""

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -187,7 +187,6 @@ storageConfig:
   ca: /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
   certFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
   keyFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
-  storagePrefix: openshift.io
   urls: null
 userAgentMatchingConfig:
   defaultRejectionMessage: ""


### PR DESCRIPTION
/assign @smarterclayton @mfojtik @sttts @deads2k @derekwaynecarr 

Not setting this value will cause us to default it from here: https://github.com/openshift/origin/blob/7599337aeefb8314f9b5bb832b42639d4e28ce26/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go#L58