### PR TITLE
BUG 1732377: Fix kube-apiserver image in rest of the files to use hypekube

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/recovery-config.yaml
+++ b/bindata/v4.1.0/kube-apiserver/recovery-config.yaml
@@ -18,9 +18,9 @@ storageConfig:
   urls:
   - "https://localhost:2379"
 
-# Make hypershift happy.
+# Make our modified kube-apiserver happy.
 # (Everything bellow this line is just to provide some certs file
-# because hypershift tries to read those even if you don't want to set them up.)
+# because our modified kube-apiserver tries to read those even if you don't want to set them up.)
 authConfig:
   oauthMetadataFile: ""
   requestHeader:

--- a/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
@@ -11,9 +11,9 @@ spec:
     image: "{{ .KubeApiserverImage }}"
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["hypershift", "openshift-kube-apiserver"]
+    command: ["hyperkube", "kube-apiserver"]
     args:
-    - --config=/etc/kubernetes/static-pod-resources/config.yaml
+    - --openshift-config=/etc/kubernetes/static-pod-resources/config.yaml
     resources:
       requests:
         memory: 1Gi

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,10 +6,6 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
-  - name: hypershift
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-hypershift:v4.0
   - name: hyperkube
     from:
       kind: DockerImage

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -38,7 +38,7 @@ type renderOpts struct {
 func NewRenderCommand() *cobra.Command {
 	renderOpts := renderOpts{
 		generic:  *genericrenderoptions.NewGenericOptions(),
-		manifest: *genericrenderoptions.NewManifestOptions("kube-apiserver", "openshift/origin-hypershift:latest"),
+		manifest: *genericrenderoptions.NewManifestOptions("kube-apiserver", "openshift/origin-hyperkube:latest"),
 
 		lockHostPath:   "/var/run/kubernetes/lock",
 		etcdServerURLs: []string{"https://127.0.0.1:2379"},

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -465,9 +465,9 @@ storageConfig:
   urls:
   - "https://localhost:2379"
 
-# Make hypershift happy.
+# Make our modified kube-apiserver happy.
 # (Everything bellow this line is just to provide some certs file
-# because hypershift tries to read those even if you don't want to set them up.)
+# because our modified kube-apiserver tries to read those even if you don't want to set them up.)
 authConfig:
   oauthMetadataFile: ""
   requestHeader:
@@ -512,9 +512,9 @@ spec:
     image: "{{ .KubeApiserverImage }}"
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
-    command: ["hypershift", "openshift-kube-apiserver"]
+    command: ["hyperkube", "kube-apiserver"]
     args:
-    - --config=/etc/kubernetes/static-pod-resources/config.yaml
+    - --openshift-config=/etc/kubernetes/static-pod-resources/config.yaml
     resources:
       requests:
         memory: 1Gi

--- a/pkg/recovery/apiserver_test.go
+++ b/pkg/recovery/apiserver_test.go
@@ -17,7 +17,7 @@ func int64Ptr(v int64) *int64 {
 }
 
 func TestApiserverRecoveryPod(t *testing.T) {
-	const image = "hypershift:latest"
+	const image = "hyperkube:latest"
 
 	tt := []struct {
 		name          string
@@ -65,8 +65,8 @@ func TestApiserverRecoveryPod(t *testing.T) {
 						{
 							Name:    "kube-apiserver-recovery",
 							Image:   image,
-							Command: []string{"hypershift", "openshift-kube-apiserver"},
-							Args:    []string{"--config=/etc/kubernetes/static-pod-resources/config.yaml"},
+							Command: []string{"hyperkube", "kube-apiserver"},
+							Args:    []string{"--openshift-config=/etc/kubernetes/static-pod-resources/config.yaml"},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 7443,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732377

leftovers from https://github.com/openshift/cluster-kube-apiserver-operator/pull/511

/cc @sttts @deads2k 