### PR TITLE
removes unused UsingDeprecatedAPIAppsV1Beta1 and UsingDeprecatedAPIAppsV1Beta2 alerts

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -80,20 +80,6 @@ spec:
   groups:
   - name: using-deprecated-apis
     rules:
-    - alert: UsingDeprecatedAPIAppsV1Beta1
-      annotations:
-        message: A client in the cluster is using deprecated apps/v1beta1 API that will be removed soon.
-      expr: |
-        apiserver_request_count{group="apps",version="v1beta1"}
-      labels:
-        severity: warning
-    - alert: UsingDeprecatedAPIAppsV1Beta2
-      annotations:
-        message: A client in the cluster is using deprecated apps/v1beta2 API that will be removed soon.
-      expr: |
-        apiserver_request_count{group="apps",version="v1beta2"}
-      labels:
-        severity: warning
     - alert: UsingDeprecatedAPIExtensionsV1Beta1
       annotations:
         message: A client in the cluster is using deprecated extensions/v1beta1 API that will be removed soon.


### PR DESCRIPTION
Since `apps/v1beta1 and apps/v1beta2` are disabled in Kube `1.17` we can safely remove the mentioned alerts as any attempt to create a resource will immediately return an error.

I run the following commands on a quite recent cluster:
```
k get --raw /apis/apps/v1beta2
k get --raw /apis/apps/v1beta1

Error from server (NotFound): the server could not find the requested resource
```

Client/Server version:
```
k version                         
Client Version: version.Info{Major:"", Minor:"", GitVersion:"v0.0.0-master+$Format:%h$", GitCommit:"$Format:%H$", GitTreeState:"", BuildDate:"1970-01-01T00:00:00Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"17+", GitVersion:"v1.17.0", GitCommit:"8a9ae19", GitTreeState:"clean", BuildDate:"2019-12-21T07:03:31Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"linux/amd64"}
```