### PR TITLE
Bug 1732945: Fallback to platform type on 4.1 infra metrics

### DIFF
--- a/pkg/operator/configmetrics/configmetrics.go
+++ b/pkg/operator/configmetrics/configmetrics.go
@@ -59,6 +59,22 @@ func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
 			}
 			g.Set(value)
 			ch <- g
+		} else {
+			// if the parent has not reported platform status yet
+			infraType := infra.Status.Platform
+			var g prometheus.Gauge
+			var value float64 = 1
+			switch {
+			// it is illegal to set type to empty string, so let the default case handle
+			// empty string (so we can detect it) while preserving the constant None here
+			case infraType == configv1.NonePlatformType:
+				g = m.cloudProvider.WithLabelValues(string(infraType), "")
+				value = 0
+			default:
+				g = m.cloudProvider.WithLabelValues(string(infraType), "")
+			}
+			g.Set(value)
+			ch <- g
 		}
 	}
 	if features, err := m.featuregateLister.Get("cluster"); err == nil {


### PR DESCRIPTION
4.1 clusters do not set infrastructure.status.platformStatus, causing the metric for cluster infrastructure to be empty. If platformstatus is nil, fallback to infrastructure type. A bug has been opened to ensure 4.2 clusters have platformStatus set during upgrade.

The previous PR #531 did not cover this difference and so reported an empty metric.