### PR TITLE
starter: initialize statis pod controllers with service monitor

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -111,6 +111,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		WithResources(operatorclient.TargetNamespace, "kube-apiserver", RevisionConfigMaps, RevisionSecrets).
 		WithCerts("kube-apiserver-certs", CertConfigMaps, CertSecrets).
 		WithVersioning(operatorclient.OperatorNamespace, "kube-apiserver", versionRecorder).
+		WithServiceMonitor(dynamicClient).
 		ToControllers()
 	if err != nil {
 		return err


### PR DESCRIPTION
Prevent panic in operator startup as when the dynamic client is not set the monitoring resource will crash.