### PR TITLE
DO NOT MERGE - Test with new feature gates on by default

### DIFF
--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -100,9 +100,12 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
 			"SupportPodPidsLimit",               // sig-pod, sjenning
+			"NodeDisruptionExclusion",           // sig-workloads, ccoleman
+			"ServiceNodeExclusion",              // sig-workloads, ccoleman
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"LegacyNodeRoleBehavior",        // sig-workloads, ccoleman
 		},
 	},
 	TechPreviewNoUpgrade: {


### PR DESCRIPTION
These three gates remove the linkage between node-role master and
cluster behavior and allow us to run 3 node clusters on cloud providers
out of the box.

Testing here before opening openshift/api PR