### PR TITLE
Start observing the Proxy object

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3242396de82077cf03c242cfe43d626bf4a5b69be0be6ad4de530c7004a6edb2
-updated: 2019-07-31T14:54:14.270029363-04:00
+updated: 2019-08-02T14:02:34.100638375+02:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: b1115bf8e14a60131a196f908223e4506b0ddc35
@@ -268,7 +268,7 @@ imports:
   - operator/clientset/versioned/scheme
   - operator/clientset/versioned/typed/operator/v1
 - name: github.com/openshift/library-go
-  version: 950af653b51af28697df79f1406fc9d21f722db8
+  version: 2532fbc98082c0e00f29fca09d97bcb0d774b9d2
   subpackages:
   - pkg/assets
   - pkg/certs
@@ -287,6 +287,7 @@ imports:
   - pkg/operator/configobserver/cloudprovider
   - pkg/operator/configobserver/featuregates
   - pkg/operator/configobserver/network
+  - pkg/operator/configobserver/proxy
   - pkg/operator/events
   - pkg/operator/genericoperatorclient
   - pkg/operator/loglevel
@@ -419,7 +420,7 @@ imports:
   - container/intsets
   - imports
 - name: google.golang.org/appengine
-  version: b2f4a3cf3c67576a2ee09e1fe62656a5086ce880
+  version: fb139bde60fa77cede04f226b4d5a3cf68dcce27
   subpackages:
   - internal
   - internal/base

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/configobserver/proxy"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -57,6 +58,7 @@ func NewConfigObserver(
 				ImageConfigLister:     configInformer.Config().V1().Images().Lister(),
 				InfrastructureLister_: configInformer.Config().V1().Infrastructures().Lister(),
 				NetworkLister:         configInformer.Config().V1().Networks().Lister(),
+				ProxyLister_:          configInformer.Config().V1().Proxies().Lister(),
 				SchedulerLister:       configInformer.Config().V1().Schedulers().Lister(),
 
 				ConfigmapLister:              kubeInformersForNamespaces.ConfigMapLister(),
@@ -74,6 +76,7 @@ func NewConfigObserver(
 					configInformer.Config().V1().Images().Informer().HasSynced,
 					configInformer.Config().V1().Infrastructures().Informer().HasSynced,
 					configInformer.Config().V1().Networks().Informer().HasSynced,
+					configInformer.Config().V1().Proxies().Informer().HasSynced,
 					configInformer.Config().V1().Schedulers().Informer().HasSynced,
 				),
 			},
@@ -93,6 +96,7 @@ func NewConfigObserver(
 			network.ObserveRestrictedCIDRs,
 			network.ObserveServicesSubnet,
 			network.ObserveExternalIPPolicy,
+			proxy.NewProxyObserveFunc([]string{"targetconfigcontroller", "proxy"}),
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,
 			images.ObserveAllowedRegistriesForImport,
@@ -112,6 +116,7 @@ func NewConfigObserver(
 	configInformer.Config().V1().Authentications().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().APIServers().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Networks().Informer().AddEventHandler(c.EventHandler())
+	configInformer.Config().V1().Proxies().Informer().AddEventHandler(c.EventHandler())
 	configInformer.Config().V1().Schedulers().Informer().AddEventHandler(c.EventHandler())
 
 	return c

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -18,6 +18,7 @@ type Listers struct {
 	InfrastructureLister_ configlistersv1.InfrastructureLister
 	ImageConfigLister     configlistersv1.ImageLister
 	NetworkLister         configlistersv1.NetworkLister
+	ProxyLister_          configlistersv1.ProxyLister
 	SchedulerLister       configlistersv1.SchedulerLister
 
 	OpenshiftEtcdEndpointsLister corelistersv1.EndpointsLister
@@ -37,6 +38,10 @@ func (l Listers) InfrastructureLister() configlistersv1.InfrastructureLister {
 
 func (l Listers) ResourceSyncer() resourcesynccontroller.ResourceSyncer {
 	return l.ResourceSync
+}
+
+func (l Listers) ProxyLister() configlistersv1.ProxyLister {
+	return l.ProxyLister_
 }
 
 func (l Listers) PreRunHasSynced() []cache.InformerSynced {

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/default.example.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/default.example.mk
@@ -20,12 +20,12 @@ CODEGEN_GROUPS_VERSION :=openshiftapiserver:v1alpha1
 #   $ make -n --print-data-base | grep ^CODEGEN
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
-# $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-openshift-apiserver-operator,./Dockerfile,.)
+$(call build-image,ocp-cli,registry.svc.ci.openshift.org/ocp/4.2:cli,./images/cli/Dockerfile.rhel,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/default.example.mk.help.log
@@ -4,7 +4,7 @@ build
 clean
 clean-binaries
 help
-image-origin-cluster-openshift-apiserver-operator
+image-ocp-cli
 images
 test
 test-unit

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/operator.example.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/operator.example.mk
@@ -22,12 +22,12 @@ CODEGEN_GROUPS_VERSION :=openshiftapiserver:v1alpha1
 #   $ make -n --print-data-base | grep ^CODEGEN
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
-# $0 - macro name
-# $1 - target suffix
-# $2 - Dockerfile path
-# $3 - context directory for image build
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-openshift-apiserver-operator,./Dockerfile,.)
+$(call build-image,ocp-openshift-apiserver-operator,registry.svc.ci.openshift.org/ocp/4.2:openshift-apiserver-operator,./Dockerfile.rhel,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/operator.example.mk.help.log
@@ -4,7 +4,7 @@ build
 clean
 clean-binaries
 help
-image-origin-cluster-openshift-apiserver-operator
+image-ocp-openshift-apiserver-operator
 images
 test
 test-unit

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/images.mk
@@ -1,19 +1,23 @@
-IMAGE_REGISTRY ?=
-IMAGE_ORG ?=openshift
-IMAGE_TAG ?=latest
-
-
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
 # e.g. to mount secrets and repo information into base image like:
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'
+IMAGE_BUILD_DEFAULT_FLAGS ?=--allow-pull
 IMAGE_BUILD_EXTRA_FLAGS ?=
 
-# $1 - image name
-# $2 - Dockerfile path
-# $3 - context
+# $1 - target name
+# $2 - image ref
+# $3 - Dockerfile path
+# $4 - context
 define build-image-internal
 image-$(1):
-	$(strip imagebuilder --allow-pull $(IMAGE_BUILD_EXTRA_FLAGS) -f $(2) -t $(addsuffix /,$(IMAGE_REGISTRY))$(addsuffix /,$(IMAGE_ORG))$(1)$(addprefix :,$(IMAGE_TAG)) $(3))
+	$(strip \
+		imagebuilder \
+		$(IMAGE_BUILD_DEFAULT_FLAGS) \
+		-t $(2)
+		-f $(3) \
+		$(IMAGE_BUILD_EXTRA_FLAGS) \
+		$(4) \
+	)
 .PHONY: image-$(1)
 
 images: image-$(1)
@@ -21,5 +25,5 @@ images: image-$(1)
 endef
 
 define build-image
-$(eval $(call build-image-internal,$(1),$(2),$(3)))
+$(eval $(call build-image-internal,$(1),$(2),$(3),$(4)))
 endef

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/observe_proxy.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/observe_proxy.go
@@ -56,7 +56,7 @@ func (f *observeProxyFlags) ObserveProxyConfig(genericListers configobserver.Lis
 	}
 
 	newProxyMap := proxyToMap(proxyConfig)
-	if len(newProxyMap) > 0 {
+	if newProxyMap != nil {
 		if err := unstructured.SetNestedStringMap(observedConfig, newProxyMap, f.configPath...); err != nil {
 			errs = append(errs, err)
 		}
@@ -82,6 +82,10 @@ func proxyToMap(proxy *configv1.Proxy) map[string]string {
 
 	if httpsProxy := proxy.Spec.HTTPSProxy; len(httpsProxy) > 0 {
 		proxyMap["HTTPS_PROXY"] = httpsProxy
+	}
+
+	if len(proxyMap) == 0 {
+		return nil
 	}
 
 	return proxyMap

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/observe_proxy_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/proxy/observe_proxy_test.go
@@ -33,10 +33,12 @@ func TestObserveProxyConfig(t *testing.T) {
 	configPath := []string{"openshift", "proxy"}
 
 	tests := []struct {
-		name          string
-		proxySpec     configv1.ProxySpec
-		expected      map[string]interface{}
-		expectedError []error
+		name           string
+		proxySpec      configv1.ProxySpec
+		previous       map[string]string
+		expected       map[string]interface{}
+		expectedError  []error
+		eventsExpected int
 	}{
 		{
 			name:          "all unset",
@@ -60,7 +62,8 @@ func TestObserveProxyConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedError: []error{},
+			expectedError:  []error{},
+			eventsExpected: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +88,9 @@ func TestObserveProxyConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(errorsGot, tt.expectedError) {
 				t.Errorf("observeProxyFlags.ObserveProxyConfig() errorsGot = %v, want %v", errorsGot, tt.expectedError)
+			}
+			if events := eventRecorder.Events(); len(events) != tt.eventsExpected {
+				t.Errorf("expected %d events, but got %d: %v", tt.eventsExpected, len(events), events)
 			}
 		})
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -600,7 +600,7 @@ func (c *InstallerController) newNodeStateForInstallInProgress(currNodeState *op
 		ret.LastFailedRevision = currNodeState.TargetRevision
 		ret.TargetRevision = 0
 		if len(errors) == 0 {
-			errors = append(errors, "no detailed termination message, see `oc get -n %q pods/%q -oyaml`", installerPod.Namespace, installerPod.Name)
+			errors = append(errors, fmt.Sprintf("no detailed termination message, see `oc get -n %q pods/%q -oyaml`", installerPod.Namespace, installerPod.Name))
 		}
 		ret.LastFailedRevisionErrors = errors
 		return ret, false, "installer pod failed", nil


### PR DESCRIPTION
Adds an observer for the Proxy object, pulls its fields and passes
them to the environment of the deployed kube-apiserver container.