### PR TITLE
use the new image since the installer is setting it correctly

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -158,8 +158,6 @@ func (r *renderOpts) Run() error {
 	if err := r.manifest.ApplyTo(&renderConfig.ManifestConfig); err != nil {
 		return err
 	}
-	// stomp the image until we cycle past our change
-	renderConfig.Image = r.newImage
 
 	if err := r.generic.ApplyTo(
 		&renderConfig.FileConfig,


### PR DESCRIPTION
Part 5 of the 7 step plan from https://github.com/openshift/cluster-kube-apiserver-operator/pull/510