### PR TITLE
Set short rotation period

### DIFF
--- a/bindata/bootkube/manifests/configmap-unsupported-cert-rotation.yaml
+++ b/bindata/bootkube/manifests/configmap-unsupported-cert-rotation.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unsupported-cert-rotation-config
+  namespace: openshift-config
+data:
+  base: 1m


### PR DESCRIPTION
The bug to get this reverted for 4.2 is https://bugzilla.redhat.com/show_bug.cgi?id=1716978

This should set base cert rotation for 1m, which means that most certs will be rotated every 15 minutes, with validity for 30 mins. 

/assign @deads2k  @mfojtik 