### PR TITLE
Fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,12 @@ $(call add-bindata,v4.1.0,./bindata/v4.1.0/...,bindata,v410_00_assets,pkg/operat
 $(call add-crd-gen,manifests,$(CRD_APIS),./manifests,./manifests)
 
 # these are extremely slow serial e2e encryption tests that modify the cluster's global state 
-.PHONY: test-e2e-encryption
 test-e2e-encryption: GO_TEST_PACKAGES :=./test/e2e-encryption/...
 test-e2e-encryption: GO_TEST_FLAGS += -v
 test-e2e-encryption: GO_TEST_FLAGS += -timeout 4h
-test-e2e-encryption: GO_TEST_FLAGS += -p 1
 test-e2e-encryption: GO_TEST_FLAGS += -parallel 1
 test-e2e-encryption: test-unit
+.PHONY: test-e2e-encryption
 
 update-codegen: update-codegen-crds
 .PHONY: update-codegen
@@ -62,6 +61,7 @@ verify-codegen: verify-codegen-crds
 test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
 test-e2e: GO_TEST_FLAGS += -v
 test-e2e: GO_TEST_FLAGS += -timeout 1h
+test-e2e: GO_TEST_FLAGS += -parallel 1
 test-e2e: test-unit
 .PHONY: test-e2e
 


### PR DESCRIPTION
Encryption tests have side effects. It left operator in a state where it was rolling out several revisions for other tests and because it was a separate package it was running in parallel with other e2e.
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-kube-apiserver-operator/662/pull-ci-openshift-cluster-kube-apiserver-operator-master-e2e-aws-operator/1510/artifacts/e2e-aws-operator/must-gather/registry-svc-ci-openshift-org-ci-op-lwp8pzd2-stable-sha256-64c63eedf863406fbc6c7515026f909a7221472cf70283708fb7010dd5e6139e/namespaces/openshift-kube-apiserver-operator/pods/kube-apiserver-operator-5bb6778647-dt22w/kube-apiserver-operator/kube-apiserver-operator/logs/current.log

Tests need to run serially and clean after itself. Make sure operator is in stable state before finishing so it doesn't affect other tests. If not a separate suite is required.

/hold
for corresponding CI change

/cc @p0lyn0mial 