### PR TITLE
Fix certrotationcontroller.Run to wait for context to be canceled

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -496,4 +496,6 @@ func (c *CertRotationController) Run(ctx context.Context, workers int) {
 	for _, certRotator := range c.certRotators {
 		go certRotator.Run(ctx, workers)
 	}
+
+	<-ctx.Done()
 }


### PR DESCRIPTION
It was printing `Shutting down CertRotation` right after start.

All callers wrap this in a `go` and unfortunatelly don't wait for it to end, as we don't support graceful termination yet, so I don't think we need a backport.

/cc @deads2k @mfojtik 