### PR TITLE
fix `make images`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 # $2 - Dockerfile path
 # $3 - context directory for image build
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-cluster-kube-apiserver-operator,./Dockerfile,.)
+$(call build-image,origin-cluster-kube-apiserver-operator,origin-cluster-kube-apiserver-operator,./Dockerfile,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name


### PR DESCRIPTION
The internals of the `make images` now take four arguments:
- target name
- tag
- file
- context

/cc @sttts @tnozicka 