### PR TITLE
add privilege to operator init container

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -17,6 +17,8 @@ spec:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
       command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
+      securityContext:
+        privileged: true
       args:
       - |
         echo -n "Fixing audit permissions."

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -326,6 +326,8 @@ spec:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
       command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
+      securityContext:
+        privileged: true
       args:
       - |
         echo -n "Fixing audit permissions."


### PR DESCRIPTION
CRI-O 1.16 made a change to how selinux labels were handled that increased security. In doing so, it tightened security and needs to be explicitly told to not label a container. In the case of this initContainer, it is trying to edit the permissions of a file on the host system, which is (to SELinux) a security flaw, and thus selinux is denying it.

explicitly add privilege to the initContainer so it can touch the hostPath

Signed-off-by: Peter Hunt <pehunt@redhat.com>