### PR TITLE
Bug 1714158 - Limit races between recovery tools and installer pods and cert-syncer

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -86,6 +86,7 @@ spec:
       - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
       - --namespace=$(POD_NAMESPACE)
       - --destination-dir=/etc/kubernetes/static-pod-certs
+      - --pod-manifest-dir=/etc/kubernetes/manifests
     resources:
       requests:
         memory: 50Mi
@@ -95,6 +96,8 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    - mountPath: /etc/kubernetes/manifests
+      name: manifest-dir
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
@@ -107,6 +110,9 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-apiserver-certs
     name: cert-dir
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: manifest-dir
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -391,6 +391,7 @@ spec:
       - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
       - --namespace=$(POD_NAMESPACE)
       - --destination-dir=/etc/kubernetes/static-pod-certs
+      - --pod-manifest-dir=/etc/kubernetes/manifests
     resources:
       requests:
         memory: 50Mi
@@ -400,6 +401,8 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+    - mountPath: /etc/kubernetes/manifests
+      name: manifest-dir
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
@@ -412,6 +415,9 @@ spec:
   - hostPath:
       path: /etc/kubernetes/static-pod-resources/kube-apiserver-certs
     name: cert-dir
+  - hostPath:
+      path: /etc/kubernetes/manifests
+    name: manifest-dir
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir

--- a/vendor/github.com/openshift/library-go/pkg/filelock/filelock.go
+++ b/vendor/github.com/openshift/library-go/pkg/filelock/filelock.go
@@ -1,0 +1,73 @@
+package filelock
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+)
+
+type lock struct {
+	path string
+}
+
+func NewLock(path string) *lock {
+	return &lock{
+		path: path,
+	}
+}
+
+func (l *lock) TryLock() (bool, error) {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_EXCL, 644)
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to create lock file %q: %v", l.path, err)
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			klog.Error(err)
+		}
+	}()
+
+	_, err = f.Write([]byte(strconv.Itoa(os.Getpid())))
+	if err != nil {
+		// We have already acquired the lock so we shouldn't fail on additional info
+		klog.Error(err)
+	}
+
+	return true, nil
+}
+
+func (l *lock) IsLocked() (bool, error) {
+	_, err := os.Stat(l.path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	// The bool return value doesn't matter but if someone was ignoring the error
+	// it is safer to assume the file is locked.
+	return true, fmt.Errorf("failed to determine if lock file %q is present: %v", l.path, err)
+}
+
+func (l *lock) Unlock() error {
+	err := os.Remove(l.path)
+	if err != nil {
+		return fmt.Errorf("failed to remove lock file %q: %v", l.path, err)
+	}
+
+	return nil
+}
+
+func (l *lock) Path() string {
+	return l.path
+}

--- a/vendor/github.com/openshift/library-go/pkg/filelock/filelock_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/filelock/filelock_test.go
@@ -1,0 +1,82 @@
+package filelock
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestIsLocked(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-is-locked")
+	if err != nil {
+		t.Fatalf("failed to create tmp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	l := NewLock(filepath.Join(dir, "lock_file"))
+	locked, err := l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if locked {
+		t.Fatal("With no file present it shouldn't be locked")
+	}
+
+	// First lock should succeed
+	locked, err = l.TryLock()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("Locking failed.")
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("With lock file present it should be locked")
+	}
+
+	// Second lock should fail
+	locked, err = l.TryLock()
+	expErr := fmt.Errorf("failed to create lock file %q: open %s: file exists", l.Path(), l.Path())
+	if !reflect.DeepEqual(err, expErr) {
+		t.Fatalf("Expected error %#v, got %#v", expErr, err)
+	}
+	if locked {
+		t.Fatal("Locking should have failed")
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !locked {
+		t.Fatal("With lock file present it should be locked")
+	}
+
+	err = l.Unlock()
+	if err != nil {
+		t.Errorf("Failed to unlock file: %v", err)
+	}
+
+	locked, err = l.IsLocked()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if locked {
+		t.Fatal("With no lock file present it should be unlocked")
+	}
+
+	// Unlocking unlocked (not present file lock) should fail
+	err = l.Unlock()
+	expErr = fmt.Errorf("failed to remove lock file %q: remove %s: no such file or directory", l.Path(), l.Path())
+	if !reflect.DeepEqual(err, expErr) {
+		t.Fatalf("Expected error %#v, got %#v", expErr, err)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_cmd.go
@@ -23,6 +23,7 @@ type CertSyncControllerOptions struct {
 	KubeConfigFile string
 	Namespace      string
 	DestinationDir string
+	PodManifestDir string
 
 	configMaps []revision.RevisionResource
 	secrets    []revision.RevisionResource
@@ -49,6 +50,7 @@ func NewCertSyncControllerCommand(configmaps, secrets []revision.RevisionResourc
 	}
 
 	cmd.Flags().StringVar(&o.DestinationDir, "destination-dir", o.DestinationDir, "Directory to write to")
+	cmd.Flags().StringVar(&o.PodManifestDir, "pod-manifest-dir", o.PodManifestDir, "Directory for the static pod manifest")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Namespace to read from (default to 'POD_NAMESPACE' environment variable)")
 	cmd.Flags().StringVar(&o.KubeConfigFile, "kubeconfig", o.KubeConfigFile, "Location of the master configuration file to run from.")
 
@@ -81,6 +83,7 @@ func (o *CertSyncControllerOptions) Run() error {
 
 	controller, err := NewCertSyncController(
 		o.DestinationDir,
+		o.PodManifestDir,
 		o.Namespace,
 		o.configMaps,
 		o.secrets,

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/hold/hold.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/hold/hold.go
@@ -1,0 +1,13 @@
+package hold
+
+import (
+	"path/filepath"
+)
+
+var (
+	installerHoldFile = "INSTALLER_HOLD"
+)
+
+func InstallerFile(podManifestDir string) string {
+	return filepath.Join(podManifestDir, installerHoldFile)
+}


### PR DESCRIPTION
It makes `regenerate-certificates` command to create a hold file `/etc/kubernetes/manifests/INSTALLER_HOLD`. 
If an installer pod sees the file when it is starting, it exits because it could rollout a new revision before all the certs are fixed in the api. `regenerate-certificates` force triggers necessary rollouts when it is done.
If cert-syncer pod sees the file when starting, it exits. It uses caches so re-queue would be risky. Kubelet will manage backoff and restart.

Requires:
 - https://github.com/openshift/library-go/pull/420
/hold

TODO:
- [x] Extract library-go changes and re-vendor back
- [x] Emit event when pods run into hold file
