### PR TITLE
Bump library-go

### DIFF
--- a/bindata/bootkube/config/config-overrides.yaml
+++ b/bindata/bootkube/config/config-overrides.yaml
@@ -1,8 +1,0 @@
-apiVersion: kubecontrolplane.config.openshift.io/v1
-kind: KubeAPIServerConfig
-storageConfig:
-  ca: /var/run/configmaps/etcd-serving-ca/ca-bundle.crt
-  certFile: /var/run/secrets/etcd-client/tls.crt
-  keyFile: /var/run/secrets/etcd-client/tls.key
-  urls: {{range .EtcdServerURLs}}
-  - {{.}}{{end}}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17
 	github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106
+	github.com/openshift/library-go v0.0.0-20200124214933-98b5598973f8
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99 h1:WWUaFPHcREzq0p/Zf
 github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106 h1:ZNHyJJhPOXh3dhGtdOmBRHiwP1POmco9Iq0X3rOoIUU=
-github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
+github.com/openshift/library-go v0.0.0-20200124214933-98b5598973f8 h1:qxjuc4MU4xmFGyvNoOmOllKbYEH5RK6RKWE1wIBwKus=
+github.com/openshift/library-go v0.0.0-20200124214933-98b5598973f8/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -183,7 +183,6 @@ func (r *renderOpts) Run() error {
 		&renderConfig.FileConfig,
 		genericrenderoptions.Template{FileName: "defaultconfig.yaml", Content: v410_00_assets.MustAsset(filepath.Join(bootstrapVersion, "kube-apiserver", "defaultconfig.yaml"))},
 		mustReadTemplateFile(filepath.Join(r.generic.TemplatesDir, "config", "bootstrap-config-overrides.yaml")),
-		mustReadTemplateFile(filepath.Join(r.generic.TemplatesDir, "config", "config-overrides.yaml")),
 		&renderConfig,
 		nil,
 	); err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/config.go
@@ -32,9 +32,6 @@ type FileConfig struct {
 	// BootstrapConfig holds the rendered control plane component config file for bootstrapping (phase 1).
 	BootstrapConfig []byte
 
-	// PostBootstrapConfig holds the rendered control plane component config file after bootstrapping (phase 2).
-	PostBootstrapConfig []byte
-
 	// Assets holds the loaded assets like certs and keys.
 	Assets map[string][]byte
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
@@ -18,7 +18,6 @@ import (
 type GenericOptions struct {
 	DefaultFile                   string
 	BootstrapOverrideFile         string
-	PostBootstrapOverrideFile     string
 	AdditionalConfigOverrideFiles []string
 
 	ConfigOutputFile string
@@ -82,16 +81,12 @@ func (o *GenericOptions) Validate() error {
 }
 
 // ApplyTo applies the options ot the given config struct using the provides text/template data.
-func (o *GenericOptions) ApplyTo(cfg *FileConfig, defaultConfig, bootstrapOverrides, postBootstrapOverrides Template, templateData interface{}, specialCases map[string]resourcemerge.MergeFunc) error {
+func (o *GenericOptions) ApplyTo(cfg *FileConfig, defaultConfig, bootstrapOverrides Template, templateData interface{}, specialCases map[string]resourcemerge.MergeFunc) error {
 	var err error
 
 	cfg.BootstrapConfig, err = o.configFromDefaultsPlusOverride(defaultConfig, bootstrapOverrides, templateData, specialCases)
 	if err != nil {
 		return fmt.Errorf("failed to generate bootstrap config (phase 1): %v", err)
-	}
-
-	if cfg.PostBootstrapConfig, err = o.configFromDefaultsPlusOverride(defaultConfig, postBootstrapOverrides, templateData, specialCases); err != nil {
-		return fmt.Errorf("failed to generate post-bootstrap config (phase 2): %v", err)
 	}
 
 	// load and render templates

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200123173517-9d0011759106
+# github.com/openshift/library-go v0.0.0-20200124214933-98b5598973f8
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib


### PR DESCRIPTION
The library-go rendering helper no longer accepts postbootstrap overrides since cluster operators actively manage postbootstrap config separately from rendering.

Canary for https://github.com/openshift/library-go/pull/681

/cc @sttts @deads2k 