### PR TITLE
encryption: decouple secret names from config

### DIFF
--- a/pkg/operator/encryption/key_controller.go
+++ b/pkg/operator/encryption/key_controller.go
@@ -190,7 +190,7 @@ func (c *keyController) validateExistingKey(keySecret *corev1.Secret, keyID uint
 		return err
 	}
 
-	_, actualKeyID, validKey := secretToKeyAndMode(actualKeySecret, c.targetNamespace)
+	_, actualKeyID, validKey := secretToKeyAndMode(actualKeySecret)
 	if valid := actualKeyID == keyID && validKey; !valid {
 		// TODO we can just get stuck in degraded here ...
 		return fmt.Errorf("secret %s is in invalid state, new keys cannot be created for encryption target", keySecret.Name)

--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -140,7 +140,7 @@ func (c *pruneController) deleteOldMigratedSecrets() error {
 	var deleteErrs []error
 	skippedKeys := 0
 	for _, s := range encryptionSecrets {
-		if hasSecret(usedSecrets, s) {
+		if hasKeyInSecret(usedSecrets, s) {
 			continue
 		}
 

--- a/pkg/operator/encryption/prune_controller_test.go
+++ b/pkg/operator/encryption/prune_controller_test.go
@@ -126,7 +126,7 @@ func TestPruneController(t *testing.T) {
 				additionalReadSecrets := keysWithPotentiallyPersistedData(scenario.targetGRs, sortRecentFirst(scenario.initialSecrets))
 				var additionaReadKeys []apiserverconfigv1.Key
 				for _, s := range additionalReadSecrets {
-					km, readKeyID, _ := secretToKeyAndMode(s, scenario.targetNamespace)
+					km, readKeyID, _ := secretToKeyAndMode(s)
 					additionaReadKeys = append(additionaReadKeys, apiserverconfigv1.Key{
 						Name:   fmt.Sprintf("%d", readKeyID),
 						Secret: km.key.Secret,

--- a/pkg/operator/encryption/secrets.go
+++ b/pkg/operator/encryption/secrets.go
@@ -26,7 +26,7 @@ func findSecretForKeyWithClient(key keyAndMode, secretClient corev1client.Secret
 	}
 
 	for _, secret := range encryptionSecretList.Items {
-		sKeyAndMode, _, ok := secretToKeyAndMode(&secret, targetNamespace)
+		sKeyAndMode, _, ok := secretToKeyAndMode(&secret)
 		if !ok {
 			continue
 		}
@@ -38,8 +38,7 @@ func findSecretForKeyWithClient(key keyAndMode, secretClient corev1client.Secret
 	return nil, nil
 }
 
-func secretToKeyAndMode(encryptionSecret *corev1.Secret, targetNamespace string) (keyAndMode, uint64, bool) {
-	component := encryptionSecret.Labels[encryptionSecretComponent]
+func secretToKeyAndMode(encryptionSecret *corev1.Secret) (keyAndMode, uint64, bool) {
 	keyData := encryptionSecret.Data[encryptionSecretKeyData]
 	keyMode := mode(encryptionSecret.Annotations[encryptionSecretMode])
 
@@ -53,7 +52,7 @@ func secretToKeyAndMode(encryptionSecret *corev1.Secret, targetNamespace string)
 		},
 		mode: keyMode,
 	}
-	invalidKey := len(keyData) == 0 || !validKeyID || component != targetNamespace
+	invalidKey := len(keyData) == 0 || !validKeyID
 	switch keyMode {
 	case aescbc, secretbox, identity:
 	default:

--- a/pkg/operator/encryption/state_test.go
+++ b/pkg/operator/encryption/state_test.go
@@ -936,7 +936,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getDesiredEncryptionState(tt.args.oldEncryptionConfig, tt.args.targetNamespace, tt.args.encryptionSecrets, tt.args.toBeEncryptedGRs)
+			got := getDesiredEncryptionState(tt.args.oldEncryptionConfig, tt.args.encryptionSecrets, tt.args.toBeEncryptedGRs)
 			if tt.validate != nil {
 				tt.validate(t, &tt.args, got)
 			}

--- a/pkg/operator/encryption/types.go
+++ b/pkg/operator/encryption/types.go
@@ -82,8 +82,6 @@ const revisionLabel = "revision"
 // overall desired configuration (which is the same as the current state when the system is at steady state).
 type groupResourcesState map[schema.GroupResource]keysState
 type keysState struct {
-	targetNamespace string
-
 	// sorted by key number, highest first
 	readSecrets []*corev1.Secret
 	writeSecret *corev1.Secret
@@ -92,7 +90,7 @@ type keysState struct {
 func (k keysState) readKeys() []keyAndMode {
 	ret := make([]keyAndMode, 0, len(k.readSecrets))
 	for _, readKey := range k.readSecrets {
-		readKeyAndMode, _, ok := secretToKeyAndMode(readKey, k.targetNamespace)
+		readKeyAndMode, _, ok := secretToKeyAndMode(readKey)
 		if !ok {
 			klog.Infof("failed to convert read secret %s to key", readKey.Name)
 			continue
@@ -107,7 +105,7 @@ func (k keysState) writeKey() keyAndMode {
 		return keyAndMode{}
 	}
 
-	writeKeyAndMode, _, ok := secretToKeyAndMode(k.writeSecret, k.targetNamespace)
+	writeKeyAndMode, _, ok := secretToKeyAndMode(k.writeSecret)
 	if !ok {
 		klog.Infof("failed to convert write secret %s to key", k.writeSecret.Name)
 		return keyAndMode{}


### PR DESCRIPTION
Secret names played a role for comparison which secrets are used in the config. This PR changes this by only taking the `<prefix>-<n>` number for sorting, but otherwise just compares mode and keys.