### PR TITLE
Add a controller to check pod creation errors

### DIFF
--- a/pkg/operator/errorreportcontroller/errorreportcontroller.go
+++ b/pkg/operator/errorreportcontroller/errorreportcontroller.go
@@ -1,0 +1,151 @@
+package errorreportcontroller
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/klog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+var (
+	messageToRootCauseMap = map[string]string{
+		"failed to create pod network sandbox": "NetworkError",
+	}
+)
+
+// FIXME: description: ErrorReportController is a controller that sets upgradeable=false if anything outside the whitelist is the specified featuregates.
+type ErrorReportController struct {
+	operatorClient v1helpers.OperatorClient
+	eventsLister   corev1listers.EventNamespaceLister
+
+	regex *regexp.Regexp
+
+	cachesToSync  []cache.InformerSynced
+	eventRecorder events.Recorder
+}
+
+func NewErrorReportController(
+	operatorClient v1helpers.OperatorClient,
+	coreInformer corev1informers.EventInformer,
+	eventRecorder events.Recorder,
+) *ErrorReportController {
+	c := &ErrorReportController{
+		operatorClient: operatorClient,
+		eventsLister:   coreInformer.Lister().Events("openshift-kube-apiserver"),
+		eventRecorder:  eventRecorder.WithComponentSuffix("error-reporter"),
+	}
+
+	// create a regular expression as (cond1|cond2|...) so that we can directly match message to condition reason
+
+	c.regex = constructCumulativeRegex(messageToRootCauseMap)
+	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced, coreInformer.Informer().HasSynced)
+	return c
+}
+
+func (c *ErrorReportController) sync() error {
+	targetEvents, err := c.eventsLister.List(labels.NewSelector())
+	if err != nil {
+		return err
+	}
+
+	cond := checkForPodCreationErrors(c.regex, targetEvents)
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return nil
+}
+
+func constructCumulativeRegex(errorToReasonMap map[string]string) *regexp.Regexp {
+	regexString := "("
+	for re := range errorToReasonMap {
+		regexString += re + "|"
+	}
+	// replace last "|" with ")"
+	regexString = regexString[:len(regexString)-1] + ")"
+
+	return regexp.MustCompile(regexString)
+}
+
+func checkForPodCreationErrors(errorsRegex *regexp.Regexp, events []*corev1.Event) operatorv1.OperatorCondition {
+	reasons := sets.NewString()
+
+	for _, e := range events {
+		if e.Reason != "FailedCreatePodSandBox" {
+			continue
+		}
+
+		// don't include the messages, we just want to be able to see what the issue is right away from the status
+		if matches := errorsRegex.FindStringSubmatch(e.Message); len(matches) > 1 {
+			reason, found := messageToRootCauseMap[matches[1]]
+			if !found {
+				klog.Errorf("couldn't find the reason for match: %s", matches[1])
+			} else {
+				reasons.Insert(reason)
+			}
+		}
+	}
+
+	if reasons.Len() > 0 {
+		return operatorv1.OperatorCondition{
+			Type:   "StaticPodCreationDegraded",
+			Reason: strings.Join(reasons.List(), "_"),
+			Status: operatorv1.ConditionTrue,
+		}
+	}
+
+	return operatorv1.OperatorCondition{
+		Type:   "StaticPodCreationDegraded",
+		Reason: "NoWatchedErrorsAppeared",
+		Status: operatorv1.ConditionFalse,
+	}
+
+}
+
+// Run starts the kube-apiserver and blocks until stopCh is closed.
+func (c *ErrorReportController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting ErrorReportController")
+	defer klog.Infof("Shutting down ErrorReportController")
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *ErrorReportController) runWorker() {
+	for c.processNextWorkItem() {
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (c *ErrorReportController) processNextWorkItem() bool {
+	err := c.sync()
+	if err == nil {
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("sync() failed with : %v", err))
+
+	return true
+}

--- a/pkg/operator/errorreportcontroller/errorreportcontroller_test.go
+++ b/pkg/operator/errorreportcontroller/errorreportcontroller_test.go
@@ -1,0 +1,70 @@
+package errorreportcontroller
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/davecgh/go-spew/spew"
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestCheckForPodCreationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+
+		events   []*corev1.Event
+		expected operatorv1.OperatorCondition
+	}{
+		{
+			name: "no events",
+			expected: operatorv1.OperatorCondition{
+				Type:   "StaticPodCreationDegraded",
+				Reason: "NoWatchedErrorsAppeared",
+				Status: operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "events with network error",
+			events: []*corev1.Event{
+				{
+					Count: 10,
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      "installer-5-control-plane-1",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Message: `(combined from similar events): Failed create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_installer-5-control-plane-1_openshift-kube-apiserver_900db7f3-d2ce-11e9-8fc8-005056be0641_0(121698f4862fd67157ca586cab18aefb048fe5d7b3bd87516098ac0e91a90a13): Multus: Err adding pod to network "openshift-sdn": Multus: error in invoke Delegate add - "openshift-sdn": failed to send CNI request: Post http://dummy/: dial unix /var/run/openshift-sdn/cniserver/socket: connect: connection refused`,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "installer-5-control-plane-1.15c2b2de1c17a9cd",
+						Namespace: "openshift-kube-apiserver",
+					},
+					Reason: "FailedCreatePodSandBox",
+					Source: corev1.EventSource{
+						Component: "kubelet",
+						Host:      "control-plane-1",
+					},
+					Type: corev1.EventTypeWarning,
+				},
+			},
+			expected: operatorv1.OperatorCondition{
+				Type:   "StaticPodCreationDegraded",
+				Reason: "NetworkError",
+				Status: operatorv1.ConditionTrue,
+			},
+		},
+	}
+
+	testRegex := constructCumulativeRegex(messageToRootCauseMap)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := checkForPodCreationErrors(testRegex, test.events)
+
+			if !reflect.DeepEqual(test.expected, actual) {
+				t.Fatal(spew.Sdump(actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This controller is supposed to help us easily track errors that
appear during kube-apiserver pods' bootstrapping simply by
looking at the operator's status.

cc @mfojtik @sttts @deads2k 