### PR TITLE
encryption: add prune controller

### DIFF
--- a/pkg/operator/encryption/helpers_test.go
+++ b/pkg/operator/encryption/helpers_test.go
@@ -212,10 +212,9 @@ func createEncryptionCfgWithWriteKey(keysResources []encryptionKeysResourceTuple
 	}
 }
 
-func createEncryptionCfgSecretWithWriteKeys(t *testing.T, targetNs string, revision string, keysResources []encryptionKeysResourceTuple) *corev1.Secret {
+func createEncryptionCfgSecret(t *testing.T, targetNs string, revision string, encryptionCfg *apiserverconfigv1.EncryptionConfiguration) *corev1.Secret {
 	t.Helper()
 
-	encryptionCfg := createEncryptionCfgWithWriteKey(keysResources)
 	encoder := apiserverCodecs.LegacyCodec(apiserverconfigv1.SchemeGroupVersion)
 	rawEncryptionCfg, err := runtime.Encode(encoder, encryptionCfg)
 	if err != nil {

--- a/pkg/operator/encryption/helpers_test.go
+++ b/pkg/operator/encryption/helpers_test.go
@@ -153,29 +153,32 @@ func actionStrings(actions []clientgotesting.Action) []string {
 }
 
 func createEncryptionCfgNoWriteKey(keyID string, keyBase64 string, resources ...string) *apiserverconfigv1.EncryptionConfiguration {
-	return &apiserverconfigv1.EncryptionConfiguration{
+	ret := &apiserverconfigv1.EncryptionConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "EncryptionConfiguration",
 			APIVersion: "apiserver.config.k8s.io/v1",
 		},
-		Resources: []apiserverconfigv1.ResourceConfiguration{
-			{
-				Resources: resources,
-				Providers: []apiserverconfigv1.ProviderConfiguration{
-					{
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
-					},
-					{
-						AESCBC: &apiserverconfigv1.AESConfiguration{
-							Keys: []apiserverconfigv1.Key{
-								{Name: keyID, Secret: keyBase64},
-							},
+	}
+
+	for _, r := range resources {
+		ret.Resources = append(ret.Resources, apiserverconfigv1.ResourceConfiguration{
+			Resources: []string{r},
+			Providers: []apiserverconfigv1.ProviderConfiguration{
+				{
+					Identity: &apiserverconfigv1.IdentityConfiguration{},
+				},
+				{
+					AESCBC: &apiserverconfigv1.AESConfiguration{
+						Keys: []apiserverconfigv1.Key{
+							{Name: keyID, Secret: keyBase64},
 						},
 					},
 				},
 			},
-		},
+		})
 	}
+
+	return ret
 }
 
 func createEncryptionCfgWithWriteKey(keysResources []encryptionKeysResourceTuple) *apiserverconfigv1.EncryptionConfiguration {

--- a/pkg/operator/encryption/key_controller.go
+++ b/pkg/operator/encryption/key_controller.go
@@ -145,25 +145,23 @@ func (c *keyController) checkAndCreateKeys() error {
 		newKeyID       uint64
 		reasons        []string
 	)
-	if len(desiredEncryptionState) == 0 {
-		// create initial key
-		newKeyRequired = true
-		newKeyID = 1
-		reasons = append(reasons, "no-secrets")
-	} else {
-		for _, grKeys := range desiredEncryptionState {
-			keyID, internalReason, ok := needsNewKey(grKeys, currentMode, externalReason)
-			if !ok {
-				continue
-			}
 
-			newKeyRequired = true
-			nextKeyID := keyID + 1
-			if newKeyID < nextKeyID {
-				newKeyID = nextKeyID
-			}
-			reasons = append(reasons, internalReason)
+	// note here that desiredEncryptionState is never empty because getDesiredEncryptionState
+	// fills up the state with all resources and set identity write key if write key secrets
+	// are missing.
+
+	for _, grKeys := range desiredEncryptionState {
+		keyID, internalReason, ok := needsNewKey(grKeys, currentMode, externalReason)
+		if !ok {
+			continue
 		}
+
+		newKeyRequired = true
+		nextKeyID := keyID + 1
+		if newKeyID < nextKeyID {
+			newKeyID = nextKeyID
+		}
+		reasons = append(reasons, internalReason)
 	}
 
 	if !newKeyRequired {

--- a/pkg/operator/encryption/key_controller_test.go
+++ b/pkg/operator/encryption/key_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-func TestEncryptionKeyController(t *testing.T) {
+func TestKeyController(t *testing.T) {
 	apiServerAesCBC := []runtime.Object{&configv1.APIServer{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 		Spec: configv1.APIServerSpec{
@@ -94,7 +94,9 @@ func TestEncryptionKeyController(t *testing.T) {
 			},
 			targetNamespace: "kms",
 			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "create:secrets:openshift-config-managed"},
-			initialObjects:  []runtime.Object{createDummyKubeAPIPod("kube-apiserver", "kms")},
+			initialObjects: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver", "kms"),
+			},
 			apiServerObjects: []runtime.Object{&configv1.APIServer{
 				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
 				Spec: configv1.APIServerSpec{

--- a/pkg/operator/encryption/migration_controller.go
+++ b/pkg/operator/encryption/migration_controller.go
@@ -47,9 +47,9 @@ const migrationWorkKey = "key"
 //   - a write-key for a resource does not show up in the
 //     encryption.apiserver.operator.openshift.io/migrated-resources And then
 //     starts a migration job (currently in-place synchronously, soon with the upstream migration tool)
-// * updates the encryption.operator.openshift.io/migrated-timestamp and
-//   encryption.operator.openshift.io/migrated-resources annotations on the
-//   write-key secrets used for migration in the previous step.
+// * updates the encryption.apiserver.operator.openshift.io/migrated-timestamp and
+//   encryption.apiserver.operator.openshift.io/migrated-resources annotations on the
+//   current write-key secrets.
 type migrationController struct {
 	operatorClient operatorv1helpers.StaticPodOperatorClient
 

--- a/pkg/operator/encryption/migration_controller_test.go
+++ b/pkg/operator/encryption/migration_controller_test.go
@@ -104,9 +104,12 @@ func TestEncryptionMigrationController(t *testing.T) {
 							},
 						},
 					}
-					ec := createEncryptionCfgSecretWithWriteKeys(t, "kms", "1", []encryptionKeysResourceTuple{keysResForConfigMaps, keysResForSecrets})
-					ec.APIVersion = corev1.SchemeGroupVersion.String()
-					return ec
+
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysResForConfigMaps, keysResForSecrets})
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					ecs.APIVersion = corev1.SchemeGroupVersion.String()
+
+					return ecs
 				}(),
 				func() *corev1.Secret {
 					s := &corev1.Secret{}

--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -1,0 +1,227 @@
+package encryption
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	pruneWorkKey        = "key"
+	keepNumberOfSecrets = 10
+)
+
+// pruneController prevents an unbounded growth of old encryption keys.
+// For a given resource, if there are more than ten keys which have been migrated,
+// this controller will delete the oldest migrated keys until there are ten migrated
+// keys total.  These keys are safe to delete since no data in etcd is encrypted using
+// them.  Keeping a small number of old keys around is meant to help facilitate
+// decryption of old backups (and general precaution).
+type pruneController struct {
+	operatorClient operatorv1helpers.StaticPodOperatorClient
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+
+	preRunCachesSynced []cache.InformerSynced
+
+	encryptedGRs map[schema.GroupResource]bool
+
+	targetNamespace          string
+	encryptionSecretSelector metav1.ListOptions
+
+	podClient    corev1client.PodsGetter
+	secretClient corev1client.SecretsGetter
+}
+
+func newPruneController(
+	targetNamespace string,
+	operatorClient operatorv1helpers.StaticPodOperatorClient,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	podClient corev1client.PodsGetter,
+	secretClient corev1client.SecretsGetter,
+	encryptionSecretSelector metav1.ListOptions,
+	eventRecorder events.Recorder,
+	encryptedGRs map[schema.GroupResource]bool,
+) *pruneController {
+	c := &pruneController{
+		operatorClient: operatorClient,
+
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EncryptionPruneController"),
+		eventRecorder: eventRecorder.WithComponentSuffix("encryption-prune-controller"), // TODO unused
+
+		encryptedGRs:    encryptedGRs,
+		targetNamespace: targetNamespace,
+
+		encryptionSecretSelector: encryptionSecretSelector,
+		podClient:                podClient,
+		secretClient:             secretClient,
+	}
+
+	c.preRunCachesSynced = setUpAllEncryptionInformers(operatorClient, targetNamespace, kubeInformersForNamespaces, c.eventHandler())
+
+	return c
+}
+
+func (c *pruneController) sync() error {
+	if ready, err := shouldRunEncryptionController(c.operatorClient); err != nil || !ready {
+		return err // we will get re-kicked when the operator status updates
+	}
+
+	configError := c.deleteOldMigratedSecrets()
+
+	// update failing condition
+	cond := operatorv1.OperatorCondition{
+		Type:   "EncryptionPruneControllerDegraded",
+		Status: operatorv1.ConditionFalse,
+	}
+	if configError != nil {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Error"
+		cond.Message = configError.Error()
+	}
+	if _, _, updateError := operatorv1helpers.UpdateStaticPodStatus(c.operatorClient, operatorv1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return configError
+}
+
+func (c *pruneController) deleteOldMigratedSecrets() error {
+	_, desiredEncryptionConfig, _, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	if err != nil {
+		return err
+	}
+	// do not try to delete anything during a transition state
+	if len(desiredEncryptionConfig) == 0 {
+		// we are woken up when the pods or secrets change
+		return nil
+	}
+
+	usedSecrets := make([]*corev1.Secret, 0, len(desiredEncryptionConfig))
+	for _, grKeys := range desiredEncryptionConfig {
+		usedSecrets = append(usedSecrets, grKeys.readSecrets...)
+	}
+
+	allkeys, err := c.secretClient.Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace).List(c.encryptionSecretSelector)
+	if err != nil {
+		return err
+	}
+
+	// sort by keyID
+	encryptionSecrets := make([]*corev1.Secret, 0, len(allkeys.Items))
+	for _, s := range allkeys.Items {
+		encryptionSecrets = append(encryptionSecrets, s.DeepCopy()) // don't use &s because it constant through-out the loop
+	}
+	sort.Slice(encryptionSecrets, func(i, j int) bool {
+		// it is fine to ignore the validKeyID bool here because we filtered out invalid secrets in the loop above
+		iKeyID, _ := secretToKeyID(encryptionSecrets[i])
+		jKeyID, _ := secretToKeyID(encryptionSecrets[j])
+		return iKeyID > jKeyID
+	})
+
+	var deleteErrs []error
+	skippedKeys := 0
+	for _, s := range encryptionSecrets {
+		if hasSecret(usedSecrets, *s) {
+			continue
+		}
+
+		// skip the most recent unused secrets around
+		if skippedKeys < keepNumberOfSecrets {
+			skippedKeys++
+			continue
+		}
+
+		// any secret that isn't a read key isn't used.  just delete them.
+		// two phase delete: finalizer, then delete
+
+		// remove our finalizer if it is present
+		secret := s.DeepCopy()
+		if finalizers := sets.NewString(secret.Finalizers...); finalizers.Has(encryptionSecretFinalizer) {
+			delete(finalizers, encryptionSecretFinalizer)
+			secret.Finalizers = finalizers.List()
+			var updateErr error
+			secret, updateErr = c.secretClient.Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace).Update(secret)
+			deleteErrs = append(deleteErrs, updateErr)
+			if updateErr != nil {
+				continue
+			}
+		}
+
+		// remove the actual secret
+		if err := c.secretClient.Secrets(operatorclient.GlobalMachineSpecifiedConfigNamespace).Delete(secret.Name, nil); err != nil {
+			deleteErrs = append(deleteErrs, err)
+		} else {
+			klog.V(4).Infof("Successfully pruned secret %s/%s", secret.Namespace, secret.Name)
+		}
+	}
+	return utilerrors.FilterOut(utilerrors.NewAggregate(deleteErrs), errors.IsNotFound)
+}
+
+func (c *pruneController) run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting EncryptionPruneController")
+	defer klog.Infof("Shutting down EncryptionPruneController")
+	if !cache.WaitForCacheSync(stopCh, c.preRunCachesSynced...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// only start one worker
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *pruneController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *pruneController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func (c *pruneController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(pruneWorkKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(pruneWorkKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(pruneWorkKey) },
+	}
+}

--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -141,7 +141,7 @@ func (c *pruneController) deleteOldMigratedSecrets() error {
 	var deleteErrs []error
 	skippedKeys := 0
 	for _, s := range encryptionSecrets {
-		if hasSecret(usedSecrets, *s) {
+		if hasSecret(usedSecrets, s) {
 			continue
 		}
 

--- a/pkg/operator/encryption/prune_controller_test.go
+++ b/pkg/operator/encryption/prune_controller_test.go
@@ -136,7 +136,7 @@ func TestPruneController(t *testing.T) {
 						Secret: km.key.Secret,
 					})
 				}
-				ec := createEncryptionCfgSecretWithWriteKeys(t, "kms", "1", []encryptionKeysResourceTuple{{
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{{
 					resource: "secrets",
 					keys: append([]apiserverconfigv1.Key{
 						{
@@ -146,7 +146,7 @@ func TestPruneController(t *testing.T) {
 					}, additionaReadKeys...),
 				}})
 				ec.APIVersion = corev1.SchemeGroupVersion.String()
-				return ec
+				return createEncryptionCfgSecret(t, "kms", "1", ec)
 			}()
 			fakeKubeClient := fake.NewSimpleClientset(append(rawSecrets, writeKeySecret, fakePod, encryptionConfig)...)
 			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(scenario.targetNamespace), "test-encryptionKeyController", &corev1.ObjectReference{})

--- a/pkg/operator/encryption/prune_controller_test.go
+++ b/pkg/operator/encryption/prune_controller_test.go
@@ -1,0 +1,235 @@
+package encryption
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestPruneController(t *testing.T) {
+	scenarios := []struct {
+		name                     string
+		initialSecrets           []*corev1.Secret
+		encryptionSecretSelector metav1.ListOptions
+		targetNamespace          string
+		targetGRs                map[schema.GroupResource]bool
+		// expectedActions holds actions to be verified in the form of "verb:resource:namespace"
+		expectedActions       []string
+		expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration
+		validateFunc          func(ts *testing.T, actions []clientgotesting.Action, initialSecrets []*corev1.Secret)
+	}{
+		{
+			name:            "no-op only 10 keys were migrated",
+			targetNamespace: "kms",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialSecrets: func() []*corev1.Secret {
+				ns := "kms"
+				all := []*corev1.Secret{}
+				all = append(all, createMigratedEncryptionKeySecretsWithRndKey(t, 10, ns, "secrets")...)
+				all = append(all, createEncryptionKeySecretWithRawKey(ns, nil, 11, []byte("cfbbae883984944e48d25590abdfd300")))
+				return all
+			}(),
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "list:secrets:openshift-config-managed"},
+		},
+
+		{
+			name:            "14 keys were migrated, 1 of them is used, 10 are kept, the 3 most recent are pruned",
+			targetNamespace: "kms",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialSecrets: createMigratedEncryptionKeySecretsWithRndKey(t, 14, "kms", "secrets"),
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"list:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"delete:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"delete:secrets:openshift-config-managed",
+				"update:secrets:openshift-config-managed",
+				"delete:secrets:openshift-config-managed",
+			},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, initialSecrets []*corev1.Secret) {
+				validateSecretsWerePruned(ts, actions, initialSecrets[:3])
+			},
+		},
+
+		{
+			name:            "no-op the migrated keys don't match the selector",
+			targetNamespace: "kms",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialSecrets: func() []*corev1.Secret {
+				return createMigratedEncryptionKeySecretsWithRndKey(t, 15, "not-kms", "secrets")
+			}(),
+			encryptionSecretSelector: metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", "encryption.apiserver.operator.openshift.io/component", "kms")},
+			expectedActions: []string{
+				"list:pods:kms",
+				"get:secrets:kms",
+				"list:secrets:openshift-config-managed",
+				"list:secrets:openshift-config-managed",
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// setup
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				&operatorv1.StaticPodOperatorStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:   "EncryptionPruneControllerDegraded",
+								Status: "False",
+							},
+						},
+					},
+				},
+				nil,
+				nil,
+			)
+			rawSecrets := []runtime.Object{}
+			for _, initialSecret := range scenario.initialSecrets {
+				rawSecrets = append(rawSecrets, initialSecret)
+			}
+			grs := []schema.GroupResource{}
+			for gr := range scenario.targetGRs {
+				grs = append(grs, gr)
+			}
+			fakePod := createDummyKubeAPIPod("kube-apiserver-1", "kms")
+			writeKeyRaw := []byte("71ea7c91419a68fd1224f88d50316b4e") // NzFlYTdjOTE0MTlhNjhmZDEyMjRmODhkNTAzMTZiNGU=
+			writeKeyID := uint64(len(scenario.initialSecrets) + 1)
+			writeKeySecret := createEncryptionKeySecretWithRawKey(scenario.targetNamespace, nil, writeKeyID, writeKeyRaw)
+			encryptionConfig := func() *corev1.Secret {
+				additionalReadSecrets := keysWithPotentiallyPersistedData(grs, sortRecentFirst(scenario.initialSecrets))
+				var additionaReadKeys []apiserverconfigv1.Key
+				for _, s := range additionalReadSecrets {
+					km, readKeyID, _ := secretToKeyAndMode(s, scenario.targetNamespace)
+					additionaReadKeys = append(additionaReadKeys, apiserverconfigv1.Key{
+						Name:   fmt.Sprintf("%d", readKeyID),
+						Secret: km.key.Secret,
+					})
+				}
+				ec := createEncryptionCfgSecretWithWriteKeys(t, "kms", "1", []encryptionKeysResourceTuple{{
+					resource: "secrets",
+					keys: append([]apiserverconfigv1.Key{
+						{
+							Name:   fmt.Sprintf("%d", writeKeyID),
+							Secret: base64.StdEncoding.EncodeToString(writeKeyRaw),
+						},
+					}, additionaReadKeys...),
+				}})
+				ec.APIVersion = corev1.SchemeGroupVersion.String()
+				return ec
+			}()
+			fakeKubeClient := fake.NewSimpleClientset(append(rawSecrets, writeKeySecret, fakePod, encryptionConfig)...)
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(scenario.targetNamespace), "test-encryptionKeyController", &corev1.ObjectReference{})
+			// we pass "openshift-config-managed" and $targetNamespace ns because the controller creates an informer for secrets in that namespace.
+			// note that the informer factory is not used in the test - it's only needed to create the controller
+			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", scenario.targetNamespace)
+			fakeSecretClient := fakeKubeClient.CoreV1()
+
+			target := newPruneController(
+				scenario.targetNamespace,
+				fakeOperatorClient,
+				kubeInformers,
+				fakeKubeClient.CoreV1(),
+				fakeSecretClient,
+				scenario.encryptionSecretSelector,
+				eventRecorder,
+				scenario.targetGRs,
+			)
+
+			// act
+			err := target.sync()
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validateActionsVerbs(fakeKubeClient.Actions(), scenario.expectedActions); err != nil {
+				t.Fatalf("incorrect action(s) detected: %v", err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(t, fakeKubeClient.Actions(), scenario.initialSecrets)
+			}
+		})
+	}
+}
+
+func validateSecretsWerePruned(ts *testing.T, actions []clientgotesting.Action, expectedDeletedSecrets []*corev1.Secret) {
+	ts.Helper()
+
+	deletedSecretsCount := 0
+	finalizersRemovedCount := 0
+	for _, action := range actions {
+		if action.GetVerb() == "update" {
+			updateAction := action.(clientgotesting.UpdateAction)
+			actualSecret := updateAction.GetObject().(*corev1.Secret)
+			for _, expectedDeletedSecret := range expectedDeletedSecrets {
+				if expectedDeletedSecret.Name == actualSecret.GetName() {
+					expectedDeletedSecretsCpy := expectedDeletedSecret.DeepCopy()
+					expectedDeletedSecretsCpy.Finalizers = []string{}
+					if equality.Semantic.DeepEqual(actualSecret, expectedDeletedSecretsCpy) {
+						finalizersRemovedCount++
+						break
+					}
+				}
+			}
+		}
+		if action.GetVerb() == "delete" {
+			deleteAction := action.(clientgotesting.DeleteAction)
+			for _, expectedDeletedSecret := range expectedDeletedSecrets {
+				if expectedDeletedSecret.Name == deleteAction.GetName() && expectedDeletedSecret.Namespace == deleteAction.GetNamespace() {
+					deletedSecretsCount++
+				}
+			}
+		}
+	}
+	if deletedSecretsCount != len(expectedDeletedSecrets) {
+		ts.Errorf("%d key(s) were deleted but %d were expected to be deleted", deletedSecretsCount, len(expectedDeletedSecrets))
+	}
+	if finalizersRemovedCount != len(expectedDeletedSecrets) {
+		ts.Errorf("expected to see %d finalizers removed but got %d", len(expectedDeletedSecrets), finalizersRemovedCount)
+	}
+}
+
+func createMigratedEncryptionKeySecretsWithRndKey(ts *testing.T, count int, namespace, resource string) []*corev1.Secret {
+	ts.Helper()
+	rawKey := make([]byte, 32)
+	if _, err := rand.Read(rawKey); err != nil {
+		ts.Fatal(err)
+	}
+	ret := []*corev1.Secret{}
+	for i := 1; i <= count; i++ {
+		s := createMigratedEncryptionKeySecretWithRawKey(namespace, []schema.GroupResource{{Group: "", Resource: resource}}, uint64(i), rawKey, time.Now())
+		ret = append(ret, s)
+	}
+	return ret
+}

--- a/pkg/operator/encryption/state.go
+++ b/pkg/operator/encryption/state.go
@@ -289,8 +289,7 @@ func getGRsActualKeys(encryptionConfig *apiserverconfigv1.EncryptionConfiguratio
 	out := map[schema.GroupResource]groupResourceKeys{}
 	for _, resourceConfig := range encryptionConfig.Resources {
 		// resources should be a single group resource and
-		// providers should be have at least one "key" provider and the identity provider
-		if len(resourceConfig.Resources) != 1 || len(resourceConfig.Providers) < 2 {
+		if len(resourceConfig.Resources) != 1 {
 			klog.Infof("skipping invalid encryption config for resource %s", resourceConfig.Resources)
 			continue // should never happen
 		}

--- a/pkg/operator/encryption/state_controller.go
+++ b/pkg/operator/encryption/state_controller.go
@@ -1,0 +1,200 @@
+package encryption
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const stateWorkKey = "key"
+
+// stateController is responsible for creating a single secret in
+// openshift-config-managed with the name destName.  This single secret
+// contains the complete EncryptionConfiguration that is consumed by the API
+// server that is performing the encryption.  Thus this secret represents
+// the current state of all resources in encryptedGRs.  Every encryption key
+// that matches encryptionSecretSelector is included in this final secret.
+// This secret is synced into targetNamespace at a static location.  This
+// indirection allows the cluster to recover from the deletion of targetNamespace.
+// See getResourceConfigs for details on how the raw state of all keys
+// is converted into a single encryption config.  The logic for determining
+// the current write key is of special interest.
+type stateController struct {
+	queue              workqueue.RateLimitingInterface
+	eventRecorder      events.Recorder
+	preRunCachesSynced []cache.InformerSynced
+
+	encryptedGRs             map[schema.GroupResource]bool
+	destName                 string
+	targetNamespace          string
+	encryptionSecretSelector metav1.ListOptions
+
+	operatorClient operatorv1helpers.StaticPodOperatorClient
+	secretClient   corev1client.SecretsGetter
+	podClient      corev1client.PodsGetter
+
+	encoder runtime.Encoder
+}
+
+func newStateController(
+	targetNamespace, destName string,
+	operatorClient operatorv1helpers.StaticPodOperatorClient,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	secretClient corev1client.SecretsGetter,
+	encryptionSecretSelector metav1.ListOptions,
+	eventRecorder events.Recorder,
+	encryptedGRs map[schema.GroupResource]bool,
+	podClient corev1client.PodsGetter,
+) *stateController {
+	c := &stateController{
+		operatorClient: operatorClient,
+
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EncryptionStateController"),
+		eventRecorder: eventRecorder.WithComponentSuffix("encryption-state-controller"),
+
+		encryptedGRs:    encryptedGRs,
+		destName:        destName,
+		targetNamespace: targetNamespace,
+
+		encryptionSecretSelector: encryptionSecretSelector,
+		secretClient:             secretClient,
+		podClient:                podClient,
+	}
+
+	c.preRunCachesSynced = setUpAllEncryptionInformers(operatorClient, targetNamespace, kubeInformersForNamespaces, c.eventHandler())
+	c.encoder = apiserverCodecs.LegacyCodec(apiserverconfigv1.SchemeGroupVersion)
+
+	return c
+}
+
+func (c *stateController) sync() error {
+	if ready, err := shouldRunEncryptionController(c.operatorClient); err != nil || !ready {
+		return err // we will get re-kicked when the operator status updates
+	}
+
+	configError := c.generateAndApplyCurrentEncryptionConfigSecret()
+
+	// update failing condition
+	cond := operatorv1.OperatorCondition{
+		Type:   "EncryptionStateControllerDegraded",
+		Status: operatorv1.ConditionFalse,
+	}
+	if configError != nil {
+		cond.Status = operatorv1.ConditionTrue
+		cond.Reason = "Error"
+		cond.Message = configError.Error()
+	}
+	if _, _, updateError := operatorv1helpers.UpdateStaticPodStatus(c.operatorClient, operatorv1helpers.UpdateStaticPodConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return configError
+}
+
+func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret() error {
+	// TODO: fix scenarios 7 and 8
+	_, encryptionState, _, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	if err != nil {
+		return err
+	}
+	if len(encryptionState) == 0 {
+		c.queue.AddAfter(stateWorkKey, 2*time.Minute)
+		return nil
+	}
+
+	resourceConfigs := getResourceConfigs(encryptionState)
+
+	// if we have no config, do not create the secret
+	if len(resourceConfigs) == 0 {
+		return nil
+	}
+
+	return c.applyEncryptionConfigSecret(resourceConfigs)
+}
+
+func (c *stateController) applyEncryptionConfigSecret(resourceConfigs []apiserverconfigv1.ResourceConfiguration) error {
+	encryptionConfig := &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs}
+	encryptionConfigBytes, err := runtime.Encode(c.encoder, encryptionConfig)
+	if err != nil {
+		return err // indicates static generated code is broken, unrecoverable
+	}
+
+	_, _, applyErr := resourceapply.ApplySecret(c.secretClient, c.eventRecorder, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.destName,
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Annotations: map[string]string{
+				kubernetesDescriptionKey: kubernetesDescriptionScaryValue,
+			},
+			Finalizers: []string{encryptionSecretFinalizer},
+		},
+		Data: map[string][]byte{encryptionConfSecret: encryptionConfigBytes},
+	})
+	return applyErr
+}
+
+func (c *stateController) run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting EncryptionStateController")
+	defer klog.Infof("Shutting down EncryptionStateController")
+	if !cache.WaitForCacheSync(stopCh, c.preRunCachesSynced...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync for EncryptionStateController"))
+		return
+	}
+
+	// only start one worker
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *stateController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *stateController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func (c *stateController) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(stateWorkKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(stateWorkKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(stateWorkKey) },
+	}
+}

--- a/pkg/operator/encryption/state_controller_test.go
+++ b/pkg/operator/encryption/state_controller_test.go
@@ -1,0 +1,758 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+func TestEncryptionStateController(t *testing.T) {
+	scenarios := []struct {
+		name                     string
+		initialResources         []runtime.Object
+		encryptionSecretSelector metav1.ListOptions
+		targetNamespace          string
+		targetGRs                map[schema.GroupResource]bool
+		// expectedActions holds actions to be verified in the form of "verb:resource:namespace"
+		expectedActions []string
+		// destName denotes the name of the secret that contains EncryptionConfiguration
+		// this field is required to create the controller
+		destName                   string
+		expectedEncryptionCfg      *apiserverconfigv1.EncryptionConfiguration
+		validateFunc               func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration)
+		validateOperatorClientFunc func(ts *testing.T, operatorClient v1helpers.StaticPodOperatorClient)
+		expectedError              error
+	}{
+		// scenario 1: validates if "encryption-config-kube-apiserver-test" secret with EncryptionConfiguration in "openshift-config-managed" namespace
+		// was not created when no secrets with encryption keys are present in that namespace.
+		{
+			name:            "no secret with EncryptionConfig is created when there are no secrets with the encryption keys",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+			},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+		},
+
+		// scenario 2: validates if "encryption-config-kube-apiserver-test" secret with EncryptionConfiguration in "openshift-config-managed" namespace is created,
+		// it also checks the content and the order of encryption providers, this test expects identity first and aescbc second
+		{
+			name:                     "secret with EncryptionConfig is created without a write key",
+			targetNamespace:          "kms",
+			encryptionSecretSelector: metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=kms"},
+			destName:                 "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("61def964fb967f5d7c44a2af8dab6865")),
+			},
+			expectedActions:       []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedEncryptionCfg: createEncryptionCfgNoWriteKey("1", "NjFkZWY5NjRmYjk2N2Y1ZDdjNDRhMmFmOGRhYjY4NjU=", "secrets"),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+						err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+						if err != nil {
+							ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		// scenario 3
+		{
+			name:            "secret with EncryptionConfig is created and it contains a single write key",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7")),
+				func() *corev1.Secret {
+					ec := createEncryptionCfgNoWriteKey("34", "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=", "secrets")
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+			},
+			expectedEncryptionCfg: func() *apiserverconfigv1.EncryptionConfiguration {
+				keysRes := encryptionKeysResourceTuple{
+					resource: "secrets",
+					keys: []apiserverconfigv1.Key{
+						{
+							Name:   "34",
+							Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+						},
+					},
+				}
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+				return ec
+			}(),
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("create", "secrets") {
+						createAction := action.(clientgotesting.CreateAction)
+						actualSecret := createAction.GetObject().(*corev1.Secret)
+						err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+						if err != nil {
+							ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		// scenario 4
+		{
+			name:            "no-op when no key is transitioning",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
+				func() *corev1.Secret {
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "34",
+								Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+				func() *corev1.Secret {
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "34",
+								Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
+		},
+
+		// scenario 5
+		{
+			name:            "the key with ID=34 is transitioning (observed as a read key) so it is used as a write key in the EncryptionConfig",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7")),
+				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("dda090c18770163d57d6aaca85f7b3a5")),
+				func() *corev1.Secret { // encryption config in kms namespace
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "33",
+								Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+							},
+							{
+								Name:   "34",
+								Secret: "ZGRhMDkwYzE4NzcwMTYzZDU3ZDZhYWNhODVmN2IzYTU=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+				func() *corev1.Secret { // encryption config in openshift-config-managed
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "33",
+								Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+							},
+							{
+								Name:   "34",
+								Secret: "ZGRhMDkwYzE4NzcwMTYzZDU3ZDZhYWNhODVmN2IzYTU=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedEncryptionCfg: func() *apiserverconfigv1.EncryptionConfiguration {
+				keysRes := encryptionKeysResourceTuple{
+					resource: "secrets",
+					keys: []apiserverconfigv1.Key{
+						{
+							Name:   "34",
+							Secret: "ZGRhMDkwYzE4NzcwMTYzZDU3ZDZhYWNhODVmN2IzYTU=",
+						},
+						{
+							Name:   "33",
+							Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+						},
+					},
+				}
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+				return ec
+			}(),
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("update", "secrets") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actualSecret := updateAction.GetObject().(*corev1.Secret)
+						err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+						if err != nil {
+							ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		// scenario 6
+		{
+			name:            "checks if the order of the keys is preserved and that they read keys are pruned - all migrated",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 31, []byte("a1f1b3e36c477d91ea85af0f32358f70")),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 32, []byte("42b07b385a0edee268f1ac41cfc53857")),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("b0af82240e10c032fd9bbbedd3b5955a")),
+				createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("1c06e8517890c8dc44f627905efc86b8"), time.Now()),
+				func() *corev1.Secret { // encryption config in kms namespace
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "34",
+								Secret: "MWMwNmU4NTE3ODkwYzhkYzQ0ZjYyNzkwNWVmYzg2Yjg=",
+							},
+							{
+								Name:   "33",
+								Secret: "YjBhZjgyMjQwZTEwYzAzMmZkOWJiYmVkZDNiNTk1NWE=",
+							},
+							{
+								Name:   "32",
+								Secret: "NDJiMDdiMzg1YTBlZGVlMjY4ZjFhYzQxY2ZjNTM4NTc=",
+							},
+							{
+								Name:   "31",
+								Secret: "YTFmMWIzZTM2YzQ3N2Q5MWVhODVhZjBmMzIzNThmNzA=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+				func() *corev1.Secret { // encryption config in openshift-config-managed namespace
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "34",
+								Secret: "MWMwNmU4NTE3ODkwYzhkYzQ0ZjYyNzkwNWVmYzg2Yjg=",
+							},
+							{
+								Name:   "33",
+								Secret: "YjBhZjgyMjQwZTEwYzAzMmZkOWJiYmVkZDNiNTk1NWE=",
+							},
+							{
+								Name:   "32",
+								Secret: "NDJiMDdiMzg1YTBlZGVlMjY4ZjFhYzQxY2ZjNTM4NTc=",
+							},
+							{
+								Name:   "31",
+								Secret: "YTFmMWIzZTM2YzQ3N2Q5MWVhODVhZjBmMzIzNThmNzA=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedEncryptionCfg: func() *apiserverconfigv1.EncryptionConfiguration {
+				keysRes := encryptionKeysResourceTuple{
+					resource: "secrets",
+					keys: []apiserverconfigv1.Key{
+						{
+							Name:   "34",
+							Secret: "MWMwNmU4NTE3ODkwYzhkYzQ0ZjYyNzkwNWVmYzg2Yjg=",
+						},
+					},
+				}
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+				return ec
+			}(),
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("update", "secrets") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actualSecret := updateAction.GetObject().(*corev1.Secret)
+						err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+						if err != nil {
+							ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		// scenario 7
+		{
+			name:            "checks if the order of the keys is preserved - with a key that is transitioning",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 31, []byte("a1f1b3e36c477d91ea85af0f32358f70")),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 32, []byte("42b07b385a0edee268f1ac41cfc53857")),
+				createExpiredMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 33, []byte("b0af82240e10c032fd9bbbedd3b5955a")),
+				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("1c06e8517890c8dc44f627905efc86b8")),
+				func() *corev1.Secret { // encryption config in kms namespace
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "33",
+								Secret: base64.StdEncoding.EncodeToString([]byte("b0af82240e10c032fd9bbbedd3b5955a")),
+							},
+							{
+								Name:   "34",
+								Secret: base64.StdEncoding.EncodeToString([]byte("1c06e8517890c8dc44f627905efc86b8")),
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+				func() *corev1.Secret { // encryption config in openshift-config-managed namespace
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "33",
+								Secret: base64.StdEncoding.EncodeToString([]byte("b0af82240e10c032fd9bbbedd3b5955a")),
+							},
+							{
+								Name:   "34",
+								Secret: base64.StdEncoding.EncodeToString([]byte("1c06e8517890c8dc44f627905efc86b8")),
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedEncryptionCfg: func() *apiserverconfigv1.EncryptionConfiguration {
+				keysRes := encryptionKeysResourceTuple{
+					resource: "secrets",
+					keys: []apiserverconfigv1.Key{
+						{
+							Name:   "34",
+							Secret: base64.StdEncoding.EncodeToString([]byte("1c06e8517890c8dc44f627905efc86b8")),
+						},
+						{
+							Name:   "33",
+							Secret: base64.StdEncoding.EncodeToString([]byte("b0af82240e10c032fd9bbbedd3b5955a")),
+						},
+					},
+				}
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+				return ec
+			}(),
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms"},
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				wasSecretValidated := false
+				for _, action := range actions {
+					if action.Matches("update", "secrets") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						actualSecret := updateAction.GetObject().(*corev1.Secret)
+						err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+						if err != nil {
+							ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+						}
+						wasSecretValidated = true
+						break
+					}
+				}
+				if !wasSecretValidated {
+					ts.Errorf("the secret wasn't created and validated")
+				}
+			},
+		},
+
+		// scenario 8
+		//
+		// BUG: this test simulates deletion of an encryption config in the target ns - the encryption config had a single secret
+		//      as a result a new encryption config is created with a single read key - that effectively means that the encryption was turned off (temporarily)
+		{
+			name:            "no encryption cfg in the target ns (was deleted)",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
+				func() *corev1.Secret {
+					keysRes := encryptionKeysResourceTuple{
+						resource: "secrets",
+						keys: []apiserverconfigv1.Key{
+							{
+								Name:   "34",
+								Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedEncryptionCfg: func() *apiserverconfigv1.EncryptionConfiguration {
+				keysRes := encryptionKeysResourceTuple{
+					resource: "secrets",
+					keys: []apiserverconfigv1.Key{
+						{
+							Name:   "34",
+							Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+						},
+					},
+				}
+				ec := createEncryptionCfgWithWriteKey([]encryptionKeysResourceTuple{keysRes})
+				return ec
+			}(),
+			validateFunc: func(ts *testing.T, actions []clientgotesting.Action, destName string, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration) {
+				// TODO: fix the temporary identity key on config reconstruction in getDesiredEncryptionState
+				/*
+					wasSecretValidated := false
+					for _, action := range actions {
+						if action.Matches("update", "secrets") {
+							updateAction := action.(clientgotesting.UpdateAction)
+							actualSecret := updateAction.GetObject().(*corev1.Secret)
+							err := validateSecretWithEncryptionConfig(actualSecret, expectedEncryptionCfg, destName)
+							if err != nil {
+								ts.Fatalf("failed to verfy the encryption config, due to %v", err)
+							}
+							wasSecretValidated = true
+							break
+						}
+					}
+					if !wasSecretValidated {
+						ts.Errorf("the secret wasn't created and validated")
+					}
+				*/
+			},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "update:secrets:openshift-config-managed", "create:events:kms"},
+		},
+
+		// scenario 9
+		//
+		// verifies if removing a target GR doesn't have effect - we will keep encrypting that GR
+		{
+			name:            "a user can't stop encrypting config maps",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}, {Group: "", Resource: "configmaps"}}, 34, []byte("171582a0fcd6c5fdb65cbf5a3e9249d7"), time.Now()),
+				func() *corev1.Secret { // encryption config in kms namespace
+					keysRes := []encryptionKeysResourceTuple{
+						{
+							resource: "configmaps",
+							keys: []apiserverconfigv1.Key{
+								{
+									Name:   "34",
+									Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+								},
+							},
+						},
+						{
+							resource: "secrets",
+							keys: []apiserverconfigv1.Key{
+								{
+									Name:   "34",
+									Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+								},
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey(keysRes)
+					ecs := createEncryptionCfgSecret(t, "kms", "1", ec)
+					return ecs
+				}(),
+				func() *corev1.Secret { // encryption config in openshift-config-managed namespace
+					keysRes := []encryptionKeysResourceTuple{
+						{
+							resource: "configmaps",
+							keys: []apiserverconfigv1.Key{
+								{
+									Name:   "34",
+									Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+								},
+							},
+						},
+						{
+							resource: "secrets",
+							keys: []apiserverconfigv1.Key{
+								{
+									Name:   "34",
+									Secret: "MTcxNTgyYTBmY2Q2YzVmZGI2NWNiZjVhM2U5MjQ5ZDc=",
+								},
+							},
+						},
+					}
+					ec := createEncryptionCfgWithWriteKey(keysRes)
+					ecs := createEncryptionCfgSecret(t, "openshift-config-managed", "1", ec)
+					ecs.Name = "encryption-config-kube-apiserver-test"
+					return ecs
+				}(),
+			},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed"},
+		},
+
+		// scenario 10
+		{
+			name:            "degraded a pod with invalid condition",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPodInUnknownPhase("kube-apiserver-1", "kms"),
+			},
+			expectedActions: []string{"list:pods:kms"},
+			expectedError:   errors.New("api server pod kube-apiserver-1 in unknown phase"),
+			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.StaticPodOperatorClient) {
+				expectedCondition := operatorv1.OperatorCondition{
+					Type:    "EncryptionStateControllerDegraded",
+					Status:  "True",
+					Reason:  "Error",
+					Message: "api server pod kube-apiserver-1 in unknown phase",
+				}
+				validateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
+			},
+		},
+
+		// scenario 11
+		{
+			name:            "no-op as an invalid secret is not considered",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("")),
+			},
+			expectedActions: []string{"list:pods:kms"},
+			validateOperatorClientFunc: func(ts *testing.T, operatorClient v1helpers.StaticPodOperatorClient) {
+				expectedCondition := operatorv1.OperatorCondition{
+					Type:   "EncryptionStateControllerDegraded",
+					Status: "False",
+				}
+				validateOperatorClientConditions(ts, operatorClient, []operatorv1.OperatorCondition{expectedCondition})
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// setup
+			fakeOperatorClient := v1helpers.NewFakeStaticPodOperatorClient(
+				&operatorv1.StaticPodOperatorSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: operatorv1.Managed,
+					},
+				},
+				&operatorv1.StaticPodOperatorStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						// we need to set up proper conditions before the test starts because
+						// the controller calls UpdateStatus which calls UpdateOperatorStatus method which is unsupported (fake client) and throws an exception
+						Conditions: []operatorv1.OperatorCondition{
+							{
+								Type:   "EncryptionStateControllerDegraded",
+								Status: "False",
+							},
+						},
+					},
+				},
+				nil,
+				nil,
+			)
+			fakeKubeClient := fake.NewSimpleClientset(scenario.initialResources...)
+			eventRecorder := events.NewRecorder(fakeKubeClient.CoreV1().Events(scenario.targetNamespace), "test-encryptionKeyController", &corev1.ObjectReference{})
+			// we pass "openshift-config-managed" and $targetNamespace ns because the controller creates an informer for secrets in that namespace.
+			// note that the informer factory is not used in the test - it's only needed to create the controller
+			kubeInformers := v1helpers.NewKubeInformersForNamespaces(fakeKubeClient, "openshift-config-managed", scenario.targetNamespace)
+			fakeSecretClient := fakeKubeClient.CoreV1()
+			fakePodClient := fakeKubeClient.CoreV1()
+
+			target := newStateController(
+				scenario.targetNamespace, scenario.destName,
+				fakeOperatorClient,
+				kubeInformers,
+				fakeSecretClient,
+				scenario.encryptionSecretSelector,
+				eventRecorder,
+				scenario.targetGRs,
+				fakePodClient,
+			)
+
+			// act
+			err := target.sync()
+
+			// validate
+			if err == nil && scenario.expectedError != nil {
+				t.Fatal("expected to get an error from sync() method")
+			}
+			if err != nil && scenario.expectedError == nil {
+				t.Fatal(err)
+			}
+			if err != nil && scenario.expectedError != nil && err.Error() != scenario.expectedError.Error() {
+				t.Fatalf("unexpected error returned = %v, expected = %v", err, scenario.expectedError)
+			}
+			if err := validateActionsVerbs(fakeKubeClient.Actions(), scenario.expectedActions); err != nil {
+				t.Fatalf("incorrect action(s) detected: %v", err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(t, fakeKubeClient.Actions(), scenario.destName, scenario.expectedEncryptionCfg)
+			}
+			if scenario.validateOperatorClientFunc != nil {
+				scenario.validateOperatorClientFunc(t, fakeOperatorClient)
+			}
+		})
+	}
+}
+
+func validateSecretWithEncryptionConfig(actualSecret *corev1.Secret, expectedEncryptionCfg *apiserverconfigv1.EncryptionConfiguration, expectedSecretName string) error {
+	actualEncryptionCfg, err := secretDataToEncryptionConfig(actualSecret)
+	if err != nil {
+		return fmt.Errorf("failed to verfy the encryption config, due to %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(expectedEncryptionCfg, actualEncryptionCfg) {
+		return fmt.Errorf("%s", diff.ObjectDiff(expectedEncryptionCfg, actualEncryptionCfg))
+	}
+
+	// rewrite the payload and compare the rest
+	expectedSecret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      expectedSecretName,
+			Namespace: "openshift-config-managed",
+			Annotations: map[string]string{
+				kubernetesDescriptionKey: kubernetesDescriptionScaryValue,
+			},
+			Finalizers: []string{"encryption.apiserver.operator.openshift.io/deletion-protection"},
+		},
+		Data: actualSecret.Data,
+	}
+
+	// those are filled by the server
+	if len(actualSecret.Kind) == 0 {
+		actualSecret.Kind = "Secret"
+	}
+	if len(actualSecret.APIVersion) == 0 {
+		actualSecret.APIVersion = corev1.SchemeGroupVersion.String()
+	}
+
+	if !equality.Semantic.DeepEqual(expectedSecret, actualSecret) {
+		return fmt.Errorf("%s", diff.ObjectDiff(expectedSecret, actualSecret))
+	}
+
+	return nil
+}

--- a/pkg/operator/encryption/state_test.go
+++ b/pkg/operator/encryption/state_test.go
@@ -1,0 +1,875 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/utils/diff"
+)
+
+func TestGetDesiredEncryptionState(t *testing.T) {
+	type args struct {
+		oldEncryptionConfig *apiserverconfigv1.EncryptionConfiguration
+		targetNamespace     string
+		encryptionSecrets   []*corev1.Secret
+		toBeEncryptedGRs    []schema.GroupResource
+	}
+	type ValidateState func(ts *testing.T, args *args, state groupResourcesState)
+
+	nilState := func(ts *testing.T, _ *args, state groupResourcesState) {
+		if state != nil {
+			ts.Errorf("expected nil state, got: %#v", state)
+		}
+	}
+
+	equalsConfig := func(expected *apiserverconfigv1.EncryptionConfiguration) func(ts *testing.T, args *args, state groupResourcesState) {
+		return func(ts *testing.T, _ *args, state groupResourcesState) {
+			if expected == nil && state != nil {
+				ts.Errorf("expected nil state, got: %#v", state)
+				return
+			}
+			if expected != nil && state == nil {
+				ts.Errorf("expected non-nil state corresponding to config %#v", expected)
+				return
+			}
+			if expected == nil && state == nil {
+				return
+			}
+			expected := expected.DeepCopy()
+			expected.TypeMeta = metav1.TypeMeta{}
+			encryptionConfig := &apiserverconfigv1.EncryptionConfiguration{Resources: getResourceConfigs(state)}
+			if !reflect.DeepEqual(expected, encryptionConfig) {
+				ts.Errorf("state %#v does not match encryption config (A input, B output):\n%s", state, diff.ObjectDiff(expected, encryptionConfig))
+			}
+		}
+	}
+
+	outputMatchingInputConfig := func(ts *testing.T, args *args, state groupResourcesState) {
+		equalsConfig(args.oldEncryptionConfig)(ts, args, state)
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		validate ValidateState
+	}{
+		{
+			"first run: no config, no secrets => nothing done, nil state returned",
+			args{
+				nil,
+				"kms",
+				nil,
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			nilState,
+		},
+		{
+			"config exists, no secrets => nothing done, config unchanged",
+			args{
+				createEncryptionCfgNoWriteKey("1", "NzFlYTdjOTE0MTlhNjhmZDEyMjRmODhkNTAzMTZiNGU=", "configmaps", "secrets"),
+				"kms",
+				nil,
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			outputMatchingInputConfig,
+		},
+		{
+			"config exists with only one resource => 2nd resource is added",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("71ea7c91419a68fd1224f88d50316b4e")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"config exists with two resources => 2nd resource stays",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}, {
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("71ea7c91419a68fd1224f88d50316b4e")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"no config, secrets exist => first config is created",
+			args{
+				nil,
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("71ea7c91419a68fd1224f88d50316b4e")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}},
+					},
+				}}),
+		},
+		{
+			"no config, multiple secrets exists, some migrated => config is recreated, with identity as write key",
+			args{
+				nil,
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 5, []byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}}, 4, []byte("447907494bßc4897b876c8476bf807bc"), time.Now()),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 3, []byte("3cbfbe7d76876e076b076c659cd895ff"), time.Now()),
+					createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}}, 2, []byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 1, []byte("11ea7c91419a68fd1224f88d50316b4a"), time.Now()),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}},
+					},
+				}}),
+		},
+		{
+			"config exists, only some secret is missing => missing secret is not used as write key, but next most-recent key is",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{
+						{
+							Resources: []string{"configmaps"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "5",
+										Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									}},
+								},
+							}, {
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "4",
+										Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+									}},
+								},
+							}, {
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "3",
+										Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+									}},
+								},
+							}, {
+								Identity: &apiserverconfigv1.IdentityConfiguration{},
+							}},
+						},
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "5",
+										Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									}},
+								},
+							}, {
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "4",
+										Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+									}},
+								},
+							}, {
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "3",
+										Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+									}},
+								},
+							}, {
+								Identity: &apiserverconfigv1.IdentityConfiguration{},
+							}},
+						},
+					}},
+				"kms",
+				[]*corev1.Secret{
+					// missing: createEncryptionKeySecretWithRawKey("kms", nil, 5, []byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}}, 4, []byte("447907494bßc4897b876c8476bf807bc"), time.Now()),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 3, []byte("3cbfbe7d76876e076b076c659cd895ff"), time.Now()),
+					createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}}, 2, []byte("2b234b23cb23c4b2cb24cb24bcbffbca")),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 1, []byte("11ea7c91419a68fd1224f88d50316b4a"), time.Now()),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				// 4 is becoming new write key, not 5!
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "3",
+									Secret: base64.StdEncoding.EncodeToString([]byte("3cbfbe7d76876e076b076c659cd895ff")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				}}),
+		},
+		{
+			"config exists without identity => identity is appended",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{
+						{
+							Resources: []string{"configmaps"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "5",
+										Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									}},
+								},
+							}},
+						},
+						{
+							Resources: []string{"secrets"},
+							Providers: []apiserverconfigv1.ProviderConfiguration{{
+								AESCBC: &apiserverconfigv1.AESConfiguration{
+									Keys: []apiserverconfigv1.Key{{
+										Name:   "5",
+										Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									}},
+								},
+							}},
+						},
+					}},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 5, []byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"config exists, new key secret => new key added as read key",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}, {
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("11ea7c91419a68fd1224f88d50316b4e")),
+					createEncryptionKeySecretWithRawKey("kms", nil, 2, []byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"config exists, read keys are consistent => new write key is set",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}, {
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("11ea7c91419a68fd1224f88d50316b4e")),
+					createEncryptionKeySecretWithRawKey("kms", nil, 2, []byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"config exists, read+write keys are consistent, not migrated => nothing changes",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}, {
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("11ea7c91419a68fd1224f88d50316b4e")),
+					createEncryptionKeySecretWithRawKey("kms", nil, 2, []byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+		{
+			"config exists, read+write keys are consistent, migrated => old read-keys are pruned from config",
+			args{
+				&apiserverconfigv1.EncryptionConfiguration{
+					Resources: []apiserverconfigv1.ResourceConfiguration{{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}, {
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "1",
+									Secret: base64.StdEncoding.EncodeToString([]byte("11ea7c91419a68fd1224f88d50316b4e")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					}},
+				},
+				"kms",
+				[]*corev1.Secret{
+					createEncryptionKeySecretWithRawKey("kms", nil, 1, []byte("11ea7c91419a68fd1224f88d50316b4e")),
+					createMigratedEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}}, 2, []byte("2bc2bdbc2bec2ebce7b27ce792639723"), time.Now()),
+				},
+				[]schema.GroupResource{{Group: "", Resource: "configmaps"}, {Group: "", Resource: "secrets"}},
+			},
+			equalsConfig(&apiserverconfigv1.EncryptionConfiguration{
+				Resources: []apiserverconfigv1.ResourceConfiguration{
+					{
+						Resources: []string{"configmaps"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+					{
+						Resources: []string{"secrets"},
+						Providers: []apiserverconfigv1.ProviderConfiguration{{
+							AESCBC: &apiserverconfigv1.AESConfiguration{
+								Keys: []apiserverconfigv1.Key{{
+									Name:   "2",
+									Secret: base64.StdEncoding.EncodeToString([]byte("2bc2bdbc2bec2ebce7b27ce792639723")),
+								}},
+							},
+						}, {
+							Identity: &apiserverconfigv1.IdentityConfiguration{},
+						}},
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDesiredEncryptionState(tt.args.oldEncryptionConfig, tt.args.targetNamespace, tt.args.encryptionSecrets, tt.args.toBeEncryptedGRs)
+			if tt.validate != nil {
+				tt.validate(t, &tt.args, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This include a getDesiredEncryptionState cleanup with:

- move encryption config into the focus, secrets only give additional info about migration
- by that handle missing secrets (don't panic as before)
- fix bug that all existing keys are added as read keys
- in STEP 2, only add missing read-keys, never drop. We only drop in the last step after migration has finished. This makes us resilient to secret deletion. Conversely, when the config is deleted and we still have the secrets (and the resource list did not change, during upgrade it is a bad time to delete the config), we can reconstruct the config.
- added getDesiredEncryptionState unit tests
- make getDesiredEncryptionState handle nil configs correctly
- add state controller