### PR TITLE
Bug 1798048: bindata: remove revision suffix from containers

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext:
         privileged: true
   containers:
-  - name: kube-apiserver-REVISION
+  - name: kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -81,7 +81,7 @@ spec:
         value: REVISION
     securityContext:
       privileged: true
-  - name: kube-apiserver-cert-syncer-REVISION
+  - name: kube-apiserver-cert-syncer
     env:
     - name: POD_NAME
       valueFrom:
@@ -109,7 +109,7 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: kube-apiserver-cert-regeneration-controller-REVISION
+  - name: kube-apiserver-cert-regeneration-controller
     env:
     - name: POD_NAMESPACE
       valueFrom:
@@ -131,7 +131,7 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
-  - name: kube-apiserver-insecure-readyz-REVISION
+  - name: kube-apiserver-insecure-readyz
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -450,7 +450,7 @@ spec:
       securityContext:
         privileged: true
   containers:
-  - name: kube-apiserver-REVISION
+  - name: kube-apiserver
     image: ${IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
@@ -502,7 +502,7 @@ spec:
         value: REVISION
     securityContext:
       privileged: true
-  - name: kube-apiserver-cert-syncer-REVISION
+  - name: kube-apiserver-cert-syncer
     env:
     - name: POD_NAME
       valueFrom:
@@ -530,7 +530,7 @@ spec:
       name: resource-dir
     - mountPath: /etc/kubernetes/static-pod-certs
       name: cert-dir
-  - name: kube-apiserver-cert-regeneration-controller-REVISION
+  - name: kube-apiserver-cert-regeneration-controller
     env:
     - name: POD_NAMESPACE
       valueFrom:
@@ -552,7 +552,7 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
-  - name: kube-apiserver-insecure-readyz-REVISION
+  - name: kube-apiserver-insecure-readyz
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
We don't need revision suffix as the pod already has revision in label. The original intent was to make it clear which revision we have in artifact logs, but having this suffix makes it harder to debug or to get logs when debugging broken clusters.

Combined with https://github.com/kubernetes/kubernetes/pull/87809 I think we will get into desirable state :-)

/cc @deads2k 
/cc @smarterclayton 