### PR TITLE
bump(*): openshift/library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 	github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e
-	github.com/openshift/library-go v0.0.0-20200103144857-38e0f6451b16
+	github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e/go.mod h1:nLJa
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20191031181212-bdca3bf7d454 h1:iLsYWhstnDtzE2Syn3QJQrx4F7mpcpwhAPNbk0Zkpvo=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20191031181212-bdca3bf7d454/go.mod h1:ArHs8HJeXUzb2/WdnsiGXCVCWQwX5X0a1GNS6hM9FN0=
 github.com/openshift/library-go v0.0.0-20190923093227-76b67dd70a86/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
-github.com/openshift/library-go v0.0.0-20200103144857-38e0f6451b16 h1:x/9HV6Ysry1WMhTY1Q8fqUSIhUNkIyq1SYvb5n66tng=
-github.com/openshift/library-go v0.0.0-20200103144857-38e0f6451b16/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
+github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8 h1:gjmVJ0XiETkdUbVm4Fu5Hg7S9mlXcEuG6DztuQ4KiYM=
+github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/config/configdefaults/config_default.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/configdefaults/config_default.go
@@ -44,7 +44,7 @@ func SetRecommendedHTTPServingInfoDefaults(config *configv1.HTTPServingInfo) {
 
 func SetRecommendedServingInfoDefaults(config *configv1.ServingInfo) {
 	DefaultString(&config.BindAddress, "0.0.0.0:8443")
-	DefaultString(&config.BindNetwork, "tcp4")
+	DefaultString(&config.BindNetwork, "tcp")
 	DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/serving-cert/tls.key")
 	DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/serving-cert/tls.crt")
 	DefaultString(&config.ClientCA, "/var/run/configmaps/client-ca/ca-bundle.crt")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200103144857-38e0f6451b16
+# github.com/openshift/library-go v0.0.0-20200106191802-9821002633e8
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib


### PR DESCRIPTION
* openshift/library-go#657 : config: default bind network to tcp instead of tcp4