### PR TITLE
Revert "Fix certsyncer to use longlived localhost-recovery cert for cert-syncer"

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/kubeconfig-cm.yaml
+++ b/bindata/v4.1.0/kube-apiserver/kubeconfig-cm.yaml
@@ -22,5 +22,5 @@ data:
     users:
       - name: kube-apiserver-cert-syncer
         user:
-          client-certificate: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt
-          client-key: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key
+          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-apiserver-cert-syncer-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-apiserver-cert-syncer-client-cert-key/tls.key

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -442,6 +442,49 @@ func NewCertRotationController(
 	}
 	ret.certRotators = append(ret.certRotators, certRotator)
 
+	certRotator, err = certrotation.NewCertRotationController(
+		"KubeAPIServerCertSyncer",
+		certrotation.SigningRotation{
+			Namespace:     operatorclient.OperatorNamespace,
+			Name:          "kube-control-plane-signer",
+			Validity:      60 * defaultRotationDay,
+			Refresh:       30 * defaultRotationDay,
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+			Client:        kubeClient.CoreV1(),
+			EventRecorder: eventRecorder,
+		},
+		certrotation.CABundleRotation{
+			Namespace:     operatorclient.OperatorNamespace,
+			Name:          "kube-control-plane-signer-ca",
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
+			Client:        kubeClient.CoreV1(),
+			EventRecorder: eventRecorder,
+		},
+		certrotation.TargetRotation{
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "kube-apiserver-cert-syncer-client-cert-key",
+			Validity:  30 * rotationDay,
+			Refresh:   15 * rotationDay,
+			CertCreator: &certrotation.ClientRotation{
+				UserInfo: &user.DefaultInfo{
+					Name:   "system:kube-apiserver-cert-syncer",
+					Groups: []string{"system:masters"},
+				},
+			},
+			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
+			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
+			Client:        kubeClient.CoreV1(),
+			EventRecorder: eventRecorder,
+		},
+		operatorClient,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ret.certRotators = append(ret.certRotators, certRotator)
+
 	return ret, nil
 }
 

--- a/pkg/operator/configobservation/apiserver/observe_apiserver.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver.go
@@ -118,8 +118,8 @@ func observeNamedCertificates(apiServer *configv1.APIServer, recorder events.Rec
 		"certFile": "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.crt",
 		"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key"})
 	observedNamedCertificates = append(observedNamedCertificates, map[string]interface{}{
-		"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-		"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key"})
+		"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+		"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key"})
 
 	for index, namedCertificate := range namedCertificates {
 		observedNamedCertificate := map[string]interface{}{}

--- a/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_apiserver_test.go
@@ -148,8 +148,8 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
-							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key",
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key",
 						},
 					},
 				},
@@ -196,8 +196,8 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
-							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key",
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
@@ -248,8 +248,8 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
-							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key",
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
@@ -302,8 +302,8 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
-							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key",
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",
@@ -363,8 +363,8 @@ func TestObserveNamedCertificates(t *testing.T) {
 							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
-							"certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
-							"keyFile":  "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key",
+							"certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.crt",
+							"keyFile":  "/etc/kubernetes/static-pod-certs/secrets/localhost-recovery-serving-certkey/tls.key",
 						},
 						map[string]interface{}{
 							"certFile": "/etc/kubernetes/static-pod-certs/secrets/user-serving-cert-000/tls.crt",

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -227,10 +227,11 @@ var RevisionConfigMaps = []revision.RevisionResource{
 var RevisionSecrets = []revision.RevisionResource{
 	// these need to removed, but if we remove them now, the cluster will die because we don't reload them yet
 	{Name: "etcd-client"},
+	// this is needed so that the cert syncer itself can request certs.  It uses localhost
+	{Name: "kube-apiserver-cert-syncer-client-cert-key"},
 	{Name: "kubelet-client"},
 	// etcd encryption
 	{Name: "encryption-config", Optional: true},
-	{Name: "localhost-recovery-serving-certkey"},
 }
 
 var CertConfigMaps = []revision.RevisionResource{
@@ -247,6 +248,7 @@ var CertSecrets = []revision.RevisionResource{
 	{Name: "service-network-serving-certkey"},
 	{Name: "external-loadbalancer-serving-certkey"},
 	{Name: "internal-loadbalancer-serving-certkey"},
+	{Name: "localhost-recovery-serving-certkey"},
 
 	{Name: "user-serving-cert", Optional: true},
 	{Name: "user-serving-cert-000", Optional: true},

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -236,8 +236,8 @@ data:
     users:
       - name: kube-apiserver-cert-syncer
         user:
-          client-certificate: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt
-          client-key: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key
+          client-certificate: /etc/kubernetes/static-pod-resources/secrets/kube-apiserver-cert-syncer-client-cert-key/tls.crt
+          client-key: /etc/kubernetes/static-pod-resources/secrets/kube-apiserver-cert-syncer-client-cert-key/tls.key
 `)
 
 func v410KubeApiserverKubeconfigCmYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#656

The PR was correct to wire it, but the locahost recovery seems to be wired wrong and neither CI nor the operator detect broken certsyncer :(

Installer pre-populates the files managed by certsyncer, so we never find out its broken in CI.

We need to revert until we have a fix for the localhost recovery SNI cert. And we need to wire certsyncer informers to fail after a while to get the container failing, or get healthz wired for that container in future.

```
E1120 08:48:02.984629       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.ConfigMap: Unauthorized
E1120 08:48:02.988881       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.Secret: Unauthorized
E1120 08:48:03.986085       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.ConfigMap: Unauthorized
E1120 08:48:03.990080       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.Secret: Unauthorized
E1120 08:48:04.987488       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.ConfigMap: Unauthorized
E1120 08:48:04.991269       1 reflector.go:123] k8s.io/client-go/informers/factory.go:134: Failed to list *v1.Secret: Unauthorized
....
```

@openshift/sig-master 

/cc @mfojtik 