### PR TITLE
Consume the latest openshift api so sctp is enabled in lowlatency featureset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/imdario/mergo v0.3.8
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
-	github.com/openshift/api v0.0.0-20191217141120-791af96035a5
+	github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 	github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e
 	github.com/openshift/library-go v0.0.0-20191218095328-1c12909e5923
 	github.com/prometheus/client_golang v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5X
 github.com/openshift/api v0.0.0-20191213091414-3fbf6bcf78e8/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v0.0.0-20191217141120-791af96035a5 h1:iNT2RyvG4HrDU95JH1/6l+oALMmzgLL/Tp3AXAje0ic=
 github.com/openshift/api v0.0.0-20191217141120-791af96035a5/go.mod h1:dOo9oLY4lehI1ZZvNtMKwRVZTqG0y+z8564y1cf1ZOw=
+github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6 h1:SxAWPzmw6o8FZ9MMfYqZ6s/DpIadkztdUb+IMyezqY4=
+github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6/go.mod h1:dv+J0b/HWai0QnMVb37/H0v36klkLBi2TNpPeWDxX10=
 github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e h1:l+fwEFa4Voy9u+6pVOJI33sxwddz1oJ6rbVYpDfGytY=
 github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e/go.mod h1:nLJaHFCQ5Mavh98g2ejEnWYFWBMGVdphrKNjLErOn/w=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20191031181212-bdca3bf7d454 h1:iLsYWhstnDtzE2Syn3QJQrx4F7mpcpwhAPNbk0Zkpvo=

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -131,6 +131,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"TopologyManager",                // sig-pod, sjenning
 			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
+			"SCTPSupport",                    // sig-network, ccallend
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/vendor/github.com/openshift/api/go.mod
+++ b/vendor/github.com/openshift/api/go.mod
@@ -10,9 +10,3 @@ require (
 	k8s.io/code-generator v0.17.0
 	k8s.io/klog v1.0.0
 )
-
-replace (
-	k8s.io/api => k8s.io/api v0.17.0
-	k8s.io/apimachinery => k8s.io/apimachinery v0.17.0
-	k8s.io/code-generator => k8s.io/code-generator v0.17.0
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -145,7 +145,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20191217141120-791af96035a5
+# github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 github.com/openshift/api
 github.com/openshift/api/apps
 github.com/openshift/api/apps/v1


### PR DESCRIPTION
Fetched the latest pseudoversion, used it in the replace directive.
Ran `go mod tidy` and `go mod vendor`.
Not sure I need to update something in https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/bootkube/config/bootstrap-config-overrides.yaml the same way it was done in https://github.com/openshift/cluster-kube-apiserver-operator/pull/658