### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
 test-e2e: GO_TEST_FLAGS += -v
 test-e2e: test-unit
 
+.PHONY: test-sec
+test-sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium -confidence medium -exclude G304 -quiet ./...
+
 CRD_SCHEMA_GEN_VERSION := v1.0.0
 crd-schema-gen:
 	git clone -b $(CRD_SCHEMA_GEN_VERSION) --single-branch --depth 1 https://github.com/openshift/crd-schema-gen.git $(CRD_SCHEMA_GEN_GOPATH)/src/github.com/openshift/crd-schema-gen

--- a/pkg/cmd/insecurereadyz/readyz.go
+++ b/pkg/cmd/insecurereadyz/readyz.go
@@ -71,6 +71,9 @@ func (r *readyzOpts) Complete() error {
 
 // Run contains the logic of the insecure-readyz command.
 func (r *readyzOpts) Run() error {
+	// #nosec
+	// gosec(G402): This is already assumed to skip the verification and that's
+	// the intent. So we can ignore this warning.
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}

--- a/pkg/cmd/regeneratecerts/regenerate_certificates.go
+++ b/pkg/cmd/regeneratecerts/regenerate_certificates.go
@@ -340,6 +340,9 @@ func (o *Options) Run() error {
 		}
 
 		dir := filepath.Join(def.toplevelDir, def.objectType, def.name)
+		// #nosec
+		// gosec(G301): This contains public certiicates, so it should be
+		// public.
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
 			return fmt.Errorf("failed to create dir %q: %v", dir, err)

--- a/pkg/recovery/apiserver.go
+++ b/pkg/recovery/apiserver.go
@@ -189,7 +189,7 @@ func (s *Apiserver) Create() error {
 	}
 
 	s.recoveryResourcesDir = filepath.Join(s.StaticPodResourcesDir, "recovery-kube-apiserver-pod")
-	err = os.Mkdir(s.recoveryResourcesDir, 755)
+	err = os.Mkdir(s.recoveryResourcesDir, 0750)
 	if err != nil {
 		if os.IsExist(err) {
 			klog.Errorf("Recovery dir %q already exist. Please use `recovery-apiserver destroy` command or remove the dir manually.", s.recoveryResourcesDir)


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile.

Warnings were also addressed as part of this PR.