### PR TITLE
[release-4.4] Bug 1771410: Disable delegated auth for recovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17
 	github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b
-	github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
+	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627
+	github.com/openshift/library-go v0.0.0-20200221162931-2e4133873386
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -305,13 +305,12 @@ github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5X
 github.com/openshift/api v0.0.0-20200116145750-0e2ff1e215dd/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b h1:BERD6sZj7w9Tt0RBpuw87AC0+SppyxEUgUG/Of5rI+E=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
-github.com/openshift/build-machinery-go v0.0.0-20200205161356-ef115f5adc73/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e h1:qlMmBDqBavn7p4Y22teVEkJCnU9YAwhABHeXanAirWE=
-github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4E6yt4XWiBEPKnJbs/E8pgUq9AjZqzQfsL3eeT84Qs=
+github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627 h1:Rs1RtB123VJr+kqXBYOTERNp23tZUUZ6w1gWrkroH3M=
-github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627/go.mod h1:T+sDdW3J/cgxUSqPdAwmhFrJhfFRv1ZtCSTVY59phN4=
+github.com/openshift/library-go v0.0.0-20200221162931-2e4133873386 h1:1R8CIzzeLym3I3niv0yozj4/Sm9EaSS9pSnJe+EaayA=
+github.com/openshift/library-go v0.0.0-20200221162931-2e4133873386/go.mod h1:0rRwY0q5NuKHdiP88Pe5+OVNU8mi0mv5XQ7f7nUbYVc=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -33,27 +33,29 @@ func NewCertRegenerationControllerCommand(ctx context.Context) *cobra.Command {
 		TLSServerName: "localhost-recovery",
 	}
 
-	cmd := controllercmd.
-		NewControllerCommandConfig("cert-regeneration-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
-			o.controllerContext = controllerContext
+	ccc := controllercmd.NewControllerCommandConfig("cert-regeneration-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+		o.controllerContext = controllerContext
 
-			err := o.Validate(ctx)
-			if err != nil {
-				return err
-			}
+		err := o.Validate(ctx)
+		if err != nil {
+			return err
+		}
 
-			err = o.Complete(ctx)
-			if err != nil {
-				return err
-			}
+		err = o.Complete(ctx)
+		if err != nil {
+			return err
+		}
 
-			err = o.Run(ctx)
-			if err != nil {
-				return err
-			}
+		err = o.Run(ctx)
+		if err != nil {
+			return err
+		}
 
-			return nil
-		}).NewCommandWithContext(ctx)
+		return nil
+	})
+	// Serving client for delegated AuthN/AuthZ doesn't support setting TLS SNI name so we need to disable it or it fails recovery
+	ccc.DisableServing = true
+	cmd := ccc.NewCommandWithContext(ctx)
 	cmd.Use = "cert-regeneration-controller"
 	cmd.Short = "Start the Cluster Certificate Regeneration Controller"
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
@@ -15,14 +15,14 @@ endef
 verify-deps: tmp_dir:=$(shell mktemp -d)
 verify-deps:
 	$(call restore-deps,$(tmp_dir))
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || echo '`go.mod` content is incorrect - did you run `go mod tidy`?'
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || echo '`go.sum` content is incorrect - did you run `go mod tidy`?'
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || ( echo '`go.mod` content is incorrect - did you run `go mod tidy`?' && false )
+	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || ( echo '`go.sum` content is incorrect - did you run `go mod tidy`?' && false )
 	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff
 	@     $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
 		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
 		echo 'Did you run `go mod vendor`?' && \
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
-		exit 1 \
+		false \
 	)
 .PHONY: verify-deps
 
@@ -39,4 +39,3 @@ update-deps-overrides:
 include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 )
-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -194,7 +194,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200210090402-3b072832771e
+# github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib
@@ -214,7 +214,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627
+# github.com/openshift/library-go v0.0.0-20200221162931-2e4133873386
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-kube-apiserver-operator/pull/768

requires:
- [x] bump when https://github.com/openshift/library-go/pull/716 merges

/cc @soltysh @deads2k 