### PR TITLE
Bug 1716426: Backport admission controller fixes

### DIFF
--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,21 +1,13 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admission:
-  pluginConfigs:
+  pluginConfig:
     network.openshift.io/ExternalIPRanger:
       configuration:
         allowIngressIP: true
         apiVersion: network.openshift.io/v1
         externalIPNetworkCIDRs: null
         kind: ExternalIPRangerAdmissionConfig
-      location: ""
-    network.openshift.io/RestrictedEndpointsAdmission:
-      configuration:
-        apiVersion: network.openshift.io/v1
-        kind: RestrictedEndpointsAdmissionConfig
-        restrictedCIDRs:
-        - 10.3.0.0/16 # ServiceCIDR
-        - 10.2.0.0/16 # ClusterCIDR
       location: ""
 aggregatorConfig:
   proxyClientInfo:

--- a/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/kube-apiserver/defaultconfig.yaml
@@ -1,14 +1,5 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
-admission:
-  pluginConfig:
-    network.openshift.io/ExternalIPRanger:
-      configuration:
-        allowIngressIP: true
-        apiVersion: network.openshift.io/v1
-        externalIPNetworkCIDRs: null
-        kind: ExternalIPRangerAdmissionConfig
-      location: ""
 aggregatorConfig:
   proxyClientInfo:
     certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -89,6 +89,7 @@ func NewConfigObserver(
 				[]string{"apiServerArguments", "cloud-config"}),
 			featuregates.NewObserveFeatureFlagsFunc(nil, []string{"apiServerArguments", "feature-gates"}),
 			network.ObserveRestrictedCIDRs,
+			network.ObserveServicesSubnet,
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -15,7 +15,7 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 	listers := genericListers.(configobservation.Listers)
 
 	var errs []error
-	restrictedCIDRsPath := []string{"admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
+	restrictedCIDRsPath := []string{"admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
 
 	previouslyObservedConfig := map[string]interface{}{}
 	if currentRestrictedCIDRBs, _, err := unstructured.NestedStringSlice(existingConfig, restrictedCIDRsPath...); len(currentRestrictedCIDRBs) > 0 {

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -10,57 +10,94 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 )
 
-// ObserveRestrictedCIDRs observes list of restrictedCIDRs.
+// ObserveRestrictedCIDRs generates two configuration
 func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
 	listers := genericListers.(configobservation.Listers)
 
 	var errs []error
-	restrictedCIDRsPath := []string{"admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs"}
+	configPath := []string{"admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration"}
 
-	previouslyObservedConfig := map[string]interface{}{}
-	if currentRestrictedCIDRBs, _, err := unstructured.NestedStringSlice(existingConfig, restrictedCIDRsPath...); len(currentRestrictedCIDRBs) > 0 {
-		if err != nil {
-			errs = append(errs, err)
-		}
-		if err := unstructured.SetNestedStringSlice(previouslyObservedConfig, currentRestrictedCIDRBs, restrictedCIDRsPath...); err != nil {
-			errs = append(errs, err)
-		}
+	admissionControllerConfig := unstructured.Unstructured{}
+	prev, ok, err := unstructured.NestedMap(existingConfig, configPath...)
+	if err != nil {
+		errs = append(errs, err)
 	}
+	if ok && err == nil {
+		// If we ever bump the API version, we'll have to do conversion here.
+		admissionControllerConfig.SetUnstructuredContent(prev)
+	}
+	admissionControllerConfig.SetAPIVersion("network.openshift.io/v1")
+	admissionControllerConfig.SetKind("RestrictedEndpointsAdmissionConfig")
 
-	observedConfig := map[string]interface{}{}
 	clusterCIDRs, err := network.GetClusterCIDRs(listers.NetworkLister, recorder)
 	if err != nil {
 		errs = append(errs, err)
-		return previouslyObservedConfig, errs
 	}
+
 	serviceCIDR, err := network.GetServiceCIDR(listers.NetworkLister, recorder)
 	if err != nil {
 		errs = append(errs, err)
+	}
+
+	// If we weren't able to retrieve cidrs, then return the previous configuration
+	if len(errs) > 0 || len(clusterCIDRs) == 0 || len(serviceCIDR) == 0 {
+		previouslyObservedConfig := map[string]interface{}{}
+		unstructured.SetNestedMap(previouslyObservedConfig, admissionControllerConfig.Object, configPath...)
 		return previouslyObservedConfig, errs
 	}
 
 	// set observed values
-	//  admissionPluginConfig:
-	//    network.openshift.io/RestrictedEndpointsAdmission:
-	//	  configuration:
-	//	    restrictedCIDRs:
-	//	    - 10.3.0.0/16 # ServiceCIDR
-	//	    - 10.2.0.0/16 # ClusterCIDR
-	//  servicesSubnet: 10.3.0.0/16
+	//  admission:
+	//    pluginConfig:
+	//      network.openshift.io/RestrictedEndpointsAdmission:
+	//        configuration:
+	//          version: network.openshift.io/v1
+	//          kind: RestrictedEndpointsAdmission
+	//          restrictedCIDRs:
+	//            - 10.3.0.0/16 # ServiceCIDR
+	//            - 10.2.0.0/16 # ClusterCIDR
 	restrictedCIDRs := clusterCIDRs
 	if len(serviceCIDR) > 0 {
 		restrictedCIDRs = append(restrictedCIDRs, serviceCIDR)
 	}
-	if len(restrictedCIDRs) > 0 {
-		if err := unstructured.SetNestedStringSlice(observedConfig, restrictedCIDRs, restrictedCIDRsPath...); err != nil {
-			errs = append(errs, err)
-		}
+
+	if err := unstructured.SetNestedStringSlice(admissionControllerConfig.Object, restrictedCIDRs, "restrictedCIDRs"); err != nil {
+		errs = append(errs, err)
 	}
-	if len(serviceCIDR) > 0 {
-		if err := unstructured.SetNestedField(observedConfig, serviceCIDR, "servicesSubnet"); err != nil {
-			errs = append(errs, err)
+
+	observedConfig := map[string]interface{}{}
+	unstructured.SetNestedMap(observedConfig, admissionControllerConfig.Object, configPath...)
+
+	return observedConfig, errs
+}
+
+// ObserveServicesSubnet watches the network configuration and generates the
+// servicesSubnet
+func ObserveServicesSubnet(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+
+	out := map[string]interface{}{}
+	configPath := []string{"servicesSubnet"}
+
+	prev, ok, err := unstructured.NestedString(existingConfig, configPath...)
+	if err != nil {
+		return out, []error{err}
+	}
+	if ok {
+		if err := unstructured.SetNestedField(out, prev, configPath...); err != nil {
+			return out, []error{err}
 		}
 	}
 
-	return observedConfig, errs
+	errs := []error{}
+	serviceCIDR, err := network.GetServiceCIDR(listers.NetworkLister, recorder)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := unstructured.SetNestedField(out, serviceCIDR, configPath...); err != nil {
+		errs = append(errs, err)
+	}
+
+	return out, errs
 }

--- a/pkg/operator/configobservation/network/observe_network_test.go
+++ b/pkg/operator/configobservation/network/observe_network_test.go
@@ -5,8 +5,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"k8s.io/client-go/tools/cache"
 
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
@@ -14,8 +14,42 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-func TestObserveClusterConfig(t *testing.T) {
+func TestObserveRestrictedCIDRs(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	listers := configobservation.Listers{
+		NetworkLister: configlistersv1.NewNetworkLister(indexer),
+	}
+
+	// With no network configured, check that a rump configuration is returned
+	result, errors := ObserveRestrictedCIDRs(listers, events.NewInMemoryRecorder("network"), map[string]interface{}{})
+	if len(errors) > 0 {
+		t.Error("expected len(errors) == 0")
+	}
+	if result == nil {
+		t.Errorf("expected result != nil")
+	}
+
+	conf, ok, err := unstructured.NestedMap(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration")
+	if err != nil || !ok {
+		t.Errorf("Unexpected configuration returned: %v", result)
+	}
+	if conf["kind"] != "RestrictedEndpointsAdmissionConfig" {
+		t.Errorf("unexpected Kind %v", conf["kind"])
+	}
+	if conf["apiVersion"] != "network.openshift.io/v1" {
+		t.Errorf("unexpected APIVersion %v", conf["apiVersion"])
+	}
+
+	cidrs, ok, err := unstructured.NestedStringSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if len(cidrs) != 0 {
+		t.Errorf("expected restrictedCIDRs to be empty, got %v", cidrs)
+	}
+
+	// Next, add the network config and see that it reacts
 	if err := indexer.Add(&configv1.Network{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Status: configv1.NetworkStatus{
@@ -25,14 +59,10 @@ func TestObserveClusterConfig(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err.Error())
 	}
-	listers := configobservation.Listers{
-		NetworkLister: configlistersv1.NewNetworkLister(indexer),
-	}
-	result, errors := ObserveRestrictedCIDRs(listers, events.NewInMemoryRecorder("network"), map[string]interface{}{})
-	if len(errors) > 0 {
-		t.Error("expected len(errors) == 0")
-	}
-	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+
+	result, errors = ObserveRestrictedCIDRs(listers, events.NewInMemoryRecorder("network"), map[string]interface{}{})
+
+	restrictedCIDRs, _, err := unstructured.NestedStringSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,5 +71,120 @@ func TestObserveClusterConfig(t *testing.T) {
 	}
 	if restrictedCIDRs[1] != "serviceCIDR" {
 		t.Error(restrictedCIDRs[1])
+	}
+
+	// Update the network config and see that it works
+	if err := indexer.Update(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.NetworkStatus{
+			ClusterNetwork: []configv1.ClusterNetworkEntry{{CIDR: "podCIDR2"}},
+			ServiceNetwork: []string{"serviceCIDR2"},
+		},
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Note that we pass the previous result back in
+	result, errors = ObserveRestrictedCIDRs(listers, events.NewInMemoryRecorder("network"), result)
+
+	restrictedCIDRs, _, err = unstructured.NestedStringSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restrictedCIDRs[0] != "podCIDR2" {
+		t.Error(restrictedCIDRs[0])
+	}
+	if restrictedCIDRs[1] != "serviceCIDR2" {
+		t.Error(restrictedCIDRs[1])
+	}
+
+	// When the network object goes missing (simulate transient failure),
+	// you stll get the old config
+	if err := indexer.Delete(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	result, errors = ObserveRestrictedCIDRs(listers, events.NewInMemoryRecorder("network"), result)
+
+	restrictedCIDRs, _, err = unstructured.NestedStringSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restrictedCIDRs) != 2 {
+		t.Fatalf("expected 2 restrictedCIDRs, got %v", result)
+	}
+	if restrictedCIDRs[0] != "podCIDR2" {
+		t.Error(restrictedCIDRs[0])
+	}
+	if restrictedCIDRs[1] != "serviceCIDR2" {
+		t.Error(restrictedCIDRs[1])
+	}
+
+}
+
+func TestObserveServicesSubnet(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	listers := configobservation.Listers{
+		NetworkLister: configlistersv1.NewNetworkLister(indexer),
+	}
+
+	// With no network configured, check that a rump configuration is returned
+	result, errors := ObserveServicesSubnet(listers, events.NewInMemoryRecorder("network"), map[string]interface{}{})
+	if len(errors) > 0 {
+		t.Error("expected len(errors) == 0")
+	}
+	if result == nil {
+		t.Errorf("expected result != nil")
+	}
+
+	conf, ok, err := unstructured.NestedString(result, "servicesSubnet")
+	if err != nil || !ok {
+		t.Errorf("Unexpected configuration returned: %v", result)
+	}
+	if conf != "" {
+		t.Errorf("Unexpected value: %v", conf)
+	}
+
+	// Next, add the network config and see that it reacts
+	if err := indexer.Add(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.NetworkStatus{
+			ClusterNetwork: []configv1.ClusterNetworkEntry{{CIDR: "podCIDR"}},
+			ServiceNetwork: []string{"serviceCIDR"},
+		},
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	result, errors = ObserveServicesSubnet(listers, events.NewInMemoryRecorder("network"), map[string]interface{}{})
+	conf, ok, err = unstructured.NestedString(result, "servicesSubnet")
+	if err != nil || !ok {
+		t.Errorf("Unexpected configuration returned: %v", result)
+	}
+	if conf != "serviceCIDR" {
+		t.Errorf("Unexpected value: %v", conf)
+	}
+
+	// Change the config and see that it is updated.
+	if err := indexer.Update(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.NetworkStatus{
+			ClusterNetwork: []configv1.ClusterNetworkEntry{{CIDR: "podCIDR1"}},
+			ServiceNetwork: []string{"serviceCIDR1"},
+		},
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	result, errors = ObserveServicesSubnet(listers, events.NewInMemoryRecorder("network"), result)
+	conf, ok, err = unstructured.NestedString(result, "servicesSubnet")
+	if err != nil || !ok {
+		t.Errorf("Unexpected configuration returned: %v", result)
+	}
+	if conf != "serviceCIDR1" {
+		t.Errorf("Unexpected value: %v", conf)
 	}
 }

--- a/pkg/operator/configobservation/network/observe_network_test.go
+++ b/pkg/operator/configobservation/network/observe_network_test.go
@@ -1,9 +1,10 @@
 package network
 
 import (
+	"testing"
+
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
@@ -31,7 +32,7 @@ func TestObserveClusterConfig(t *testing.T) {
 	if len(errors) > 0 {
 		t.Error("expected len(errors) == 0")
 	}
-	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admissionPluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
+	restrictedCIDRs, _, err := unstructured.NestedSlice(result, "admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission", "configuration", "restrictedCIDRs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -141,6 +141,7 @@ func isRequiredConfigPresent(config []byte) error {
 	requiredPaths := [][]string{
 		{"servingInfo", "namedCertificates"},
 		{"storageConfig", "urls"},
+		{"admission", "pluginConfig", "network.openshift.io/RestrictedEndpointsAdmission"},
 	}
 	for _, requiredPath := range requiredPaths {
 		configVal, found, err := unstructured.NestedFieldNoCopy(existingConfig, requiredPath...)

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -35,7 +35,7 @@ func TestIsRequiredConfigPresent(t *testing.T) {
 		     }
 		   ]
 		 },
-         "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
+		 "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
 		 "storageConfig": {
 		   "urls": null
 		 }

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -35,6 +35,7 @@ func TestIsRequiredConfigPresent(t *testing.T) {
 		     }
 		   ]
 		 },
+         "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
 		 "storageConfig": {
 		   "urls": null
 		 }
@@ -53,6 +54,7 @@ func TestIsRequiredConfigPresent(t *testing.T) {
 		     }
 		   ]
 		 },
+        "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
 		 "storageConfig": {
 		   "urls": []
 		 }
@@ -71,6 +73,7 @@ func TestIsRequiredConfigPresent(t *testing.T) {
       }
     ]
   },
+  "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
   "storageConfig": {
     "urls": ""
   }
@@ -89,6 +92,7 @@ func TestIsRequiredConfigPresent(t *testing.T) {
 		     }
 		   ]
 		 },
+         "admission": {"pluginConfig": { "network.openshift.io/RestrictedEndpointsAdmission": {}}},
 		 "storageConfig": {
 		   "urls": [ "val" ]
 		 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -80,21 +80,13 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
 admission:
-  pluginConfigs:
+  pluginConfig:
     network.openshift.io/ExternalIPRanger:
       configuration:
         allowIngressIP: true
         apiVersion: network.openshift.io/v1
         externalIPNetworkCIDRs: null
         kind: ExternalIPRangerAdmissionConfig
-      location: ""
-    network.openshift.io/RestrictedEndpointsAdmission:
-      configuration:
-        apiVersion: network.openshift.io/v1
-        kind: RestrictedEndpointsAdmissionConfig
-        restrictedCIDRs:
-        - 10.3.0.0/16 # ServiceCIDR
-        - 10.2.0.0/16 # ClusterCIDR
       location: ""
 aggregatorConfig:
   proxyClientInfo:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -79,15 +79,6 @@ func v3110KubeApiserverCmYaml() (*asset, error) {
 
 var _v3110KubeApiserverDefaultconfigYaml = []byte(`apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
-admission:
-  pluginConfig:
-    network.openshift.io/ExternalIPRanger:
-      configuration:
-        allowIngressIP: true
-        apiVersion: network.openshift.io/v1
-        externalIPNetworkCIDRs: null
-        kind: ExternalIPRangerAdmissionConfig
-      location: ""
 aggregatorConfig:
   proxyClientInfo:
     certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt


### PR DESCRIPTION
This backports the the admission controller fixes in #494, along with an extra commit that leaves the ExternalIPRanger disabled.