### PR TITLE
encryption: fix encryption bootstrap logic

### DIFF
--- a/pkg/operator/encryption/controllers.go
+++ b/pkg/operator/encryption/controllers.go
@@ -3,13 +3,21 @@ package encryption
 import (
 	"k8s.io/client-go/tools/cache"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiserverconfig "k8s.io/apiserver/pkg/apis/config"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
@@ -23,6 +31,98 @@ var (
 func init() {
 	utilruntime.Must(apiserverconfigv1.AddToScheme(apiserverScheme))
 	utilruntime.Must(apiserverconfig.AddToScheme(apiserverScheme))
+}
+
+type runner interface {
+	run(stopCh <-chan struct{})
+}
+
+func NewControllers(
+	targetNamespace, destName string,
+	operatorClient operatorv1helpers.StaticPodOperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	apiServerInformer configv1informers.APIServerInformer,
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
+	kubeClient kubernetes.Interface,
+	eventRecorder events.Recorder,
+	resourceSyncer resourcesynccontroller.ResourceSyncer,
+	dynamicClient dynamic.Interface, // temporary hack for in-process storage migration
+	encryptedGRs ...schema.GroupResource,
+) (*Controllers, error) {
+	// avoid using the CachedSecretGetter as we need strong guarantees that our encryptionSecretSelector works
+	// otherwise we could see secrets from a different component (which will break our keyID invariants)
+	// this is fine in terms of performance since these controllers will be idle most of the time
+	// TODO: update the eventHandlers used by the controllers to ignore components that do not match their own
+	encryptionSecretSelector := metav1.ListOptions{LabelSelector: encryptionSecretComponent + "=" + targetNamespace}
+
+	if err := resourceSyncer.SyncSecret(
+		resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: encryptionConfSecret},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: destName},
+	); err != nil {
+		return nil, err
+	}
+
+	return &Controllers{
+		controllers: []runner{
+			newKeyController(
+				targetNamespace,
+				operatorClient,
+				apiServerClient,
+				apiServerInformer,
+				kubeInformersForNamespaces,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
+				encryptionSecretSelector,
+				eventRecorder,
+				encryptedGRs,
+			),
+			newStateController(
+				targetNamespace,
+				destName,
+				operatorClient,
+				kubeInformersForNamespaces,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
+				encryptionSecretSelector,
+				eventRecorder,
+				encryptedGRs,
+			),
+			newPruneController(
+				targetNamespace,
+				operatorClient,
+				kubeInformersForNamespaces,
+				kubeClient.CoreV1(),
+				kubeClient.CoreV1(),
+				encryptionSecretSelector,
+				eventRecorder,
+				encryptedGRs,
+			),
+			newMigrationController(
+				targetNamespace,
+				operatorClient,
+				kubeInformersForNamespaces,
+				kubeClient.CoreV1(),
+				encryptionSecretSelector,
+				eventRecorder,
+				encryptedGRs,
+				kubeClient.CoreV1(),
+				dynamicClient,
+				kubeClient.Discovery(),
+			),
+		},
+	}, nil
+}
+
+type Controllers struct {
+	controllers []runner
+}
+
+func (c *Controllers) Run(stopCh <-chan struct{}) {
+	for _, controller := range c.controllers {
+		con := controller // capture range variable
+		go con.run(stopCh)
+	}
+	<-stopCh
 }
 
 func shouldRunEncryptionController(operatorClient operatorv1helpers.StaticPodOperatorClient) (bool, error) {

--- a/pkg/operator/encryption/key_controller.go
+++ b/pkg/operator/encryption/key_controller.go
@@ -57,7 +57,7 @@ type keyController struct {
 
 	preRunCachesSynced []cache.InformerSynced
 
-	encryptedGRs map[schema.GroupResource]bool
+	encryptedGRs []schema.GroupResource
 
 	targetNamespace          string
 	encryptionSecretSelector metav1.ListOptions
@@ -76,7 +76,7 @@ func newKeyController(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
-	encryptedGRs map[schema.GroupResource]bool,
+	encryptedGRs []schema.GroupResource,
 ) *keyController {
 	c := &keyController{
 		operatorClient:  operatorClient,

--- a/pkg/operator/encryption/key_controller.go
+++ b/pkg/operator/encryption/key_controller.go
@@ -140,6 +140,12 @@ func (c *keyController) checkAndCreateKeys() error {
 		return nil
 	}
 
+	// avoid intended start of encryption
+	hasBeenOnBefore := currentConfig != nil || secretsFound
+	if currentMode == identity && !hasBeenOnBefore {
+		return nil
+	}
+
 	var (
 		newKeyRequired bool
 		newKeyID       uint64

--- a/pkg/operator/encryption/key_controller.go
+++ b/pkg/operator/encryption/key_controller.go
@@ -131,7 +131,7 @@ func (c *keyController) checkAndCreateKeys() error {
 		return err
 	}
 
-	_, desiredEncryptionState, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	currentConfig, desiredEncryptionState, secretsFound, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/encryption/migration_controller.go
+++ b/pkg/operator/encryption/migration_controller.go
@@ -58,7 +58,7 @@ type migrationController struct {
 
 	preRunCachesSynced []cache.InformerSynced
 
-	encryptedGRs map[schema.GroupResource]bool
+	encryptedGRs []schema.GroupResource
 
 	targetNamespace          string
 	encryptionSecretSelector metav1.ListOptions
@@ -78,7 +78,7 @@ func newMigrationController(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
-	encryptedGRs map[schema.GroupResource]bool,
+	encryptedGRs []schema.GroupResource,
 	podClient corev1client.PodsGetter,
 	dynamicClient dynamic.Interface, // temporary hack
 	discoveryClient discovery.ServerResourcesInterface,

--- a/pkg/operator/encryption/migration_controller.go
+++ b/pkg/operator/encryption/migration_controller.go
@@ -156,7 +156,7 @@ type migrationTracker struct {
 // TODO doc
 func (c *migrationController) migrateKeysIfNeededAndRevisionStable() (string, error) {
 	// no storage migration during revision changes
-	currentEncryptionConfig, desiredEncryptionState, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	currentEncryptionConfig, desiredEncryptionState, _, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
 	if len(isProgressingReason) > 0 || err != nil {
 		return isProgressingReason, err
 	}

--- a/pkg/operator/encryption/migration_controller_test.go
+++ b/pkg/operator/encryption/migration_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-func TestEncryptionMigrationController(t *testing.T) {
+func TestMigrationController(t *testing.T) {
 	scenarios := []struct {
 		name                     string
 		initialResources         []runtime.Object

--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -106,7 +106,7 @@ func (c *pruneController) sync() error {
 }
 
 func (c *pruneController) deleteOldMigratedSecrets() error {
-	_, desiredEncryptionConfig, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	_, desiredEncryptionConfig, _, isProgressingReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -43,7 +43,7 @@ type pruneController struct {
 
 	preRunCachesSynced []cache.InformerSynced
 
-	encryptedGRs map[schema.GroupResource]bool
+	encryptedGRs []schema.GroupResource
 
 	targetNamespace          string
 	encryptionSecretSelector metav1.ListOptions
@@ -60,7 +60,7 @@ func newPruneController(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
-	encryptedGRs map[schema.GroupResource]bool,
+	encryptedGRs []schema.GroupResource,
 ) *pruneController {
 	c := &pruneController{
 		operatorClient: operatorClient,

--- a/pkg/operator/encryption/state.go
+++ b/pkg/operator/encryption/state.go
@@ -379,7 +379,7 @@ func getEncryptionConfigAndState(
 	secretClient corev1client.SecretsGetter,
 	targetNamespace string,
 	encryptionSecretSelector metav1.ListOptions,
-	encryptedGRs map[schema.GroupResource]bool,
+	encryptedGRs []schema.GroupResource,
 ) (*apiserverconfigv1.EncryptionConfiguration, groupResourcesState, string, error) {
 	revision, err := getAPIServerRevisionOfAllInstances(podClient.Pods(targetNamespace))
 	if err != nil {
@@ -408,12 +408,7 @@ func getEncryptionConfigAndState(
 		}
 	}
 
-	var encryptedGRsList []schema.GroupResource
-	for gr := range encryptedGRs {
-		encryptedGRsList = append(encryptedGRsList, gr)
-	}
-
-	desiredEncryptionState := getDesiredEncryptionState(encryptionConfig, targetNamespace, encryptionSecrets, encryptedGRsList)
+	desiredEncryptionState := getDesiredEncryptionState(encryptionConfig, targetNamespace, encryptionSecrets, encryptedGRs)
 
 	return encryptionConfig, desiredEncryptionState, "", nil
 }

--- a/pkg/operator/encryption/state_controller.go
+++ b/pkg/operator/encryption/state_controller.go
@@ -42,7 +42,7 @@ type stateController struct {
 	preRunCachesSynced []cache.InformerSynced
 
 	encryptedGRs             map[schema.GroupResource]bool
-	destName                 string
+	encryptionConfigName     string
 	targetNamespace          string
 	encryptionSecretSelector metav1.ListOptions
 
@@ -70,8 +70,8 @@ func newStateController(
 		eventRecorder: eventRecorder.WithComponentSuffix("encryption-state-controller"),
 
 		encryptedGRs:    encryptedGRs,
-		destName:        destName,
 		targetNamespace: targetNamespace,
+		encryptionConfigName: destName,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretClient:             secretClient,
@@ -138,7 +138,7 @@ func (c *stateController) applyEncryptionConfigSecret(resourceConfigs []apiserve
 
 	_, _, applyErr := resourceapply.ApplySecret(c.secretClient, c.eventRecorder, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.destName,
+			Name:      c.encryptionConfigName,
 			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
 			Annotations: map[string]string{
 				kubernetesDescriptionKey: kubernetesDescriptionScaryValue,

--- a/pkg/operator/encryption/state_controller.go
+++ b/pkg/operator/encryption/state_controller.go
@@ -110,7 +110,7 @@ func (c *stateController) sync() error {
 
 func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret() error {
 	// TODO: fix scenarios 7 and 8
-	_, encryptionState, _, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
+	currentConfig, desiredEncryptionState, secretsFound, transitioningReason, err := getEncryptionConfigAndState(c.podClient, c.secretClient, c.targetNamespace, c.encryptionSecretSelector, c.encryptedGRs)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/encryption/state_controller.go
+++ b/pkg/operator/encryption/state_controller.go
@@ -41,7 +41,7 @@ type stateController struct {
 	eventRecorder      events.Recorder
 	preRunCachesSynced []cache.InformerSynced
 
-	encryptedGRs             map[schema.GroupResource]bool
+	encryptedGRs             []schema.GroupResource
 	encryptionConfigName     string
 	targetNamespace          string
 	encryptionSecretSelector metav1.ListOptions
@@ -58,10 +58,10 @@ func newStateController(
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
+	podClient corev1client.PodsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
-	encryptedGRs map[schema.GroupResource]bool,
-	podClient corev1client.PodsGetter,
+	encryptedGRs []schema.GroupResource,
 ) *stateController {
 	c := &stateController{
 		operatorClient: operatorClient,
@@ -69,9 +69,9 @@ func newStateController(
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EncryptionStateController"),
 		eventRecorder: eventRecorder.WithComponentSuffix("encryption-state-controller"),
 
-		encryptedGRs:    encryptedGRs,
-		targetNamespace: targetNamespace,
+		encryptedGRs:         encryptedGRs,
 		encryptionConfigName: destName,
+		targetNamespace:      targetNamespace,
 
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretClient:             secretClient,

--- a/pkg/operator/encryption/state_controller_test.go
+++ b/pkg/operator/encryption/state_controller_test.go
@@ -28,7 +28,7 @@ func TestEncryptionStateController(t *testing.T) {
 		initialResources         []runtime.Object
 		encryptionSecretSelector metav1.ListOptions
 		targetNamespace          string
-		targetGRs                map[schema.GroupResource]bool
+		targetGRs                []schema.GroupResource
 		// expectedActions holds actions to be verified in the form of "verb:resource:namespace"
 		expectedActions []string
 		// destName denotes the name of the secret that contains EncryptionConfiguration
@@ -45,8 +45,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "no secret with EncryptionConfig is created when there are no secrets with the encryption keys",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -61,8 +61,8 @@ func TestEncryptionStateController(t *testing.T) {
 			targetNamespace:          "kms",
 			encryptionSecretSelector: metav1.ListOptions{LabelSelector: "encryption.apiserver.operator.openshift.io/component=kms"},
 			destName:                 "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -95,8 +95,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "secret with EncryptionConfig is created and it contains a single write key",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -146,8 +146,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "no-op when no key is transitioning",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -190,8 +190,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "the key with ID=34 is transitioning (observed as a read key) so it is used as a write key in the EncryptionConfig",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -278,8 +278,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "checks if the order of the keys is preserved and that they read keys are pruned - all migrated",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -380,8 +380,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "checks if the order of the keys is preserved - with a key that is transitioning",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -473,8 +473,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "no encryption cfg in the target ns (was deleted)",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -539,8 +539,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "a user can't stop encrypting config maps",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
@@ -605,8 +605,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "degraded a pod with invalid condition",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPodInUnknownPhase("kube-apiserver-1", "kms"),
@@ -629,8 +629,8 @@ func TestEncryptionStateController(t *testing.T) {
 			name:            "no-op as an invalid secret is not considered",
 			targetNamespace: "kms",
 			destName:        "encryption-config-kube-apiserver-test",
-			targetGRs: map[schema.GroupResource]bool{
-				{Group: "", Resource: "secrets"}: true,
+			targetGRs: []schema.GroupResource{
+				{Group: "", Resource: "secrets"},
 			},
 			initialResources: []runtime.Object{
 				createEncryptionKeySecretWithRawKey("kms", []schema.GroupResource{{Group: "", Resource: "secrets"}}, 1, []byte("")),
@@ -683,10 +683,10 @@ func TestEncryptionStateController(t *testing.T) {
 				fakeOperatorClient,
 				kubeInformers,
 				fakeSecretClient,
+				fakePodClient,
 				scenario.encryptionSecretSelector,
 				eventRecorder,
 				scenario.targetGRs,
-				fakePodClient,
 			)
 
 			// act

--- a/pkg/operator/encryption/state_controller_test.go
+++ b/pkg/operator/encryption/state_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
-func TestEncryptionStateController(t *testing.T) {
+func TestStateController(t *testing.T) {
 	scenarios := []struct {
 		name                     string
 		initialResources         []runtime.Object

--- a/pkg/operator/encryption/state_controller_test.go
+++ b/pkg/operator/encryption/state_controller_test.go
@@ -51,7 +51,7 @@ func TestStateController(t *testing.T) {
 			initialResources: []runtime.Object{
 				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
 			},
-			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},
+			expectedActions: []string{"list:pods:kms", "get:secrets:kms", "list:secrets:openshift-config-managed"},
 		},
 
 		// scenario 2: validates if "encryption-config-kube-apiserver-test" secret with EncryptionConfiguration in "openshift-config-managed" namespace is created,


### PR DESCRIPTION
- key controller starts with the first key when the mode changes
- state controller follows key controller only
- when config or keys exists, resetting mode to "" has no effect,
  other than being understood as identity, but leaves encryption
  mechanism active.