### PR TITLE
Remove unused post-bootstrap overrides from bootstrap bindata

### DIFF
--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,8 +1,6 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
-storageConfig:
-  ca: /var/run/configmaps/etcd-serving-ca/ca-bundle.crt
-  certFile: /var/run/secrets/etcd-client/tls.crt
-  keyFile: /var/run/secrets/etcd-client/tls.key
-  urls: {{range .EtcdServerURLs}}
-  - {{.}}{{end}}
+# This file is intentionally blank, and only exists to satisfy
+# library-go's GenericOptions.ApplyTo(). To change overrides for
+# post-bootstrap configuration, update
+# bindata/v4.1.0/kube-apiserver/config-overrides.yaml.

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -183,6 +183,9 @@ func (r *renderOpts) Run() error {
 		&renderConfig.FileConfig,
 		genericrenderoptions.Template{FileName: "defaultconfig.yaml", Content: v410_00_assets.MustAsset(filepath.Join(bootstrapVersion, "kube-apiserver", "defaultconfig.yaml"))},
 		mustReadTemplateFile(filepath.Join(r.generic.TemplatesDir, "config", "bootstrap-config-overrides.yaml")),
+		// This file is empty since the post-bootstrap config is rendered by
+		// TargetConfigController.manageKubeAPIServerConfig.
+		// But it needs to be provided or ApplyTo will fail.
 		mustReadTemplateFile(filepath.Join(r.generic.TemplatesDir, "config", "config-overrides.yaml")),
 		&renderConfig,
 		nil,


### PR DESCRIPTION
Post-bootstrap kube-apiserver config is rendered by TargetConfigController.manageKubeAPIServerConfig and does not consider the content of bindata/bootkube/config/config-overrides.yaml. That file still needs to exist, though, to maintain compatibility with the library-go type that renders the configuration.

/cc @sttts