### PR TITLE
Bug 1711431: user-serving-cert secret not being installed

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -68,7 +68,7 @@ var ObserveDefaultUserServingCertificate configobserver.ObserveConfigFunc = (&ap
 	observerFunc:  observeDefaultUserServingCertificate,
 	configPaths:   [][]string{{"servingInfo", "certFile"}, {"servingInfo", "keyFile"}},
 	resourceNames: []string{"user-serving-cert"},
-	resourceType:  corev1.ConfigMap{},
+	resourceType:  corev1.Secret{},
 }).observe
 
 // ObserveNamedCertificates returns an ObserveConfigFunc that observes user managed TLS cert info for serving secure

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -104,14 +104,14 @@ func TestObserveDefaultServingCertificate(t *testing.T) {
 			config:         nil,
 			existing:       existingConfig,
 			expected:       map[string]interface{}{},
-			expectedSynced: map[string]string{"configmap/user-serving-cert.openshift-kube-apiserver": "DELETE"},
+			expectedSynced: map[string]string{"secret/user-serving-cert.openshift-kube-apiserver": "DELETE"},
 		},
 		{
 			name:           "NoUserServingCertRef",
 			config:         newAPIServerConfig(),
 			existing:       existingConfig,
 			expected:       map[string]interface{}{},
-			expectedSynced: map[string]string{"configmap/user-serving-cert.openshift-kube-apiserver": "DELETE"},
+			expectedSynced: map[string]string{"secret/user-serving-cert.openshift-kube-apiserver": "DELETE"},
 		},
 		{
 			name:     "HappyPath",
@@ -124,7 +124,7 @@ func TestObserveDefaultServingCertificate(t *testing.T) {
 				},
 			},
 			expectedSynced: map[string]string{
-				"configmap/user-serving-cert.openshift-kube-apiserver": "configmap/happy.openshift-config",
+				"secret/user-serving-cert.openshift-kube-apiserver": "secret/happy.openshift-config",
 			},
 		},
 	}


### PR DESCRIPTION
When specifying a user managed default cert in apiservers/cluster:
```
spec:
  servingCerts:
    defaultServingCertificate:
      name: my-cert-secret
```
The secret is never copied to it final destination, resulting in a crash looping kube-apiserver pod.