### PR TITLE
Bug 1720770: remove broken default serving cert

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -64,6 +64,8 @@ var ObserveUserClientCABundle configobserver.ObserveConfigFunc = (&apiServerObse
 
 // ObserveDefaultUserServingCertificate returns an ObserveConfigFunc that observes user managed TLS cert info for
 // serving secure traffic.
+// We are disabling this because it doesn't work today and customers aren't going to be able to get the kube service network options right.
+// Customers may only use SNI.  I'm leaving this code in case we ever come up with a way to make an SNI-like thing based on IPs.
 var ObserveDefaultUserServingCertificate configobserver.ObserveConfigFunc = (&apiServerObserver{
 	observerFunc:  observeDefaultUserServingCertificate,
 	configPaths:   [][]string{{"servingInfo", "certFile"}, {"servingInfo", "keyFile"}},

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -78,7 +78,9 @@ func NewConfigObserver(
 					configInformer.Config().V1().Schedulers().Informer().HasSynced,
 				),
 			},
-			apiserver.ObserveDefaultUserServingCertificate,
+			// We are disabling this because it doesn't work today and customers aren't going to be able to get the kube service network options right.
+			// Customers may only use SNI.  I'm leaving this code in case we ever come up with a way to make an SNI-like thing based on IPs.
+			//apiserver.ObserveDefaultUserServingCertificate,
 			apiserver.ObserveNamedCertificates,
 			apiserver.ObserveUserClientCABundle,
 			apiserver.ObserveAdditionalCORSAllowedOrigins,


### PR DESCRIPTION
Based on bug https://bugzilla.redhat.com/show_bug.cgi?id=1720770 , this setting never worked.

This setting is inherently dangerous because we rely on the default serving cert to have critical IPs included in valid names to allow the service network to continue to function.  Customers should instead use the SNI capabilities we have to provide their certificates.

This pull removes our attempt to honor the setting and we will ripple through the API and the docs (https://github.com/openshift/openshift-docs/pull/15642)

/assign @sttts 
@derekwaynecarr we had an accident.