### PR TITLE
Add cert regeneration controller

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -109,6 +109,28 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+  - name: kube-apiserver-cert-regeneration-controller-REVISION
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-apiserver-operator", "cert-regeneration-controller"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --tls-server-name=localhost-recovery
+      - -v=2
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/static-pod-resources
+      name: resource-dir
   - name: kube-apiserver-insecure-readyz-REVISION
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	goflag "flag"
 	"fmt"
 	"math/rand"
@@ -13,6 +14,7 @@ import (
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/certregenerationcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/insecurereadyz"
 	operatorcmd "github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/recoveryapiserver"
@@ -35,14 +37,14 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	command := NewOperatorCommand()
+	command := NewOperatorCommand(context.Background())
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }
 
-func NewOperatorCommand() *cobra.Command {
+func NewOperatorCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-kube-apiserver-operator",
 		Short: "OpenShift cluster kube-apiserver operator",
@@ -66,6 +68,7 @@ func NewOperatorCommand() *cobra.Command {
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))
 	cmd.AddCommand(recoveryapiserver.NewRecoveryAPIServerCommand())
 	cmd.AddCommand(regeneratecerts.NewRegenerateCertsCommand())
+	cmd.AddCommand(certregenerationcontroller.NewCertRegenerationControllerCommand(ctx))
 	cmd.AddCommand(insecurereadyz.NewInsecureReadyzCommand())
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17
 	github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200123002050-ef5fb66e6346
+	github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99 h1:WWUaFPHcREzq0p/Zf
 github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200123002050-ef5fb66e6346 h1:UH7+xLg4C6sOEBV5JZuOXHbeQhuvyakO3MwXD/2+M2Y=
-github.com/openshift/library-go v0.0.0-20200123002050-ef5fb66e6346/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
+github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106 h1:ZNHyJJhPOXh3dhGtdOmBRHiwP1POmco9Iq0X3rOoIUU=
+github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/cmd/certregenerationcontroller/cabundlesyncer.go
+++ b/pkg/cmd/certregenerationcontroller/cabundlesyncer.go
@@ -1,0 +1,145 @@
+package certregenerationcontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/targetconfigcontroller"
+)
+
+const workQueueKey = "key"
+
+// CABundleController composes individual certs into CA bundle that is used
+// by kube-apiserver to validate clients.
+// Cert recovery refreshes "kube-control-plane-signer-ca" and needs the containing
+// bundle regenerated so kube-controller-manager and kube-scheduler can connect
+// using client certs.
+type CABundleController struct {
+	configMapGetter corev1client.ConfigMapsGetter
+	configMapLister corev1listers.ConfigMapLister
+
+	eventRecorder events.Recorder
+
+	cachesToSync []cache.InformerSynced
+
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewCABundleController(
+	configMapGetter corev1client.ConfigMapsGetter,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	eventRecorder events.Recorder,
+) (*CABundleController, error) {
+	c := &CABundleController{
+		configMapGetter: configMapGetter,
+		configMapLister: kubeInformersForNamespaces.ConfigMapLister(),
+		eventRecorder:   eventRecorder.WithComponentSuffix("manage-client-ca-bundle-recovery-controller"),
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CABundleRecoveryController"),
+	}
+
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+
+	// we react to some config changes
+	namespaces := []string{
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.OperatorNamespace,
+		operatorclient.TargetNamespace,
+	}
+	for _, namespace := range namespaces {
+		informers := kubeInformersForNamespaces.InformersFor(namespace)
+		informers.Core().V1().ConfigMaps().Informer().AddEventHandler(handler)
+		c.cachesToSync = append(c.cachesToSync, informers.Core().V1().ConfigMaps().Informer().HasSynced)
+	}
+
+	return c, nil
+}
+
+func (c *CABundleController) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+
+	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
+	// (@deads2k wants time to think it through)
+
+	klog.Info("Starting CA bundle controller")
+	defer func() {
+		klog.Info("Shutting down CA bundle controller")
+		c.queue.ShutDown()
+		klog.Info("CA bundle controller shut down")
+	}()
+
+	if !cache.WaitForNamedCacheSync("CABundleController", ctx.Done(), c.cachesToSync...) {
+		return
+	}
+
+	go func() {
+		wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}()
+
+	<-ctx.Done()
+}
+
+func (c *CABundleController) runWorker(ctx context.Context) {
+	for c.processNextItem(ctx) {
+	}
+}
+
+func (c *CABundleController) processNextItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.sync(ctx)
+
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %w", key, err))
+	c.queue.AddRateLimited(key)
+
+	return true
+}
+
+func (c *CABundleController) sync(ctx context.Context) error {
+	// Always start 10 seconds later after a change occurred. Makes us less likely to steal work and logs from the operator.
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		return nil
+	}
+
+	_, changed, err := targetconfigcontroller.ManageClientCABundle(c.configMapLister, c.configMapGetter, c.eventRecorder)
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		klog.V(2).Info("Refreshed client CA bundle.")
+	}
+
+	return nil
+}

--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -1,0 +1,153 @@
+package certregenerationcontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configeversionedclient "github.com/openshift/client-go/config/clientset/versioned"
+	configexternalinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
+)
+
+type Options struct {
+	controllerContext *controllercmd.ControllerContext
+
+	TLSServerName string
+}
+
+func NewCertRegenerationControllerCommand(ctx context.Context) *cobra.Command {
+	o := &Options{
+		TLSServerName: "localhost-recovery",
+	}
+
+	cmd := controllercmd.
+		NewControllerCommandConfig("cert-regeneration-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+			o.controllerContext = controllerContext
+
+			err := o.Validate(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = o.Complete(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = o.Run(ctx)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}).NewCommandWithContext(ctx)
+	cmd.Use = "cert-regeneration-controller"
+	cmd.Short = "Start the Cluster Certificate Regeneration Controller"
+
+	cmd.PersistentFlags().StringVarP(&o.TLSServerName, "tls-server-name", "", o.TLSServerName, "The SNI hostname to set for the server in kubeconfig")
+
+	return cmd
+}
+
+func (o *Options) Validate(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Complete(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Run(ctx context.Context) error {
+	if len(o.TLSServerName) != 0 {
+		// TLSServerName chooses the SNI serving endpoint on the apiserver.
+		// Particularly useful when connecting to "localhost" and wanting to choose a special
+		// serving endpoint like "localhost-recovery" that has long-lived serving certs
+		// for localhost connections.
+		o.controllerContext.KubeConfig.TLSClientConfig.ServerName = o.TLSServerName
+		o.controllerContext.ProtoKubeConfig.TLSClientConfig.ServerName = o.TLSServerName
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(o.controllerContext.ProtoKubeConfig)
+	if err != nil {
+		return fmt.Errorf("can't build kubernetes client: %w", err)
+	}
+
+	configClient, err := configeversionedclient.NewForConfig(o.controllerContext.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	configInformers := configexternalinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
+
+	kubeAPIServerInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
+		operatorclient.OperatorNamespace,
+		operatorclient.TargetNamespace,
+	)
+
+	operatorClient, dynamicInformers, err := genericoperatorclient.NewStaticPodOperatorClient(o.controllerContext.KubeConfig, operatorv1.GroupVersion.WithResource("kubeapiservers"))
+	if err != nil {
+		return err
+	}
+
+	certRotationScale, err := certrotation.GetCertRotationScale(kubeClient, operatorclient.GlobalUserSpecifiedConfigNamespace)
+	if err != nil {
+		return err
+	}
+
+	kubeAPIServerCertRotationController, err := certrotationcontroller.NewCertRotationControllerOnlyWhenExpired(
+		kubeClient,
+		operatorClient,
+		configInformers,
+		kubeAPIServerInformersForNamespaces,
+		o.controllerContext.EventRecorder,
+		certRotationScale,
+	)
+	if err != nil {
+		return err
+	}
+
+	caBundleController, err := NewCABundleController(
+		kubeClient.CoreV1(),
+		kubeAPIServerInformersForNamespaces,
+		o.controllerContext.EventRecorder,
+	)
+	if err != nil {
+		return err
+	}
+
+	// We can't start informers until after the resources have been requested. Now is the time.
+	configInformers.Start(ctx.Done())
+	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
+	dynamicInformers.Start(ctx.Done())
+
+	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
+	// (@deads2k wants time to think it through)
+
+	go func() {
+		kubeAPIServerCertRotationController.Run(ctx, 1)
+	}()
+
+	go func() {
+		caBundleController.Run(ctx)
+	}()
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/cmd/regeneratecerts/regenerate_certificates.go
+++ b/pkg/cmd/regeneratecerts/regenerate_certificates.go
@@ -157,6 +157,7 @@ func (o *Options) Run() error {
 		Namespace:  "openshift-kube-apiserver-operator",
 	}) // this is a fake object-reference that should hopefully place us in the correct namespace
 
+	// On manual request we want to rotate even if the certs are close to expiry to avoid case when some other cert becomes invalid just after.
 	kubeAPIServerCertRotationController, err := kubeapiservercertrotationcontroller.NewCertRotationController(
 		kubeClient,
 		nil,

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -495,6 +495,28 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
+  - name: kube-apiserver-cert-regeneration-controller-REVISION
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-apiserver-operator", "cert-regeneration-controller"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --tls-server-name=localhost-recovery
+      - -v=2
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/static-pod-resources
+      name: resource-dir
   - name: kube-apiserver-insecure-readyz-REVISION
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -262,7 +262,8 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 
 	builder := NewController(c.componentName, c.startFunc).
 		WithKubeConfigFile(c.basicFlags.KubeConfigFile, nil).
-		WithLeaderElection(config.LeaderElection, "", c.componentName+"-lock").
+		WithComponentNamespace(c.basicFlags.Namespace).
+		WithLeaderElection(config.LeaderElection, c.basicFlags.Namespace, c.componentName+"-lock").
 		WithServer(config.ServingInfo, config.Authentication, config.Authorization).
 		WithRestartOnChange(exitOnChangeReactorCh, startingFileContent, observedFiles...)
 

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/flags.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/flags.go
@@ -22,6 +22,8 @@ type ControllerFlags struct {
 	ConfigFile string
 	// KubeConfigFile points to a kubeconfig file if you don't want to use the in cluster config
 	KubeConfigFile string
+	// Namespace points to a base namespace for the controller and related events
+	Namespace string
 	// TerminateOnFiles is a list of files. If any of these changes, the process terminates.
 	TerminateOnFiles []string
 }
@@ -45,6 +47,8 @@ func (f *ControllerFlags) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagFilename("config", "yaml", "yml")
 	flags.StringVar(&f.KubeConfigFile, "kubeconfig", f.KubeConfigFile, "Location of the master configuration file to run from.")
 	cmd.MarkFlagFilename("kubeconfig", "kubeconfig")
+	flags.StringVar(&f.Namespace, "namespace", f.Namespace, "Namespace where the controller is running. Auto-detected if run in cluster.")
+	cmd.Flags().MarkHidden("namespace")
 	flags.StringArrayVar(&f.TerminateOnFiles, "terminate-on-files", f.TerminateOnFiles, "A list of files. If one of them changes, the process will terminate.")
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/apiextensions.go
@@ -1,19 +1,19 @@
 package resourceapply
 
 import (
-	"k8s.io/klog"
-
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"k8s.io/klog"
 )
 
-// ApplyCustomResourceDefinition applies the required CustomResourceDefinition to the cluster.
-func ApplyCustomResourceDefinition(client apiextclientv1beta1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextv1beta1.CustomResourceDefinition) (*apiextv1beta1.CustomResourceDefinition, bool, error) {
+// ApplyCustomResourceDefinitionV1Beta1 applies the required CustomResourceDefinition to the cluster.
+func ApplyCustomResourceDefinitionV1Beta1(client apiextclientv1beta1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextv1beta1.CustomResourceDefinition) (*apiextv1beta1.CustomResourceDefinition, bool, error) {
 	existing, err := client.CustomResourceDefinitions().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.CustomResourceDefinitions().Create(required)
@@ -26,7 +26,36 @@ func ApplyCustomResourceDefinition(client apiextclientv1beta1.CustomResourceDefi
 
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
-	resourcemerge.EnsureCustomResourceDefinition(modified, existingCopy, *required)
+	resourcemerge.EnsureCustomResourceDefinitionV1Beta1(modified, existingCopy, *required)
+	if !*modified {
+		return existing, false, nil
+	}
+
+	if klog.V(4) {
+		klog.Infof("CustomResourceDefinition %q changes: %s", existing.Name, JSONPatchNoError(existing, existingCopy))
+	}
+
+	actual, err := client.CustomResourceDefinitions().Update(existingCopy)
+	reportUpdateEvent(recorder, required, err)
+
+	return actual, true, err
+}
+
+// ApplyCustomResourceDefinitionV1 applies the required CustomResourceDefinition to the cluster.
+func ApplyCustomResourceDefinitionV1(client apiextclientv1.CustomResourceDefinitionsGetter, recorder events.Recorder, required *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, bool, error) {
+	existing, err := client.CustomResourceDefinitions().Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.CustomResourceDefinitions().Create(required)
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureCustomResourceDefinitionV1(modified, existingCopy, *required)
 	if !*modified {
 		return existing, false, nil
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -3,18 +3,21 @@ package resourceapply
 import (
 	"fmt"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/api"
+	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openshift/api"
-	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 var (
@@ -25,6 +28,7 @@ var (
 
 func init() {
 	utilruntime.Must(api.InstallKube(genericScheme))
+	utilruntime.Must(apiextensionsv1beta1.AddToScheme(genericScheme))
 }
 
 type AssetFunc func(name string) ([]byte, error)
@@ -37,14 +41,27 @@ type ApplyResult struct {
 	Error   error
 }
 
-// TODO provide ways to provide cached getters
 type ClientHolder struct {
 	kubeClient          kubernetes.Interface
 	apiExtensionsClient apiextensionsclient.Interface
+	kubeInformers       v1helpers.KubeInformersForNamespaces
+}
+
+func NewClientHolder() *ClientHolder {
+	return &ClientHolder{}
+}
+
+func NewKubeClientHolder(client kubernetes.Interface) *ClientHolder {
+	return NewClientHolder().WithKubernetes(client)
 }
 
 func (c *ClientHolder) WithKubernetes(client kubernetes.Interface) *ClientHolder {
 	c.kubeClient = client
+	return c
+}
+
+func (c *ClientHolder) WithKubernetesInformers(kubeInformers v1helpers.KubeInformersForNamespaces) *ClientHolder {
+	c.kubeInformers = kubeInformers
 	return c
 }
 
@@ -96,15 +113,17 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 			}
 			result.Result, result.Changed, result.Error = ApplyServiceAccount(clients.kubeClient.CoreV1(), recorder, t)
 		case *corev1.ConfigMap:
-			if clients.kubeClient == nil {
+			client := clients.configMapsGetter()
+			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			}
-			result.Result, result.Changed, result.Error = ApplyConfigMap(clients.kubeClient.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyConfigMap(client, recorder, t)
 		case *corev1.Secret:
-			if clients.kubeClient == nil {
+			client := clients.secretsGetter()
+			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			}
-			result.Result, result.Changed, result.Error = ApplySecret(clients.kubeClient.CoreV1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplySecret(client, recorder, t)
 		case *rbacv1.ClusterRole:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
@@ -125,11 +144,16 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 				result.Error = fmt.Errorf("missing kubeClient")
 			}
 			result.Result, result.Changed, result.Error = ApplyRoleBinding(clients.kubeClient.RbacV1(), recorder, t)
-		case *v1beta1.CustomResourceDefinition:
+		case *apiextensionsv1beta1.CustomResourceDefinition:
 			if clients.apiExtensionsClient == nil {
 				result.Error = fmt.Errorf("missing apiExtensionsClient")
 			}
-			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinition(clients.apiExtensionsClient.ApiextensionsV1beta1(), recorder, t)
+			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1Beta1(clients.apiExtensionsClient.ApiextensionsV1beta1(), recorder, t)
+		case *apiextensionsv1.CustomResourceDefinition:
+			if clients.apiExtensionsClient == nil {
+				result.Error = fmt.Errorf("missing apiExtensionsClient")
+			}
+			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
 		}
@@ -138,4 +162,24 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 	}
 
 	return ret
+}
+
+func (c *ClientHolder) configMapsGetter() corev1client.ConfigMapsGetter {
+	if c.kubeClient == nil {
+		return nil
+	}
+	if c.kubeInformers == nil {
+		return c.kubeClient.CoreV1()
+	}
+	return v1helpers.CachedConfigMapGetter(c.kubeClient.CoreV1(), c.kubeInformers)
+}
+
+func (c *ClientHolder) secretsGetter() corev1client.SecretsGetter {
+	if c.kubeClient == nil {
+		return nil
+	}
+	if c.kubeInformers == nil {
+		return c.kubeClient.CoreV1()
+	}
+	return v1helpers.CachedSecretGetter(c.kubeClient.CoreV1(), c.kubeInformers)
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -1,13 +1,26 @@
 package resourcemerge
 
 import (
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
-// EnsureCustomResourceDefinition ensures that the existing matches the required.
+// EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
-func EnsureCustomResourceDefinition(modified *bool, existing *apiextv1beta1.CustomResourceDefinition, required apiextv1beta1.CustomResourceDefinition) {
+func EnsureCustomResourceDefinitionV1Beta1(modified *bool, existing *apiextensionsv1beta1.CustomResourceDefinition, required apiextensionsv1beta1.CustomResourceDefinition) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// we stomp everything
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}
+
+// EnsureCustomResourceDefinitionV1 ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextensionsv1.CustomResourceDefinition, required apiextensionsv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
 	// we stomp everything

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiextensions.go
@@ -1,9 +1,11 @@
 package resourceread
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var (
@@ -12,9 +14,8 @@ var (
 )
 
 func init() {
-	if err := apiextensionsv1beta1.AddToScheme(apiExtensionsScheme); err != nil {
-		panic(err)
-	}
+	utilruntime.Must(apiextensionsv1beta1.AddToScheme(apiExtensionsScheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(apiExtensionsScheme))
 }
 
 func ReadCustomResourceDefinitionV1Beta1OrDie(objBytes []byte) *apiextensionsv1beta1.CustomResourceDefinition {
@@ -23,4 +24,12 @@ func ReadCustomResourceDefinitionV1Beta1OrDie(objBytes []byte) *apiextensionsv1b
 		panic(err)
 	}
 	return requiredObj.(*apiextensionsv1beta1.CustomResourceDefinition)
+}
+
+func ReadCustomResourceDefinitionV1OrDie(objBytes []byte) *apiextensionsv1.CustomResourceDefinition {
+	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1beta1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*apiextensionsv1.CustomResourceDefinition)
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/monitoring_resource_controller.go
@@ -6,8 +6,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"k8s.io/klog"
-
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -17,16 +23,7 @@ import (
 	rbaclisterv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-
-	operatorv1 "github.com/openshift/api/operator/v1"
-
-	"github.com/openshift/library-go/pkg/assets"
-	"github.com/openshift/library-go/pkg/operator/condition"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/management"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/staticpod/controller/monitoring/bindata"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/klog"
 )
 
 const (
@@ -106,7 +103,7 @@ func (c MonitoringResourceController) sync() error {
 		return nil
 	}
 
-	directResourceResults := resourceapply.ApplyDirectly((&resourceapply.ClientHolder{}).WithKubernetes(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
+	directResourceResults := resourceapply.ApplyDirectly(resourceapply.NewKubeClientHolder(c.kubeClient), c.eventRecorder, c.mustTemplateAsset,
 		"manifests/prometheus-role.yaml",
 		"manifests/prometheus-role-binding.yaml",
 	)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -251,12 +251,10 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (RunnableController
 			"manifests/installer-sa.yaml",
 			"manifests/installer-cluster-rolebinding.yaml",
 		},
-		(&resourceapply.ClientHolder{}).WithKubernetes(b.kubeClient),
+		resourceapply.NewKubeClientHolder(b.kubeClient),
 		b.staticPodOperatorClient,
 		eventRecorder,
-	).
-		AddInformer(operandInformers.Core().V1().ServiceAccounts().Informer()).
-		AddInformer(operandInformers.Rbac().V1().ClusterRoleBindings().Informer()))
+	).AddKubeInformers(b.kubeInformers))
 
 	if b.dynamicClient != nil && b.enableServiceMonitorController {
 		controllers.add(monitoring.NewMonitoringResourceController(

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -6,22 +6,22 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/library-go/pkg/operator/management"
-
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	corev1 "k8s.io/api/core/v1"
-
+	"github.com/openshift/api"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
@@ -30,6 +30,16 @@ import (
 const (
 	workQueueKey = "key"
 )
+
+var (
+	genericScheme = runtime.NewScheme()
+	genericCodecs = serializer.NewCodecFactory(genericScheme)
+	genericCodec  = genericCodecs.UniversalDeserializer()
+)
+
+func init() {
+	utilruntime.Must(api.InstallKube(genericScheme))
+}
 
 type StaticResourceController struct {
 	name      string
@@ -45,7 +55,7 @@ type StaticResourceController struct {
 }
 
 // NewStaticResourceController returns a controller that maintains certain static manifests. Most "normal" types are supported,
-// but feel free to add ones we missed.  Use .AddInformer() to provide triggering conditions.
+// but feel free to add ones we missed.  Use .AddInformer(), .AddKubeInformers(), .AddNamespaceInformer or to provide triggering conditions.
 func NewStaticResourceController(
 	name string,
 	manifests resourceapply.AssetFunc,
@@ -69,6 +79,76 @@ func NewStaticResourceController(
 	c.operatorClient.Informer().AddEventHandler(c.eventHandler())
 
 	return c
+}
+
+func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1helpers.KubeInformersForNamespaces) *StaticResourceController {
+	// set the informers so we can have caching clients
+	c.clients = c.clients.WithKubernetesInformers(kubeInformersByNamespace)
+
+	ret := c
+	for _, file := range c.files {
+		objBytes, err := c.manifests(file)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("missing %q: %v", file, err))
+			continue
+		}
+		requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("cannot decode %q: %v", file, err))
+			continue
+		}
+		metadata, err := meta.Accessor(requiredObj)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("cannot get metadata %q: %v", file, err))
+			continue
+		}
+
+		// find the right subset of informers.  Interestingly, cluster scoped resources require cluster scoped informers
+		var informer informers.SharedInformerFactory
+		if _, ok := requiredObj.(*corev1.Namespace); !ok {
+			informer := kubeInformersByNamespace.InformersFor(metadata.GetName())
+			if informer == nil {
+				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetName()))
+				continue
+			}
+		} else {
+			informer := kubeInformersByNamespace.InformersFor(metadata.GetNamespace())
+			if informer == nil {
+				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetNamespace()))
+				continue
+			}
+		}
+
+		// iterate through the resources we know that are related to kube informers and add the pertinent informers
+		switch t := requiredObj.(type) {
+		case *corev1.Namespace:
+			ret = ret.AddNamespaceInformer(informer.Core().V1().Namespaces().Informer(), t.Name)
+		case *corev1.Service:
+			ret = ret.AddInformer(informer.Core().V1().Namespaces().Informer())
+		case *corev1.Pod:
+			ret = ret.AddInformer(informer.Core().V1().Pods().Informer())
+		case *corev1.ServiceAccount:
+			ret = ret.AddInformer(informer.Core().V1().ServiceAccounts().Informer())
+		case *corev1.ConfigMap:
+			ret = ret.AddInformer(informer.Core().V1().ConfigMaps().Informer())
+		case *corev1.Secret:
+			ret = ret.AddInformer(informer.Core().V1().Secrets().Informer())
+		case *rbacv1.ClusterRole:
+			ret = ret.AddInformer(informer.Rbac().V1().ClusterRoles().Informer())
+		case *rbacv1.ClusterRoleBinding:
+			ret = ret.AddInformer(informer.Rbac().V1().ClusterRoleBindings().Informer())
+		case *rbacv1.Role:
+			ret = ret.AddInformer(informer.Rbac().V1().Roles().Informer())
+		case *rbacv1.RoleBinding:
+			ret = ret.AddInformer(informer.Rbac().V1().RoleBindings().Informer())
+		default:
+			// if there's a missing case, the caller can add an informer or count on a time based trigger.
+			// if the controller doesn't handle it, then there will be failure from the underlying apply.
+			klog.V(4).Infof("unhandled type %T", requiredObj)
+		}
+	}
+
+	return ret
 }
 
 func (c *StaticResourceController) AddInformer(informer cache.SharedIndexInformer) *StaticResourceController {
@@ -188,7 +268,10 @@ func (c *StaticResourceController) Run(ctx context.Context, workers int) {
 	go wait.Until(c.runWorker, time.Second, ctx.Done())
 
 	// add time based trigger
-	go wait.Until(func() { c.queue.Add(workQueueKey) }, time.Minute, ctx.Done())
+	go wait.PollImmediateUntil(time.Minute, func() (bool, error) {
+		c.queue.Add(workQueueKey)
+		return false, nil
+	}, ctx.Done())
 
 	<-ctx.Done()
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/core_getters.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/core_getters.go
@@ -1,11 +1,19 @@
 package v1helpers
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+var (
+	emptyGetOptions  = metav1.GetOptions{}
+	emptyListOptions = metav1.ListOptions{}
 )
 
 type combinedConfigMapGetter struct {
@@ -35,13 +43,21 @@ func (g combinedConfigMapGetter) ConfigMaps(namespace string) corev1client.Confi
 }
 
 func (g combinedConfigMapInterface) Get(name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+	if !equality.Semantic.DeepEqual(options, emptyGetOptions) {
+		return nil, fmt.Errorf("GetOptions are not honored by cached client: %#v", options)
+	}
+
 	ret, err := g.lister.Get(name)
 	if err != nil {
 		return nil, err
 	}
 	return ret.DeepCopy(), nil
 }
-func (g combinedConfigMapInterface) List(opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+func (g combinedConfigMapInterface) List(options metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	if !equality.Semantic.DeepEqual(options, emptyListOptions) {
+		return nil, fmt.Errorf("ListOptions are not honored by cached client: %#v", options)
+	}
+
 	list, err := g.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -81,6 +97,10 @@ func (g combinedSecretGetter) Secrets(namespace string) corev1client.SecretInter
 }
 
 func (g combinedSecretInterface) Get(name string, options metav1.GetOptions) (*corev1.Secret, error) {
+	if !equality.Semantic.DeepEqual(options, emptyGetOptions) {
+		return nil, fmt.Errorf("GetOptions are not honored by cached client: %#v", options)
+	}
+
 	ret, err := g.lister.Get(name)
 	if err != nil {
 		return nil, err
@@ -88,7 +108,11 @@ func (g combinedSecretInterface) Get(name string, options metav1.GetOptions) (*c
 	return ret.DeepCopy(), nil
 }
 
-func (g combinedSecretInterface) List(opts metav1.ListOptions) (*corev1.SecretList, error) {
+func (g combinedSecretInterface) List(options metav1.ListOptions) (*corev1.SecretList, error) {
+	if !equality.Semantic.DeepEqual(options, emptyListOptions) {
+		return nil, fmt.Errorf("ListOptions are not honored by cached client: %#v", options)
+	}
+
 	list, err := g.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200123002050-ef5fb66e6346
+# github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib


### PR DESCRIPTION
Adds a container into kube-apiserver static pod that will automatically refresh certs if those are already expired.

https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/auto-cert-recovery.md
https://jira.coreos.com/browse/WRKLDS-100


TODO:
 - [x] extract library-go changes if the CI goes green (https://github.com/openshift/library-go/pull/579)
 - [x] real bump of library-go when the changes are in
 - [x] needs long lived service account token https://github.com/openshift/cluster-kube-apiserver-operator/pull/663
 - [x] try it

/cc @deads2k @sttts @soltysh @mfojtik 