### PR TITLE
pkg/operator/configobservation/etcd/OWNERS: Drop wking

### DIFF
--- a/pkg/operator/configobservation/etcd/OWNERS
+++ b/pkg/operator/configobservation/etcd/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
   - abhinavdahiya
-  - wking
 approvers:
   - abhinavdahiya
-  - wking


### PR DESCRIPTION
I was added here in 03b2b018d2 (#156), but I'm not sure what this package does, let alone how it should be maintained.

CC @abhinavdahiya in case he wants out too ;).