### PR TITLE
Bug 1733109: Fix kube-apiserver-to-kubelet-signer validity

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -124,8 +124,8 @@ func NewCertRotationController(
 		certrotation.SigningRotation{
 			Namespace:     operatorclient.OperatorNamespace,
 			Name:          "kube-apiserver-to-kubelet-signer",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
-			Refresh:       8 * 365 * defaultRotationDay,  // this means we effectively do not rotate
+			Validity:      1 * 365 * defaultRotationDay, // this comes from the installer
+			Refresh:       8 * 365 * defaultRotationDay, // this means we effectively do not rotate
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),


### PR DESCRIPTION
It should have been 1 year as is in bootstrap
https://bugzilla.redhat.com/show_bug.cgi?id=1733109

/cc @deads2k 
/cherrypick release-4.1