### PR TITLE
bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/openshift/api v0.0.0-20191219160953-2f4dddbbf3e6
 	github.com/openshift/client-go v0.0.0-20191216194936-57f413491e9e
-	github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd
+	github.com/openshift/library-go v0.0.0-20200114124611-9ace650367d2
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/openshift/library-go v0.0.0-20200108105826-2cb27e8b3c7b h1:o8PtQFHNJc
 github.com/openshift/library-go v0.0.0-20200108105826-2cb27e8b3c7b/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
 github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd h1:mkv11mPK5gyP5QCFOi0ebJHETtSWxLGdAblyIriAqQE=
 github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
+github.com/openshift/library-go v0.0.0-20200114124611-9ace650367d2 h1:XUgAoZ1MPaHKxBWeliGnYP430/yyviuAi5PSxjs5OuU=
+github.com/openshift/library-go v0.0.0-20200114124611-9ace650367d2/go.mod h1:+EzNb8oA3fnhC613pNcAU0DJ9s3m6WaIMECIVQm2ork=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcehelper/resource_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcehelper/resource_helpers.go
@@ -1,0 +1,76 @@
+package resourcehelper
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/api"
+)
+
+var (
+	openshiftScheme = runtime.NewScheme()
+)
+
+func init() {
+	if err := api.Install(openshiftScheme); err != nil {
+		panic(err)
+	}
+}
+
+// FormatResourceForCLIWithNamespace generates a string that can be copy/pasted for use with oc get that includes
+// specifying the namespace with the -n option (e.g., `ConfigMap/cluster-config-v1 -n kube-system`).
+func FormatResourceForCLIWithNamespace(obj runtime.Object) string {
+	gvk := GuessObjectGroupVersionKind(obj)
+	kind := gvk.Kind
+	group := gvk.Group
+	var name, namespace string
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		name = "<unknown>"
+		namespace = "<unknown>"
+	} else {
+		name = accessor.GetName()
+		namespace = accessor.GetNamespace()
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	if len(namespace) > 0 {
+		namespace = " -n " + namespace
+	}
+	return kind + group + "/" + name + namespace
+}
+
+// FormatResourceForCLI generates a string that can be copy/pasted for use with oc get.
+func FormatResourceForCLI(obj runtime.Object) string {
+	gvk := GuessObjectGroupVersionKind(obj)
+	kind := gvk.Kind
+	group := gvk.Group
+	var name string
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		name = "<unknown>"
+	} else {
+		name = accessor.GetName()
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	return kind + group + "/" + name
+}
+
+// GuessObjectGroupVersionKind returns a human readable for the passed runtime object.
+func GuessObjectGroupVersionKind(object runtime.Object) schema.GroupVersionKind {
+	if gvk := object.GetObjectKind().GroupVersionKind(); len(gvk.Kind) > 0 {
+		return gvk
+	}
+	if kinds, _, _ := scheme.Scheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0]
+	}
+	if kinds, _, _ := openshiftScheme.ObjectKinds(object); len(kinds) > 0 {
+		return kinds[0]
+	}
+	return schema.GroupVersionKind{Kind: "<unknown>"}
+}

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -143,11 +143,16 @@ func WaitForNextMigratedKey(t testing.TB, kubeClient kubernetes.Interface, prevK
 	nextKeyName, err = determineNextEncryptionKeyName(prevKeyMeta.Name, labelSelector)
 	require.NoError(t, err)
 	if len(prevKeyMeta.Name) == 0 {
-		prevKeyMeta.Name = "no previous key"
+		prevKeyMeta.Name = ""
 		prevKeyMeta.Migrated = defaultTargetGRs
 	}
 
-	t.Logf("Waiting up to %s for the next key %q, previous key was %q", waitPollTimeout.String(), nextKeyName, prevKeyMeta.Name)
+	t.Logf("Waiting up to %s for the next key %q, previous key was %q", waitPollTimeout.String(), nextKeyName, func(prevKeyName string) string {
+		if len(prevKeyName) == 0 {
+			return "no previous key"
+		}
+		return prevKeyName
+	}(prevKeyMeta.Name))
 	observedKeyName := prevKeyMeta.Name
 	if err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		currentKeyMeta, err := GetLastKeyMeta(kubeClient, namespace, labelSelector)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200109145143-01e799204bbd
+# github.com/openshift/library-go v0.0.0-20200114124611-9ace650367d2
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib
@@ -249,6 +249,7 @@ github.com/openshift/library-go/pkg/operator/render
 github.com/openshift/library-go/pkg/operator/render/options
 github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcegraph
+github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resource/retry


### PR DESCRIPTION
* openshift/library-go@6ca06218: helper for logging resource names
* openshift/library-go@23320a97: add helper functions for running prometheus query
* openshift/library-go@8dc5aa1c: allow injection of ca bundles
* openshift/library-go@695afa8f: changes the next empty encryption key's name for encryption e2e test

