### PR TITLE
Bug 1731232: Report infrastructure provider metric from the operator

### DIFF
--- a/pkg/operator/configmetrics/configmetrics.go
+++ b/pkg/operator/configmetrics/configmetrics.go
@@ -1,0 +1,48 @@
+package configmetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+// Register exposes core platform metrics that relate to the configuration
+// of Kubernetes.
+// TODO: in the future this may move to cluster-config-operator.
+func Register(configInformer configinformers.SharedInformerFactory) {
+	prometheus.MustRegister(&configMetrics{
+		infrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
+		cloudProvider: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_infrastructure_provider",
+			Help: "Reports whether the cluster is configured with an infrastructure provider. type is unset if no cloud provider is recognized or set to the constant used by the Infrastructure config. Region is set when the cluster clearly identifies a region within the provider.",
+		}, []string{"type", "region"}),
+	})
+}
+
+// configMetrics implements metrics gathering for this component.
+type configMetrics struct {
+	infrastructureLister configlisters.InfrastructureLister
+	cloudProvider        *prometheus.GaugeVec
+}
+
+// Describe reports the metadata for metrics to the prometheus collector.
+func (m *configMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.cloudProvider.WithLabelValues("", "").Desc()
+}
+
+// Collect calculates metrics from the cached config and reports them to the prometheus collector.
+func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
+	if infra, err := m.infrastructureLister.Get("cluster"); err == nil {
+		if status := infra.Status.PlatformStatus; status != nil {
+			switch {
+			case status.AWS != nil:
+				ch <- m.cloudProvider.WithLabelValues(string(status.Type), status.AWS.Region)
+			case status.GCP != nil:
+				ch <- m.cloudProvider.WithLabelValues(string(status.Type), status.GCP.Region)
+			default:
+				ch <- m.cloudProvider.WithLabelValues(string(status.Type), "")
+			}
+		}
+	}
+}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,13 +1,14 @@
 package configobservercontroller
 
 import (
-	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"k8s.io/client-go/tools/cache"
 
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
+
 	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configmetrics"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/resourcesynccontroller"
@@ -150,6 +151,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
+
+	configmetrics.Register(configInformers)
 
 	operatorConfigInformers.Start(ctx.Done())
 	kubeInformersForNamespaces.Start(ctx.Done())


### PR DESCRIPTION
The infrastructure provider metric summarizes the desired type and
region (if any) to prometheus, based on the desired config. If type
is not recognized it is passed along, if it is empty it is set as
empty.