### PR TITLE
manifests: monitor openshift-kube-apiserver namespace

### DIFF
--- a/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
@@ -6,3 +6,4 @@ metadata:
   name: openshift-kube-apiserver
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"

--- a/bindata/v4.1.0/kube-apiserver/ns.yaml
+++ b/bindata/v4.1.0/kube-apiserver/ns.yaml
@@ -6,3 +6,4 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -257,6 +257,7 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "0"
+    openshift.io/cluster-monitoring: "true"
 `)
 
 func v410KubeApiserverNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Currently, any servicemonitor deployed in the openshift-kube-apiserver namespace
is not being monitored.

This fixes it.

/cc @sttts @brancz