### PR TITLE
metrics: Report values to improve querying for core metrics

### DIFF
--- a/pkg/operator/configmetrics/configmetrics.go
+++ b/pkg/operator/configmetrics/configmetrics.go
@@ -3,6 +3,7 @@ package configmetrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 )
@@ -15,12 +16,12 @@ func Register(configInformer configinformers.SharedInformerFactory) {
 		infrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
 		cloudProvider: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_infrastructure_provider",
-			Help: "Reports whether the cluster is configured with an infrastructure provider. type is unset if no cloud provider is recognized or set to the constant used by the Infrastructure config. Region is set when the cluster clearly identifies a region within the provider.",
+			Help: "Reports whether the cluster is configured with an infrastructure provider. type is unset if no cloud provider is recognized or set to the constant used by the Infrastructure config. region is set when the cluster clearly identifies a region within the provider. The value is 1 if a cloud provider is set or 0 if it is unset.",
 		}, []string{"type", "region"}),
 		featuregateLister: configInformer.Config().V1().FeatureGates().Lister(),
 		featureSet: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_feature_set",
-			Help: "Reports the feature set the cluster is configured to expose. name corresponds to the featureSet field of the cluster.",
+			Help: "Reports the feature set the cluster is configured to expose. name corresponds to the featureSet field of the cluster. The value is 1 if a cloud provider is supported.",
 		}, []string{"name"}),
 	})
 }
@@ -43,17 +44,32 @@ func (m *configMetrics) Describe(ch chan<- *prometheus.Desc) {
 func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
 	if infra, err := m.infrastructureLister.Get("cluster"); err == nil {
 		if status := infra.Status.PlatformStatus; status != nil {
+			var g prometheus.Gauge
+			var value float64 = 1
 			switch {
+			// it is illegal to set type to empty string, so let the default case handle
+			// empty string (so we can detect it) while preserving the constant None here
+			case status.Type == configv1.NonePlatformType:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
+				value = 0
 			case status.AWS != nil:
-				ch <- m.cloudProvider.WithLabelValues(string(status.Type), status.AWS.Region)
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.AWS.Region)
 			case status.GCP != nil:
-				ch <- m.cloudProvider.WithLabelValues(string(status.Type), status.GCP.Region)
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.GCP.Region)
 			default:
-				ch <- m.cloudProvider.WithLabelValues(string(status.Type), "")
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
 			}
+			g.Set(value)
+			ch <- g
 		}
 	}
 	if features, err := m.featuregateLister.Get("cluster"); err == nil {
-		ch <- m.featureSet.WithLabelValues(string(features.Spec.FeatureSet))
+		g := m.featureSet.WithLabelValues(string(features.Spec.FeatureSet))
+		if features.Spec.FeatureSet == configv1.Default {
+			g.Set(1)
+		} else {
+			g.Set(0)
+		}
+		ch <- g
 	}
 }


### PR DESCRIPTION
By convention constant metrics in prometheus use value 1 when "enabled".
Map value 1 to "has cloud provider" for the cluster_infrastructure_provider
metric  and value 1 to "using defaults" for the cluster_feature_set metric.

Also clarify the difference between "None" and empty string for cloud
provider type for future reference.

Follow on to #526 and #527 after playing with queries.