### PR TITLE
Bug 1768417: Adjust UsingDeprecatedAPIExtensionsV1Beta1 alert

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -63,6 +63,6 @@ spec:
       annotations:
         message: A client in the cluster is using deprecated extensions/v1beta1 API that will be removed soon.
       expr: |
-        apiserver_request_count{group="extensions",version="v1beta1",resource!~"ingresses|",client!~".*/kube-controller-manager|cluster-policy-controller/.*"}
+        apiserver_request_count{group="extensions",version="v1beta1",resource!~"ingresses|",client!~"hyperkube/.*|cluster-policy-controller/.*"}
       labels:
         severity: warning


### PR DESCRIPTION
/hold
We can't be sure the calert works and need to check manually because this alert is ignored - we can't unignore it at the same time because those are different repos.

/cc @soltysh 