### PR TITLE
only use the internalIP to speak to kubelets

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/defaultconfig.yaml
+++ b/bindata/v4.1.0/kube-apiserver/defaultconfig.yaml
@@ -25,6 +25,8 @@ apiServerArguments:
   - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+  kubelet-preferred-address-types:
+  - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -105,6 +105,8 @@ apiServerArguments:
   - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+  kubelet-preferred-address-types:
+  - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
This allows the NO_PROXY setting to only list internal node CIDRs which reduces churn as nodes are added and removed.

I'm not completely sure of all the downstream impacts from this choice.