### PR TITLE
Bug 1795617:  Remove entirely deprecated alerts

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -68,36 +68,3 @@ spec:
     matchLabels:
       component: apiserver
       provider: kubernetes
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kube-apiserver
-  namespace: openshift-kube-apiserver
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-spec:
-  groups:
-  - name: using-deprecated-apis
-    rules:
-    - alert: UsingDeprecatedAPIAppsV1Beta1
-      annotations:
-        message: A client in the cluster is using deprecated apps/v1beta1 API that will be removed soon.
-      expr: |
-        apiserver_request_count{group="apps",version="v1beta1"}
-      labels:
-        severity: warning
-    - alert: UsingDeprecatedAPIAppsV1Beta2
-      annotations:
-        message: A client in the cluster is using deprecated apps/v1beta2 API that will be removed soon.
-      expr: |
-        apiserver_request_count{group="apps",version="v1beta2"}
-      labels:
-        severity: warning
-    - alert: UsingDeprecatedAPIExtensionsV1Beta1
-      annotations:
-        message: A client in the cluster is using deprecated extensions/v1beta1 API that will be removed soon.
-      expr: |
-        apiserver_request_count{group="extensions",version="v1beta1",resource!~"ingresses|",client!~"hyperkube/.*|cluster-policy-controller/.*"}
-      labels:
-        severity: warning


### PR DESCRIPTION
This picks commit from https://github.com/openshift/cluster-kube-apiserver-operator/pull/730 and applies the same pattern to the remaining alerts.

/assign @tnozicka 

/cc @LiliC @cblecker 