### PR TITLE
sets feature-gates in bootstrap-config-overrides for kube-apiserver-o…

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -54,3 +54,9 @@ admission:
         - {{.}}{{end}}{{range .ClusterCIDR}}
         - {{.}}{{end}}
     {{end}}
+apiServerArguments:
+  feature-gates:
+    - "ExperimentalCriticalPodAnnotation=true"
+    - "RotateKubeletServerCertificate=true"
+    - "SupportPodPidsLimit=true"
+    - "LocalStorageCapacityIsolation=false"


### PR DESCRIPTION
explicitly sets the following features gates:
```
"ExperimentalCriticalPodAnnotation=true"
"RotateKubeletServerCertificate=true"
"SupportPodPidsLimit=true"
"LocalStorageCapacityIsolation=false"
```