### PR TITLE
bindata: preselect container name for oc

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -8,6 +8,7 @@ metadata:
     openshift.io/component: "api"
   annotations:
     openshift.io/run-level: "0"
+    kubectl.kubernetes.io/default-logs-container: kube-apiserver
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
   name: kube-apiserver
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: kube-apiserver
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -424,6 +424,8 @@ kind: Pod
 metadata:
   namespace: openshift-kube-apiserver
   name: kube-apiserver
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: kube-apiserver
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"


### PR DESCRIPTION
This is cosmetic change to kube-apiserver pod that preselect kube-apiserver container when calling `kubectl logs`. Users don't have to specify the container name anymore and api server container will be used by default.

It require `oc` from master, there is no change in behavior with older `oc`.