### PR TITLE
Properly set pod as privileged

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -26,6 +26,8 @@ spec:
           echo -n "."
           sleep 1
         done
+      securityContext:
+        privileged: true
   containers:
   - name: kube-apiserver-REVISION
     image: ${IMAGE}
@@ -77,6 +79,8 @@ spec:
             fieldPath: metadata.namespace
       - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
         value: REVISION
+    securityContext:
+      privileged: true
   - name: kube-apiserver-cert-syncer-REVISION
     env:
     - name: POD_NAME
@@ -133,5 +137,3 @@ spec:
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir
-  securityContext:
-    privileged: true

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -335,6 +335,8 @@ spec:
           echo -n "."
           sleep 1
         done
+      securityContext:
+        privileged: true
   containers:
   - name: kube-apiserver-REVISION
     image: ${IMAGE}
@@ -386,6 +388,8 @@ spec:
             fieldPath: metadata.namespace
       - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
         value: REVISION
+    securityContext:
+      privileged: true
   - name: kube-apiserver-cert-syncer-REVISION
     env:
     - name: POD_NAME
@@ -442,8 +446,6 @@ spec:
   - hostPath:
       path: /var/log/kube-apiserver
     name: audit-dir
-  securityContext:
-    privileged: true
 `)
 
 func v410KubeApiserverPodYamlBytes() ([]byte, error) {


### PR DESCRIPTION
There is no pod-level security policy to set privileged. Instead, explicitly set privileged for every container in the pod that needs it (the two that mount audit-dir)

Signed-off-by: Peter Hunt <pehunt@redhat.com>