### PR TITLE
Bug 1767014: Ignore cluster-policy-controller since it doesn't use deprecated apis directly but only through discovery

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -63,6 +63,6 @@ spec:
       annotations:
         message: A client in the cluster is using deprecated extensions/v1beta1 API that will be removed soon.
       expr: |
-        apiserver_request_count{group="extensions",version="v1beta1",resource!~"(?:ingresses|)",client!~".*/kube-controller-manager"}
+        apiserver_request_count{group="extensions",version="v1beta1",resource!~"ingresses|",client!~".*/kube-controller-manager|cluster-policy-controller/.*"}
       labels:
         severity: warning


### PR DESCRIPTION
/cc @soltysh 