### PR TITLE
Bug 1711185 - Remove storage prefix to default to correct one for kube resources in recovery apisever

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/recovery-config.yaml
+++ b/bindata/v4.1.0/kube-apiserver/recovery-config.yaml
@@ -15,7 +15,6 @@ storageConfig:
   keyFile: /etc/kubernetes/static-pod-resources/etcd-client.key
   certFile: /etc/kubernetes/static-pod-resources/etcd-client.crt
   ca: /etc/kubernetes/static-pod-resources/etcd-serving-ca-bundle.crt
-  storagePrefix: openshift.io
   urls:
   - "https://localhost:2379"
 

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -449,7 +449,6 @@ storageConfig:
   keyFile: /etc/kubernetes/static-pod-resources/etcd-client.key
   certFile: /etc/kubernetes/static-pod-resources/etcd-client.crt
   ca: /etc/kubernetes/static-pod-resources/etcd-serving-ca-bundle.crt
-  storagePrefix: openshift.io
   urls:
   - "https://localhost:2379"
 


### PR DESCRIPTION
Catches up with storage change made here https://github.com/openshift/cluster-kube-apiserver-operator/pull/475

/priority critical-urgent

/cc @openshift/sig-master @derekwaynecarr @smarterclayton 