### PR TITLE
Bug 1718052: Do not log OAuth tokens in audit logs

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v4.1.0/kube-apiserver/defaultconfig.yaml
@@ -43,6 +43,11 @@ auditConfig:
       resources:
       - group: ""
         resources: ["events"]
+    # Don't log oauth tokens as metadata.name is the secret
+    - level: None
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens", "oauthauthorizetokens"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -122,6 +122,11 @@ auditConfig:
       resources:
       - group: ""
         resources: ["events"]
+    # Don't log oauth tokens as metadata.name is the secret
+    - level: None
+      resources:
+      - group: "oauth.openshift.io"
+        resources: ["oauthaccesstokens", "oauthauthorizetokens"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]


### PR DESCRIPTION
Even the metadata level is not safe as metadata.name is the secret.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@deads2k 