### PR TITLE
ConfigObservation: add ExternalIPRanger admission controller 

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -91,6 +91,7 @@ func NewConfigObserver(
 			featuregates.NewObserveFeatureFlagsFunc(nil, []string{"apiServerArguments", "feature-gates"}),
 			network.ObserveRestrictedCIDRs,
 			network.ObserveServicesSubnet,
+			network.ObserveExternalIPPolicy,
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,


### PR DESCRIPTION
API PR: https://github.com/openshift/api/pull/347

This PR adds support for configuring the ExternalIPRanger admission controller from the new ExternalIPs field on the Network configuration object.