### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_02_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: kube-apiserver-operator
   name: metrics

--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: kube-apiserver-operator
   labels:
     app: kube-apiserver-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: kube-apiserver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -3,6 +3,8 @@ kind: ServiceMonitor
 metadata:
   name: kube-apiserver-operator
   namespace: openshift-kube-apiserver-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -31,6 +33,8 @@ kind: PrometheusRule
 metadata:
   name: kube-apiserver-operator
   namespace: openshift-kube-apiserver-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: cluster-version

--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -5,6 +5,8 @@ metadata:
     k8s-app: apiserver
   name: kube-apiserver
   namespace: openshift-kube-apiserver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -41,6 +43,8 @@ kind: PrometheusRule
 metadata:
   name: kube-apiserver
   namespace: openshift-kube-apiserver
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: using-deprecated-apis


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252