### PR TITLE
Bug 1733232: Fix kube-apiserver-to-kubelet-signer validity

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -124,8 +124,8 @@ func NewCertRotationController(
 		certrotation.SigningRotation{
 			Namespace:     operatorclient.OperatorNamespace,
 			Name:          "kube-apiserver-to-kubelet-signer",
-			Validity:      10 * 365 * rotationDay, // this comes from the installer
-			Refresh:       8 * 365 * rotationDay,  // this means we effectively do not rotate
+			Validity:      1 * 365 * rotationDay, // this comes from the installer
+			Refresh:       8 * 365 * rotationDay, // this means we effectively do not rotate
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-kube-apiserver-operator/pull/533

https://bugzilla.redhat.com/show_bug.cgi?id=1733232

/cc @deads2k @mfojtik 