### PR TITLE
encryption: create new key when key not backed by secret

### DIFF
--- a/pkg/operator/encryption/prune_controller.go
+++ b/pkg/operator/encryption/prune_controller.go
@@ -139,9 +139,12 @@ func (c *pruneController) deleteOldMigratedSecrets() error {
 
 	var deleteErrs []error
 	skippedKeys := 0
+NextEncryptionSecret:
 	for _, s := range encryptionSecrets {
-		if hasKeyInSecret(usedSecrets, s) {
-			continue
+		for _, us := range usedSecrets {
+			if equalKeyInSecret(us, s) {
+				continue NextEncryptionSecret
+			}
 		}
 
 		// skip the most recent unused secrets around

--- a/pkg/operator/encryption/state_test.go
+++ b/pkg/operator/encryption/state_test.go
@@ -39,7 +39,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 			expected.TypeMeta = metav1.TypeMeta{}
 			encryptionConfig := &apiserverconfigv1.EncryptionConfiguration{Resources: getResourceConfigs(state)}
 			if !reflect.DeepEqual(expected, encryptionConfig) {
-				ts.Errorf("state %#v does not match encryption config (A input, B output):\n%s", state, diff.ObjectDiff(expected, encryptionConfig))
+				ts.Errorf("unexpected encryption config (A: expected, B: got):\n%s", diff.ObjectDiff(expected, encryptionConfig))
 			}
 		}
 	}
@@ -126,26 +126,26 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				Resources: []apiserverconfigv1.ResourceConfiguration{{
 					Resources: []string{"configmaps"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
-					}, {
 						AESCBC: &apiserverconfigv1.AESConfiguration{
 							Keys: []apiserverconfigv1.Key{{
 								Name:   "1",
 								Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
 							}},
 						},
+					}, {
+						Identity: &apiserverconfigv1.IdentityConfiguration{},
 					}},
 				}, {
 					Resources: []string{"secrets"},
 					Providers: []apiserverconfigv1.ProviderConfiguration{{
-						Identity: &apiserverconfigv1.IdentityConfiguration{},
-					}, {
 						AESCBC: &apiserverconfigv1.AESConfiguration{
 							Keys: []apiserverconfigv1.Key{{
 								Name:   "1",
 								Secret: base64.StdEncoding.EncodeToString([]byte("71ea7c91419a68fd1224f88d50316b4e")),
 							}},
 						},
+					}, {
+						Identity: &apiserverconfigv1.IdentityConfiguration{},
 					}},
 				}}}),
 		},
@@ -384,7 +384,7 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 				}}),
 		},
 		{
-			"config exists, only some secret is missing => missing secret is not used as write key, but next most-recent key is",
+			"config exists, write key secret is missing => no-op",
 			args{
 				&apiserverconfigv1.EncryptionConfiguration{
 					Resources: []apiserverconfigv1.ResourceConfiguration{
@@ -461,15 +461,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
-									Name:   "4",
-									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
 								}},
 							},
 						}, {
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
-									Name:   "5",
-									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
 								}},
 							},
 						}, {
@@ -488,15 +488,15 @@ func TestGetDesiredEncryptionState(t *testing.T) {
 						Providers: []apiserverconfigv1.ProviderConfiguration{{
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
-									Name:   "4",
-									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
+									Name:   "5",
+									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
 								}},
 							},
 						}, {
 							AESCBC: &apiserverconfigv1.AESConfiguration{
 								Keys: []apiserverconfigv1.Key{{
-									Name:   "5",
-									Secret: base64.StdEncoding.EncodeToString([]byte("55b5bcbc85cb857c7c07c56c54983cbcd")),
+									Name:   "4",
+									Secret: base64.StdEncoding.EncodeToString([]byte("447907494bßc4897b876c8476bf807bc")),
 								}},
 							},
 						}, {

--- a/pkg/operator/encryption/types.go
+++ b/pkg/operator/encryption/types.go
@@ -120,6 +120,10 @@ func (k keysState) latestKey() (*corev1.Secret, uint64) {
 	return key, keyID
 }
 
+func secretIsBacked(s *corev1.Secret) bool {
+	return s != nil && len(s.Namespace) > 0
+}
+
 // groupResourceKeys represents, for a single group resource, the write and read keys in a
 // format that can be directly translated to and from the on disk EncryptionConfiguration object.
 type groupResourceKeys struct {


### PR DESCRIPTION
- fake secrets have no namespace. We use this (temporarily until we have a good internal state data structure) to tell the key controller that it should create a new key.
- clean up key controller tests
- fix along the way that not-most-recent keys are used as write keys if there are newer ones in the config already.