### PR TITLE
Revert "Set short rotation period"

### DIFF
--- a/bindata/bootkube/manifests/configmap-unsupported-cert-rotation.yaml
+++ b/bindata/bootkube/manifests/configmap-unsupported-cert-rotation.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: unsupported-cert-rotation-config
-  namespace: openshift-config
-data:
-  base: 1m


### PR DESCRIPTION
This reverts commit b36a3f6066282bca0ce874675539e0854996e2fb, #493

This change killed the past eight hours of e2e-aws tests (e.g. [here][1] and [here][2]), so there's already plenty of data to dig through.  Revert to get CI flowing again for everyone else.

[1]: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/320/pull-ci-openshift-machine-api-operator-master-e2e-aws/1118
[2]: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/22970/pull-ci-openshift-origin-master-e2e-aws/9433