### PR TITLE
bug 1798725: static pod operator cannot be composed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17
 	github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200131215035-839609804250
+	github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99 h1:WWUaFPHcREzq0p/Zf
 github.com/openshift/api v0.0.0-20200122114642-1108c9abdb99/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200131215035-839609804250 h1:HRcxp/BLSf5p+8s/JiGK8ifHPRm5ldQIWS0QcyFu3ms=
-github.com/openshift/library-go v0.0.0-20200131215035-839609804250/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
+github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65 h1:rL5n5b9aaTxEInHMAcvbgJKvszXNAI6bfVN3OybHKyc=
+github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65/go.mod h1:/P1rPwPkaaNtylv8PLYkOTbf6tCdaNYDNqL9Y8GzJfE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/golang.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/golang.mk
@@ -1,7 +1,10 @@
-GO ?=go
-GOPATH ?=$(shell $(GO) env GOPATH)
-GO_PACKAGE ?=$(shell $(GO) list -m -f '{{ .Path }}' || echo 'no_package_detected')
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	version.mk \
+)
 
+GO ?=go
+
+GOPATH ?=$(shell $(GO) env GOPATH)
 GOOS ?=$(shell $(GO) env GOOS)
 GOHOSTOS ?=$(shell $(GO) env GOHOSTOS)
 GOARCH ?=$(shell $(GO) env GOARCH)
@@ -13,9 +16,11 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
-GO_PACKAGES ?=./...
-GO_TEST_PACKAGES ?=$(GO_PACKAGES)
+go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
+GO_REQUIRED_MIN_VERSION ?=1.13.5
+ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
+$(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
+endif
 
 # Projects not using modules can clear the variable, but by default we want to prevent
 # our projects with modules to unknowingly ignore vendor folder until golang is fixed to use
@@ -29,10 +34,16 @@ else
 GO_MOD_FLAGS ?=-mod=vendor
 endif
 
+GO_PACKAGE ?=$(shell $(GO) list $(GO_MOD_FLAGS) -m -f '{{ .Path }}' || echo 'no_package_detected')
+GO_PACKAGES ?=./...
+GO_TEST_PACKAGES ?=$(GO_PACKAGES)
+GO_FILES ?=$(shell find . -name '*.go' -not -path '*/vendor/*' -not -path '*/_output/*' -print)
+
+
 GO_BUILD_PACKAGES ?=./cmd/...
 GO_BUILD_PACKAGES_EXPANDED ?=$(shell $(GO) list $(GO_MOD_FLAGS) $(GO_BUILD_PACKAGES))
 go_build_binaries =$(notdir $(GO_BUILD_PACKAGES_EXPANDED))
-GO_BUILD_FLAGS ?=
+GO_BUILD_FLAGS ?=-trimpath
 GO_BUILD_BINDIR ?=
 
 GO_TEST_FLAGS ?=-race

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/version.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/lib/version.mk
@@ -1,0 +1,14 @@
+# $1 - required version
+# $2 - current version
+define is_equal_or_higher_version
+$(strip $(filter $(2),$(firstword $(shell set -euo pipefail && echo -e '$(1)\n$(2)' | sort -V -r -b))))
+endef
+
+# $1 - program name
+# $2 - required version variable name
+# $3 - current version string
+define require_minimal_version
+$(if $($(2)),\
+$(if $(strip $(call is_equal_or_higher_version,$($(2)),$(3))),,$(error `$(1)` is required with minimal version "$($(2))", detected version "$(3)". You can override this check by using `make $(2):=`)),\
+)
+endef

--- a/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps.mk
+++ b/vendor/github.com/openshift/library-go/alpha-build-machinery/make/targets/openshift/deps.mk
@@ -6,7 +6,7 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
 
-ifneq "$(GO) list -m" ""
+ifneq "$(GO) list $(GO_MOD_FLAGS) -m" ""
 include $(deps_gomod_mkfile)
 else
 include $(deps_glide_mkfile)

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -77,11 +78,14 @@ func (c *baseController) Sync(ctx context.Context, syncCtx SyncContext) error {
 	return c.sync(ctx, syncCtx)
 }
 
+// QueueKey return queue key for given name.
+func QueueKey(name string) string {
+	return strings.ToLower(name) + "Key"
+}
+
 func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.Duration) {
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if err := c.sync(ctx, c.syncContext); err != nil {
-			utilruntime.HandleError(fmt.Errorf("periodical resync of controller %s failed: %v", c.name, err))
-		}
+		c.syncContext.Queue().Add(QueueKey(c.name))
 	}, interval)
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -30,6 +30,9 @@ const (
 	// This condition is set to False when the pods change state to running and are observed ready.
 	StaticPodsDegradedConditionType = "StaticPodsDegraded"
 
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
 	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
 	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
 	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
@@ -54,6 +57,9 @@ const (
 	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
 	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
 	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
 
 	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
 	// the operator attempted to created required resource(s) (secrets, configmaps, ...).

--- a/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -1,0 +1,117 @@
+package staleconditions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const workQueueKey = "key"
+
+type RemoveStaleConditions struct {
+	conditions []string
+
+	operatorClient v1helpers.OperatorClient
+	cachesToSync   []cache.InformerSynced
+
+	eventRecorder events.Recorder
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewRemoveStaleConditions(
+	conditions []string,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+) *RemoveStaleConditions {
+	c := &RemoveStaleConditions{
+		conditions: conditions,
+
+		operatorClient: operatorClient,
+		eventRecorder:  eventRecorder,
+		cachesToSync:   []cache.InformerSynced{operatorClient.Informer().HasSynced},
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "RemoveStaleConditions"),
+	}
+
+	operatorClient.Informer().AddEventHandler(c.eventHandler())
+
+	return c
+}
+
+func (c RemoveStaleConditions) sync() error {
+	removeStaleConditionsFn := func(status *operatorv1.OperatorStatus) error {
+		for _, condition := range c.conditions {
+			v1helpers.RemoveOperatorCondition(&status.Conditions, condition)
+		}
+		return nil
+	}
+
+	if _, _, err := v1helpers.UpdateStatus(c.operatorClient, removeStaleConditionsFn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run starts the kube-scheduler and blocks until stopCh is closed.
+func (c *RemoveStaleConditions) Run(ctx context.Context, workers int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting RemoveStaleConditions")
+	defer klog.Infof("Shutting down RemoveStaleConditions")
+
+	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, ctx.Done())
+
+	<-ctx.Done()
+}
+
+func (c *RemoveStaleConditions) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *RemoveStaleConditions) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *RemoveStaleConditions) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -459,13 +459,13 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 
 	if numAvailable > 0 {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeAvailable,
+			Type:    condition.StaticPodsAvailableConditionType,
 			Status:  operatorv1.ConditionTrue,
 			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeAvailable,
+			Type:    condition.StaticPodsAvailableConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "ZeroNodesActive",
 			Message: fmt.Sprintf("%d nodes are active; %s", numAvailable, revisionDescription),
@@ -475,13 +475,13 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	// Progressing means that the any node is not at the latest available revision
 	if numProgressing > 0 {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeProgressing,
+			Type:    condition.NodeInstallerProgressingConditionType,
 			Status:  operatorv1.ConditionTrue,
 			Message: fmt.Sprintf("%s", revisionDescription),
 		})
 	} else {
 		v1helpers.SetOperatorCondition(&newStatus.Conditions, operatorv1.OperatorCondition{
-			Type:    operatorv1.OperatorStatusTypeProgressing,
+			Type:    condition.NodeInstallerProgressingConditionType,
 			Status:  operatorv1.ConditionFalse,
 			Reason:  "AllNodesAtLatestRevision",
 			Message: fmt.Sprintf("%s", revisionDescription),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200131215035-839609804250
+# github.com/openshift/library-go v0.0.0-20200205212311-6f4b8eee2d65
 github.com/openshift/library-go/alpha-build-machinery
 github.com/openshift/library-go/alpha-build-machinery/make
 github.com/openshift/library-go/alpha-build-machinery/make/lib
@@ -258,6 +258,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resource/retry
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/revisioncontroller
+github.com/openshift/library-go/pkg/operator/staleconditions
 github.com/openshift/library-go/pkg/operator/staticpod
 github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod
 github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource


### PR DESCRIPTION
Update to fix the operator.  This cannot be done in the static pod code itself because some consumers like etcd still rely on those directly set conditions and removing them would break it.