### PR TITLE
Bug 1797593: Revert "force cert rotation every couple days for development"

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -117,10 +117,6 @@ func newCertRotationController(
 		rotationDay = day
 		klog.Warningf("!!! UNSUPPORTED VALUE SET !!!")
 		klog.Warningf("Certificate rotation base set to %q", rotationDay)
-	} else {
-		// for the development cycle, make the rotation 60 times faster (every twelve hours or so).
-		// This must be reverted before we ship
-		rotationDay = rotationDay / 60
 	}
 
 	certRotator, err := certrotation.NewCertRotationController(


### PR DESCRIPTION
This reverts commit 4f38d5351554f081dcf1628bba664708cc8ab9b2.

This makes 4.4 have a long rotation time again.