### PR TITLE
Bug 1729242: OCP 4 AWS privilege escalation vulnerability by running pods on masters

### DIFF
--- a/pkg/operator/configobservation/scheduler/observer_scheduler_test.go
+++ b/pkg/operator/configobservation/scheduler/observer_scheduler_test.go
@@ -15,27 +15,45 @@ import (
 
 func TestObserveSchedulerConfig(t *testing.T) {
 	nodeSelector := "type=user-node,region=east"
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if err := indexer.Add(&configv1.Scheduler{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-		Spec: configv1.SchedulerSpec{
-			DefaultNodeSelector: nodeSelector,
+	tests := []struct {
+		description          string
+		nodeSelectorExpected string
+		SchedulerSpec        configv1.SchedulerSpec
+	}{
+		{
+			description:          "Empty scheduler spec",
+			nodeSelectorExpected: workerNodeSelector,
+			SchedulerSpec:        configv1.SchedulerSpec{},
 		},
-	}); err != nil {
-		t.Fatal(err.Error())
+		{
+			description:          "Non-empty scheduler spec",
+			nodeSelectorExpected: nodeSelector,
+			SchedulerSpec: configv1.SchedulerSpec{
+				DefaultNodeSelector: nodeSelector,
+			},
+		},
 	}
-	listers := configobservation.Listers{
-		SchedulerLister: configlistersv1.NewSchedulerLister(indexer),
-	}
-	result, errors := ObserveDefaultNodeSelector(listers, events.NewInMemoryRecorder("scheduler"), map[string]interface{}{})
-	if len(errors) > 0 {
-		t.Fatalf("expected len(errors) == 0")
-	}
-	observedSelector, _, err := unstructured.NestedString(result, "projectConfig", "defaultNodeSelector")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if observedSelector != nodeSelector {
-		t.Fatalf("expected nodeselector to be %v but got %v", nodeSelector, observedSelector)
+	for _, test := range tests {
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		if err := indexer.Add(&configv1.Scheduler{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			Spec:       test.SchedulerSpec,
+		}); err != nil {
+			t.Fatal(err.Error())
+		}
+		listers := configobservation.Listers{
+			SchedulerLister: configlistersv1.NewSchedulerLister(indexer),
+		}
+		result, errors := ObserveDefaultNodeSelector(listers, events.NewInMemoryRecorder("scheduler"), map[string]interface{}{})
+		if len(errors) > 0 {
+			t.Fatalf("expected len(errors) == 0")
+		}
+		observedSelector, _, err := unstructured.NestedString(result, "projectConfig", "defaultNodeSelector")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if observedSelector != test.nodeSelectorExpected {
+			t.Fatalf("expected nodeselector to be %v but got %v in %v", test.nodeSelectorExpected, observedSelector, test.description)
+		}
 	}
 }


### PR DESCRIPTION
Make worker label as defaultNodeSelector to avoid pods getting scheduled to master nodes.

/cc @deads2k @enj @sttts 