### PR TITLE
Bug 1801154: manifests/: Throw away unused high cardinality apiserver duration buckets

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -83,6 +83,11 @@ spec:
       regex: network_plugin_operations_latency_microseconds|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds
       sourceLabels:
       - __name__
+    - action: drop
+      regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+      sourceLabels:
+      - __name__
+      - le
     relabelings:
     - action: replace
       targetLabel: apiserver


### PR DESCRIPTION
This shouldn't have any effect on our alerts or dashboards as the buckets are cumulative and for those purposes the remaining buckets should be sufficient.

Note: this change was made in "upstream" kube-promethues repo, see background for this https://github.com/coreos/kube-prometheus/pull/387
