### PR TITLE
Bug 1775580: bump(library-go): handle deletion of target revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-00010101000000-000000000000 // indirect
 	github.com/openshift/api v3.9.1-0.20191202033935-e7263773f60c+incompatible
 	github.com/openshift/client-go v0.0.0
-	github.com/openshift/library-go v0.0.0-20191210125924-37b9180d4790
+	github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f
 	github.com/pkg/profile v1.3.0 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
@@ -47,7 +47,7 @@ replace (
 	github.com/kubernetes-sigs/kube-storage-version-migrator => github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20191031181212-bdca3bf7d454
 	github.com/openshift/api => github.com/openshift/api v3.9.1-0.20191202033935-e7263773f60c+incompatible
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20191022152013-2823239d2298
-	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20191212110802-6c13a7945ef1
+	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
 	k8s.io/api => k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/openshift/library-go v0.0.0-20191210125924-37b9180d4790 h1:y3XUDaVobJ
 github.com/openshift/library-go v0.0.0-20191210125924-37b9180d4790/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20191212110802-6c13a7945ef1 h1:fYcjaHHRgTewACVm5vNDzKR5I4of4OQiJXrAO97gI/Q=
 github.com/openshift/library-go v0.0.0-20191212110802-6c13a7945ef1/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
+github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f h1:li4Vqq+nujicX4fs64/gzN5EVHgprWpRJK+03qvRL6Y=
+github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -303,7 +303,10 @@ func (c *InstallerController) manageInstallationPods(operatorSpec *operatorv1.St
 			if err := c.ensureInstallerPod(currNodeState.NodeName, operatorSpec, currNodeState.TargetRevision); err != nil {
 				c.eventRecorder.Warningf("InstallerPodFailed", "Failed to create installer pod for revision %d on node %q: %v",
 					currNodeState.TargetRevision, currNodeState.NodeName, err)
-				return true, err
+				// if a newer revision is pending, continue, so we retry later with the latest available revision
+				if !(operatorStatus.LatestAvailableRevision > currNodeState.TargetRevision) {
+					return true, err
+				}
 			}
 
 			newCurrNodeState, installerPodFailed, reason, err := c.newNodeStateForInstallInProgress(currNodeState, operatorStatus.LatestAvailableRevision)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20191210125924-37b9180d4790 => github.com/openshift/library-go v0.0.0-20191212110802-6c13a7945ef1
+# github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f => github.com/openshift/library-go v0.0.0-20191213080717-2caff7a5db8f
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib


### PR DESCRIPTION
Pick of https://github.com/openshift/cluster-kube-apiserver-operator/pull/695.