### PR TITLE
make whole kube-apiserver pod privileged

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -17,8 +17,6 @@ spec:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
       command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
-      securityContext:
-        privileged: true
       args:
       - |
         echo -n "Fixing audit permissions."
@@ -135,3 +133,5 @@ spec:
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir
+  securityContext:
+    privileged: true

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -326,8 +326,6 @@ spec:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
       command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
-      securityContext:
-        privileged: true
       args:
       - |
         echo -n "Fixing audit permissions."
@@ -444,6 +442,8 @@ spec:
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir
+  securityContext:
+    privileged: true
 `)
 
 func v410KubeApiserverPodYamlBytes() ([]byte, error) {


### PR DESCRIPTION
As it was previously assumed to be privileged (as it is static), as well as the other containers need write access to the audit logs

ref: https://storage.googleapis.com/origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.3/2497/artifacts/e2e-aws/pods/openshift-kube-apiserver_kube-apiserver-ip-10-0-150-56.ec2.internal_kube-apiserver-4.log

from another failed promomtion job

Signed-off-by: Peter Hunt <pehunt@redhat.com>