### PR TITLE
build: fix copy stanza in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe 
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN mkdir -p /usr/share/bootkube/manifests/ /manifests/
-COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/* /usr/share/bootkube/manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/ /usr/share/bootkube/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
 COPY manifests/*.yaml /manifests/
 COPY manifests/image-references /manifests/


### PR DESCRIPTION
The shell globbing causes docker to flatten the directory structure. The
operator fails at runtime when trying to find:

    usr/share/bootkube/manifests/config/bootstrap-config-overrides.yaml