### PR TITLE
Bug 1812583: Normalize CPU requests on masters

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -46,7 +46,7 @@ spec:
     resources:
       requests:
         memory: 1Gi
-        cpu: 150m
+        cpu: 300m
     ports:
     - containerPort: 6443
     volumeMounts:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -469,7 +469,7 @@ spec:
     resources:
       requests:
         memory: 1Gi
-        cpu: 150m
+        cpu: 300m
     ports:
     - containerPort: 6443
     volumeMounts:


### PR DESCRIPTION
The kube-apiserver uses approximately 33% of master CPU in a
reasonable medium sized workload. Given a 1 core per master baseline
(since CPU is compressible and shared), assign the kube-apiserver
roughly 33% of that core on each master.