### PR TITLE
CRDs are related to KAS because people ask why their resources aren't…

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -123,6 +123,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		"kube-apiserver",
 		[]configv1.ObjectReference{
 			{Group: "operator.openshift.io", Resource: "kubeapiservers", Name: "cluster"},
+			{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 			{Resource: "namespaces", Name: operatorclient.GlobalUserSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.GlobalMachineSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.OperatorNamespace},


### PR DESCRIPTION
… present

Some bugs have come in recently and we need to have CRD manifests for SCC, CRQ, and servicemonitor.

/assign @sttts 