### PR TITLE
baremetal: Explicitly advertise the host IP chosen by kubelet

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -40,7 +40,7 @@ spec:
             echo "Copying system trust bundle"
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
+          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP}
     resources:
       requests:
         memory: 1Gi
@@ -79,6 +79,10 @@ spec:
             fieldPath: metadata.namespace
       - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
         value: REVISION
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.hostIP
     securityContext:
       privileged: true
   - name: kube-apiserver-cert-syncer-REVISION

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -349,7 +349,7 @@ spec:
             echo "Copying system trust bundle"
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
+          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP}
     resources:
       requests:
         memory: 1Gi
@@ -388,6 +388,10 @@ spec:
             fieldPath: metadata.namespace
       - name: STATIC_POD_VERSION # Avoid using 'REVISION' here otherwise it will be substituted
         value: REVISION
+      - name: HOST_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.hostIP
     securityContext:
       privileged: true
   - name: kube-apiserver-cert-syncer-REVISION


### PR DESCRIPTION
When using the baremetal infrastructure platform, the networking architecture
includes 3 Virtual IP addresses (VIPs).  For more information about the use
of these VIPs, see this document:

https://github.com/openshift/installer/blob/master/docs/design/baremetal/networking-infrastructure.md

By default, the kube-apiserver will advertise an IP address that it determines
from the default network interface.  When running in IPv4, we have been getting
lucky that the VIPs were never chosen.  They are always listed after the primary
address when you observe with "ip", and the same order is reflected in golang
when it iterates available IP addresses.

When we starting running IPv6 clusters, we observed kube-apiserver often
advertising one of the VIPs instead of the permanent IP address for the
interface.  This is bad because the VIP can move between servers.

These IPv6 VIPs are "deprecated" addresses, and we observed them listed
first in the list of addresses for an interface.  For more info on "deprecated" 
IPv6 addresses, see:

http://www.davidc.net/networking/ipv6-source-address-selection-linux

Unfortunately, this attribute is not accessible using golang's net package.
Accessing this attribute from golang would require rewriting the relevant
code for Linux to use the netlink interface directly.  This is far from a
trivial change, so we seek a simpler workaround in the meantime.

This same problem exists with kubelet and which IP address it chooses for
a master Node.  That was resolved with some scripts that filter out VIPs
and then specify the correct IP address directly as a command line argument.
For more information on the related kubelet workaround, see:

https://github.com/openshift/machine-config-operator/pull/1444

This PR builds on what was done for kubelet, and explicitly tells
kube-apiserver to advertise the address that we already determined was
correct for kubelet.