### PR TITLE
bug 1693951: consume the master kubelet bootstrap credential from a separate confi…

### DIFF
--- a/bindata/bootkube/manifests/configmap-kubelet-bootstrap-kubeconfig-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kubelet-bootstrap-kubeconfig-ca.yaml
@@ -1,0 +1,10 @@
+# this allows the master kubelet bootstrap credential to be revoked.  The signing key is destroyed when the bootstrap machine is deleted.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubelet-bootstrap-kubeconfig
+  namespace: openshift-config-managed
+data:
+  ca-bundle.crt: |
+    {{ .Assets | load "kubelet-bootstrap-kubeconfig-ca-bundle.crt" | indent 4 }}
+

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -324,6 +324,8 @@ func ManageClientCABundle(lister corev1listers.ConfigMapLister, client coreclien
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "kube-control-plane-signer-ca"},
 		// this bundle is what a user uses to mint new client certs it directly manages
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "user-client-ca"},
+		// this bundle is what validates the master kubelet bootstrap credential.  Users can invalid this by removing it.
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace, Name: "kubelet-bootstrap-kubeconfig"},
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
…gmap for revocation

implements https://github.com/openshift/enhancements/pull/196