### PR TITLE
bug 1797601: force cert rotation every couple days for development

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -117,6 +117,10 @@ func newCertRotationController(
 		rotationDay = day
 		klog.Warningf("!!! UNSUPPORTED VALUE SET !!!")
 		klog.Warningf("Certificate rotation base set to %q", rotationDay)
+	} else {
+		// for the development cycle, make the rotation 60 times faster (every twelve hours or so).
+		// This must be reverted before we ship
+		rotationDay = rotationDay / 60
 	}
 
 	certRotator, err := certrotation.NewCertRotationController(


### PR DESCRIPTION
This will make DR easier to test and ensure rotation is working pretty well.