### PR TITLE
bump library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b
 	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/library-go v0.0.0-20200309133644-48193d0ad816
+	github.com/openshift/library-go v0.0.0-20200317103838-27356bc78c87
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+q
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
 github.com/openshift/kubernetes-client-go v0.0.0-20200304132934-02649b23d68a h1:T7NDMVHiarViSL0H0wPkiYCvkcPF1APOIZ4QmGxRAm0=
 github.com/openshift/kubernetes-client-go v0.0.0-20200304132934-02649b23d68a/go.mod h1:cLXlTMtWHkuK4tD360KpWz2gG2KtdWEr/OT02i3emRQ=
-github.com/openshift/library-go v0.0.0-20200309133644-48193d0ad816 h1:sdMHMutbyRa87+aWkOMt5asoLCbPT9p+SbXpyCxl+Bw=
-github.com/openshift/library-go v0.0.0-20200309133644-48193d0ad816/go.mod h1:HM1nXsKTup/9rYnmXdYbbN+8Ux8Xp39odoqZ4qvSyBo=
+github.com/openshift/library-go v0.0.0-20200317103838-27356bc78c87 h1:h+Lj7AsiEweXmwA8OhPcFw0U3MmFOaCKTiTWhquGcSU=
+github.com/openshift/library-go v0.0.0-20200317103838-27356bc78c87/go.mod h1:OmQif4QBSpapk+JQ8aIIbaCRCCV92Dyt45lH+Os+OvM=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/cmd/regeneratecerts/carry/kubecontrollermanager/certrotationcontroller/kubecontrollermanagercertrotation.go
+++ b/pkg/cmd/regeneratecerts/carry/kubecontrollermanager/certrotationcontroller/kubecontrollermanagercertrotation.go
@@ -1,23 +1,30 @@
 package certrotationcontroller
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/regeneratecerts/carry/kubecontrollermanager/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 // defaultRotationDay is the default rotation base for all cert rotation operations.
 const defaultRotationDay = 24 * time.Hour
 
 type CertRotationController struct {
-	certRotators []*certrotation.CertRotationController
+	certRotators []factory.Controller
+	cachesToSync []cache.InformerSynced
+	recorder     events.Recorder
 }
 
 func NewCertRotationController(
@@ -27,7 +34,13 @@ func NewCertRotationController(
 	eventRecorder events.Recorder,
 	day time.Duration,
 ) (*CertRotationController, error) {
-	ret := &CertRotationController{}
+	ret := &CertRotationController{
+		// we have to wait for the informers to be synced because of RunOnce...
+		cachesToSync: []cache.InformerSynced{
+			kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Informer().HasSynced,
+			kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Informer().HasSynced,
+		},
+	}
 
 	rotationDay := defaultRotationDay
 	if day != time.Duration(0) {
@@ -36,7 +49,7 @@ func NewCertRotationController(
 		klog.Warningf("Certificate rotation base set to %q", rotationDay)
 	}
 
-	certRotator, err := certrotation.NewCertRotationController(
+	certRotator := certrotation.NewCertRotationController(
 		"CSRSigningCert",
 		certrotation.SigningRotation{
 			Namespace: operatorclient.OperatorNamespace,
@@ -71,10 +84,9 @@ func NewCertRotationController(
 			EventRecorder: eventRecorder,
 		},
 		nil,
+		eventRecorder,
 	)
-	if err != nil {
-		return nil, err
-	}
+	ret.recorder = eventRecorder
 	ret.certRotators = append(ret.certRotators, certRotator)
 
 	return ret, nil
@@ -84,8 +96,9 @@ func (c *CertRotationController) WaitForReady(stopCh <-chan struct{}) {
 	klog.Infof("Waiting for CertRotation")
 	defer klog.Infof("Finished waiting for CertRotation")
 
-	for _, certRotator := range c.certRotators {
-		certRotator.WaitForReady(stopCh)
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
 	}
 }
 
@@ -93,8 +106,9 @@ func (c *CertRotationController) WaitForReady(stopCh <-chan struct{}) {
 // This eliminates the need to pass an OperatorClient and avoids dubious writes and status.
 func (c *CertRotationController) RunOnce() error {
 	errlist := []error{}
+	runOnceCtx := context.WithValue(context.Background(), certrotation.RunOnceContextKey, true)
 	for _, certRotator := range c.certRotators {
-		if err := certRotator.RunOnce(); err != nil {
+		if err := certRotator.Sync(runOnceCtx, factory.NewSyncContext("CertRotationController", c.recorder)); err != nil {
 			errlist = append(errlist, err)
 		}
 	}

--- a/pkg/cmd/regeneratecerts/regenerate_certificates.go
+++ b/pkg/cmd/regeneratecerts/regenerate_certificates.go
@@ -188,6 +188,7 @@ func (o *Options) Run() error {
 	// wait until the controllers are ready
 	kubeAPIServerCertRotationController.WaitForReady(ctx.Done())
 	kubeControllerManagerCertRotationController.WaitForReady(ctx.Done())
+
 	select {
 	case <-ctx.Done():
 		return nil

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -222,7 +221,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	staleConditionsController := staleconditions.NewRemoveStaleConditions(
+	staleConditionsController := staleconditions.NewRemoveStaleConditionsController(
 		[]string{
 			// the static pod operator used to directly set these. this removes those conditions since the static pod operator was updated.
 			// these can be removed in 4.5
@@ -258,7 +257,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go staleConditionsController.Run(ctx, 1)
 
 	<-ctx.Done()
-	return fmt.Errorf("stopped")
+	return nil
 }
 
 // RevisionConfigMaps is a list of configmaps that are directly copied for the current values.  A different actor/controller modifies these.

--- a/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/leaderelection/leaderelection.go
@@ -3,6 +3,7 @@ package leaderelection
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -64,7 +65,8 @@ func ToConfigMapLeaderElection(clientConfig *rest.Config, config configv1.Leader
 		RetryPeriod:     config.RetryPeriod.Duration,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStoppedLeading: func() {
-				klog.Fatalf("leaderelection lost")
+				defer os.Exit(0)
+				klog.Warningf("leader election lost")
 			},
 		},
 	}, nil

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/base_controller.go
@@ -3,11 +3,9 @@ package factory
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -16,11 +14,12 @@ import (
 
 // baseController represents generic Kubernetes controller boiler-plate
 type baseController struct {
-	name         string
-	cachesToSync []cache.InformerSynced
-	sync         func(ctx context.Context, controllerContext SyncContext) error
-	syncContext  SyncContext
-	resyncEvery  time.Duration
+	name           string
+	cachesToSync   []cache.InformerSynced
+	sync           func(ctx context.Context, controllerContext SyncContext) error
+	syncContext    SyncContext
+	resyncEvery    time.Duration
+	postStartHooks []PostStartHook
 }
 
 var _ Controller = &baseController{}
@@ -36,10 +35,10 @@ func (c *baseController) Run(ctx context.Context, workers int) {
 		panic("timeout waiting for informer cache") // this will be recovered using HandleCrash()
 	}
 
-	var workerWaitGroup sync.WaitGroup
+	var workerWg sync.WaitGroup
 	defer func() {
 		defer klog.Infof("All %s workers have been terminated", c.name)
-		workerWaitGroup.Wait()
+		workerWg.Wait()
 	}()
 
 	// queueContext is used to track and initiate queue shutdown
@@ -47,11 +46,11 @@ func (c *baseController) Run(ctx context.Context, workers int) {
 
 	for i := 1; i <= workers; i++ {
 		klog.Infof("Starting #%d worker of %s controller ...", i, c.name)
-		workerWaitGroup.Add(1)
+		workerWg.Add(1)
 		go func() {
 			defer func() {
 				klog.Infof("Shutting down worker of %s controller ...", c.name)
-				workerWaitGroup.Done()
+				workerWg.Done()
 			}()
 			c.runWorker(queueContext)
 		}()
@@ -59,11 +58,29 @@ func (c *baseController) Run(ctx context.Context, workers int) {
 
 	// runPeriodicalResync is independent from queue
 	if c.resyncEvery > 0 {
-		workerWaitGroup.Add(1)
+		workerWg.Add(1)
 		go func() {
-			defer workerWaitGroup.Done()
+			defer workerWg.Done()
 			c.runPeriodicalResync(ctx, c.resyncEvery)
 		}()
+	}
+
+	// run post-start hooks (custom triggers, etc.)
+	if len(c.postStartHooks) > 0 {
+		var hookWg sync.WaitGroup
+		defer func() {
+			hookWg.Wait() // wait for the post-start hooks
+			klog.Infof("All %s post start hooks have been terminated", c.name)
+		}()
+		for i := range c.postStartHooks {
+			hookWg.Add(1)
+			go func(index int) {
+				defer hookWg.Done()
+				if err := c.postStartHooks[index](ctx, c.syncContext); err != nil {
+					klog.Warningf("%s controller post start hook error: %v", c.name, err)
+				}
+			}(i)
+		}
 	}
 
 	// Handle controller shutdown
@@ -82,17 +99,12 @@ func (c *baseController) Sync(ctx context.Context, syncCtx SyncContext) error {
 	return c.sync(ctx, syncCtx)
 }
 
-// QueueKey return queue key for given name.
-func QueueKey(name string) string {
-	return strings.ToLower(name) + "Key"
-}
-
 func (c *baseController) runPeriodicalResync(ctx context.Context, interval time.Duration) {
 	if interval == 0 {
 		return
 	}
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		c.syncContext.Queue().Add(QueueKey(c.name))
+		c.syncContext.Queue().Add(DefaultQueueKey)
 	}, interval)
 }
 
@@ -117,18 +129,24 @@ func (c *baseController) runWorker(queueCtx context.Context) {
 }
 
 func (c *baseController) processNextWorkItem(queueCtx context.Context) {
-	syncObject, quit := c.syncContext.Queue().Get()
+	key, quit := c.syncContext.Queue().Get()
 	if quit {
 		return
 	}
-	defer c.syncContext.Queue().Done(syncObject)
+	defer c.syncContext.Queue().Done(key)
 
-	runtimeObject, _ := syncObject.(runtime.Object)
-	if err := c.sync(queueCtx, c.syncContext.(syncContext).withRuntimeObject(runtimeObject)); err != nil {
-		utilruntime.HandleError(fmt.Errorf("%s controller failed to sync %+v with: %w", c.name, syncObject, err))
-		c.syncContext.Queue().AddRateLimited(syncObject)
+	syncCtx := c.syncContext.(syncContext)
+	var ok bool
+	syncCtx.queueKey, ok = key.(string)
+	if !ok {
+		klog.Warningf("Queue key is not string: %+v", key)
+	}
+
+	if err := c.sync(queueCtx, syncCtx); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s controller failed to sync %+v with: %w", c.name, key, err))
+		c.syncContext.Queue().AddRateLimited(key)
 		return
 	}
 
-	c.syncContext.Queue().Forget(syncObject)
+	c.syncContext.Queue().Forget(key)
 }

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/controller_context.go
@@ -17,12 +17,9 @@ import (
 // syncContext implements SyncContext and provide user access to queue and object that caused
 // the sync to be triggered.
 type syncContext struct {
-	queue         workqueue.RateLimitingInterface
 	eventRecorder events.Recorder
-
-	// queueRuntimeObject holds the object we got from informer
-	// There is no direct access to this object to prevent cache mutation.
-	queueRuntimeObject runtime.Object
+	queue         workqueue.RateLimitingInterface
+	queueKey      string
 }
 
 var _ SyncContext = syncContext{}
@@ -35,30 +32,16 @@ func NewSyncContext(name string, recorder events.Recorder) SyncContext {
 	}
 }
 
-// GetObject gives the object from the queue.
-// For controllers generated without WithRuntimeObject() this always return nil.
-func (c syncContext) GetObject() runtime.Object {
-	if c.queueRuntimeObject == nil {
-		return nil
-	}
-	return c.queueRuntimeObject.DeepCopyObject()
-}
-
 func (c syncContext) Queue() workqueue.RateLimitingInterface {
 	return c.queue
 }
 
-func (c syncContext) Recorder() events.Recorder {
-	return c.eventRecorder
+func (c syncContext) QueueKey() string {
+	return c.queueKey
 }
 
-// withRuntimeObject make a copy of existing sync context and set the queueRuntimeObject.
-func (c syncContext) withRuntimeObject(obj runtime.Object) SyncContext {
-	return syncContext{
-		eventRecorder:      c.Recorder(),
-		queue:              c.Queue(),
-		queueRuntimeObject: obj,
-	}
+func (c syncContext) Recorder() events.Recorder {
+	return c.eventRecorder
 }
 
 func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespaces sets.String) (bool, bool) {
@@ -76,78 +59,46 @@ func (c syncContext) isInterestingNamespace(obj interface{}, interestingNamespac
 }
 
 // eventHandler provides default event handler that is added to an informers passed to controller factory.
-func (c syncContext) eventHandler(keyName string, objectQueue bool, interestingNamespaces sets.String) cache.ResourceEventHandler {
+func (c syncContext) eventHandler(queueKeyFunc ObjectQueueKeyFunc, interestingNamespaces sets.String) cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := obj.(runtime.Object)
 			if !ok {
 				utilruntime.HandleError(fmt.Errorf("added object %+v is not runtime Object", obj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(new, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := new.(runtime.Object)
 			if !ok {
 				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			isNamespace, isInteresting := c.isInterestingNamespace(obj, interestingNamespaces)
-			if !objectQueue {
-				if !isNamespace {
-					c.Queue().Add(keyName)
-				} else if isInteresting {
-					c.Queue().Add(keyName)
-				}
-				return
-			}
 			runtimeObj, ok := obj.(runtime.Object)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if ok {
-					if !isNamespace {
-						c.Queue().Add(tombstone.Obj.(runtime.Object))
-					} else if isInteresting {
-						c.Queue().Add(tombstone.Obj.(runtime.Object))
+					if !isNamespace || (isNamespace && isInteresting) {
+						c.Queue().Add(queueKeyFunc(tombstone.Obj.(runtime.Object)))
 					}
 					return
 				}
 				utilruntime.HandleError(fmt.Errorf("updated object %+v is not runtime Object", runtimeObj))
 				return
 			}
-			if !isNamespace {
-				c.Queue().Add(runtimeObj)
-			} else if isInteresting {
-				c.Queue().Add(runtimeObj)
+			if !isNamespace || (isNamespace && isInteresting) {
+				c.Queue().Add(queueKeyFunc(runtimeObj))
 			}
 		},
 	}

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/factory.go
@@ -1,13 +1,18 @@
 package factory
 
 import (
+	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 )
+
+// DefaultQueueKey is the queue key used for string trigger based controllers.
+const DefaultQueueKey = "key"
 
 // Factory is generator that generate standard Kubernetes controllers.
 // Factory is really generic and should be only used for simple controllers that does not require special stuff..
@@ -15,8 +20,9 @@ type Factory struct {
 	sync                  SyncFunc
 	syncContext           SyncContext
 	resyncInterval        time.Duration
-	objectQueue           bool
 	informers             []Informer
+	informerQueueKeys     []informersWithQueueKey
+	postStartHooks        []PostStartHook
 	namespaceInformers    []*namespaceInformer
 	cachesToSync          []cache.InformerSynced
 	interestingNamespaces sets.String
@@ -33,6 +39,21 @@ type namespaceInformer struct {
 	informer   Informer
 	namespaces sets.String
 }
+
+type informersWithQueueKey struct {
+	informers  []Informer
+	queueKeyFn ObjectQueueKeyFunc
+}
+
+// PostStartHook specify a function that will run after controller is started.
+// The context is cancelled when the controller is asked to shutdown and the post start hook should terminate as well.
+// The syncContext allow access to controller queue and event recorder.
+type PostStartHook func(ctx context.Context, syncContext SyncContext) error
+
+// ObjectQueueKeyFunc is used to make a string work queue key out of the runtime object that is passed to it.
+// This can extract the "namespace/name" if you need to or just return "key" if you building controller that only use string
+// triggers.
+type ObjectQueueKeyFunc func(runtime.Object) string
 
 // New return new factory instance.
 func New() *Factory {
@@ -54,6 +75,24 @@ func (f *Factory) WithInformers(informers ...Informer) *Factory {
 	return f
 }
 
+// WithInformersQueueKeyFunc is used to register event handlers and get the caches synchronized functions.
+// Pass informers you want to use to react to changes on resources. If informer event is observed, then the Sync() function
+// is called.
+// Pass the queueKeyFn you want to use to transform the informer runtime.Object into string key used by work queue.
+func (f *Factory) WithInformersQueueKeyFunc(queueKeyFn ObjectQueueKeyFunc, informers ...Informer) *Factory {
+	f.informerQueueKeys = append(f.informerQueueKeys, informersWithQueueKey{
+		informers:  informers,
+		queueKeyFn: queueKeyFn,
+	})
+	return f
+}
+
+// WithPostStartHooks allows to register functions that will run asynchronously after the controller is started via Run command.
+func (f *Factory) WithPostStartHooks(hooks ...PostStartHook) *Factory {
+	f.postStartHooks = append(f.postStartHooks, hooks...)
+	return f
+}
+
 // WithNamespaceInformer is used to register event handlers and get the caches synchronized functions.
 // The sync function will only trigger when the object observed by this informer is a namespace and its name matches the interestingNamespaces.
 // Do not use this to register non-namespace informers.
@@ -72,14 +111,6 @@ func (f *Factory) WithNamespaceInformer(informer Informer, interestingNamespaces
 //       This can be used to detect periodical resyncs, but normal Sync() have to be cautious about `nil` objects.
 func (f *Factory) ResyncEvery(interval time.Duration) *Factory {
 	f.resyncInterval = interval
-	return f
-}
-
-// WithRuntimeObject cause the factory to produce controller that pass the runtime.Object from event handler that was
-// triggered to queue (instead of requeue using simple string key). This allow to access this object, however storing
-// object in queue might increase memory usage (?).
-func (f *Factory) WithRuntimeObject() *Factory {
-	f.objectQueue = true
 	return f
 }
 
@@ -105,20 +136,34 @@ func (f *Factory) ToController(name string, eventRecorder events.Recorder) Contr
 	}
 
 	c := &baseController{
-		name:        name,
-		sync:        f.sync,
-		resyncEvery: f.resyncInterval,
-		syncContext: ctx,
+		name:         name,
+		sync:         f.sync,
+		resyncEvery:  f.resyncInterval,
+		cachesToSync: append([]cache.InformerSynced{}, f.cachesToSync...),
+		syncContext:  ctx,
+	}
+
+	for i := range f.informerQueueKeys {
+		for d := range f.informerQueueKeys[i].informers {
+			informer := f.informerQueueKeys[i].informers[d]
+			queueKeyFn := f.informerQueueKeys[i].queueKeyFn
+			informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(queueKeyFn, sets.NewString()))
+			c.cachesToSync = append(c.cachesToSync, informer.HasSynced)
+		}
 	}
 
 	for i := range f.informers {
-		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, sets.NewString()))
-		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+		f.informers[i].AddEventHandler(c.syncContext.(syncContext).eventHandler(func(runtime.Object) string {
+			return DefaultQueueKey
+		}, sets.NewString()))
+		c.cachesToSync = append(c.cachesToSync, f.informers[i].HasSynced)
 	}
 
 	for i := range f.namespaceInformers {
-		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(QueueKey(name), f.objectQueue, f.namespaceInformers[i].namespaces))
-		c.cachesToSync = append(f.cachesToSync, f.informers[i].HasSynced)
+		f.namespaceInformers[i].informer.AddEventHandler(c.syncContext.(syncContext).eventHandler(func(runtime.Object) string {
+			return DefaultQueueKey
+		}, f.namespaceInformers[i].namespaces))
+		c.cachesToSync = append(c.cachesToSync, f.namespaceInformers[i].informer.HasSynced)
 	}
 
 	return c

--- a/vendor/github.com/openshift/library-go/pkg/controller/factory/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/factory/interfaces.go
@@ -3,7 +3,6 @@ package factory
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -35,9 +34,8 @@ type SyncContext interface {
 	// an error, the object is automatically re-queued. Use with caution.
 	Queue() workqueue.RateLimitingInterface
 
-	// GetObject provides access to current synced object deep copy.
-	// It is safe to mutate this object inside Sync().
-	GetObject() runtime.Object
+	// QueueKey represents the queue key passed to the Sync function.
+	QueueKey() string
 
 	// Recorder provide access to event recorder.
 	Recorder() events.Recorder

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -3,18 +3,14 @@ package certrotation
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -27,9 +23,9 @@ const (
 	CertificateIssuer = "auth.openshift.io/certificate-issuer"
 	// CertificateHostnames contains the hostnames used by a signer.
 	CertificateHostnames = "auth.openshift.io/certificate-hostnames"
+	// RunOnceContextKey is a context value key that can be used to call the controller Sync() and make it only run the syncWorker once and report error.
+	RunOnceContextKey = "cert-rotation-controller.openshift.io/run-once"
 )
-
-const workQueueKey = "key"
 
 // CertRotationController does:
 //
@@ -46,9 +42,6 @@ type CertRotationController struct {
 	CABundleRotation CABundleRotation
 	TargetRotation   TargetRotation
 	OperatorClient   v1helpers.StaticPodOperatorClient
-
-	cachesToSync []cache.InformerSynced
-	queue        workqueue.RateLimitingInterface
 }
 
 func NewCertRotationController(
@@ -57,31 +50,37 @@ func NewCertRotationController(
 	caBundleRotation CABundleRotation,
 	targetRotation TargetRotation,
 	operatorClient v1helpers.StaticPodOperatorClient,
-) (*CertRotationController, error) {
+	recorder events.Recorder,
+) factory.Controller {
 	c := &CertRotationController{
-		name: name,
-
+		name:             name,
 		SigningRotation:  signingRotation,
 		CABundleRotation: caBundleRotation,
 		TargetRotation:   targetRotation,
 		OperatorClient:   operatorClient,
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), strings.Replace(name, "-", "_", -1)),
 	}
-
-	signingRotation.Informer.Informer().AddEventHandler(c.eventHandler())
-	caBundleRotation.Informer.Informer().AddEventHandler(c.eventHandler())
-	targetRotation.Informer.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, signingRotation.Informer.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, caBundleRotation.Informer.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, targetRotation.Informer.Informer().HasSynced)
-
-	return c, nil
+	return factory.New().
+		ResyncEvery(30*time.Second).
+		WithSync(c.Sync).
+		WithInformers(
+			signingRotation.Informer.Informer(),
+			caBundleRotation.Informer.Informer(),
+			targetRotation.Informer.Informer(),
+		).
+		WithPostStartHooks(
+			c.targetCertRecheckerPostRunHook,
+		).
+		ToController("CertRotationController", recorder.WithComponentSuffix("cert-rotation-controller"))
 }
 
-func (c CertRotationController) sync() error {
+func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	syncErr := c.syncWorker()
+
+	// running this function with RunOnceContextKey value context will make this "run-once" without updating status.
+	isRunOnce, ok := ctx.Value(RunOnceContextKey).(bool)
+	if ok && isRunOnce {
+		return syncErr
+	}
 
 	newCondition := operatorv1.OperatorCondition{
 		Type:   fmt.Sprintf(condition.CertRotationDegradedConditionTypeFmt, c.name),
@@ -92,8 +91,12 @@ func (c CertRotationController) sync() error {
 		newCondition.Reason = "RotationError"
 		newCondition.Message = syncErr.Error()
 	}
-	if _, _, updateErr := v1helpers.UpdateStaticPodStatus(c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition)); updateErr != nil {
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(c.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	if updateErr != nil {
 		return updateErr
+	}
+	if updated && syncErr != nil {
+		syncCtx.Recorder().Warningf("RotationError", newCondition.Message)
 	}
 
 	return syncErr
@@ -117,97 +120,24 @@ func (c CertRotationController) syncWorker() error {
 	return nil
 }
 
-func (c *CertRotationController) WaitForReady(stopCh <-chan struct{}) {
-	klog.Infof("Waiting for CertRotationController - %q", c.name)
-	defer klog.Infof("Finished waiting for CertRotationController - %q", c.name)
-
-	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
-		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
-		return
+func (c CertRotationController) targetCertRecheckerPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
+	// If we have a need to force rechecking the cert, use this channel to do it.
+	refresher, ok := c.TargetRotation.CertCreator.(TargetCertRechecker)
+	if !ok {
+		return nil
 	}
-}
-
-// RunOnce will run the cert rotation logic, but will not try to update the static pod status.
-// This eliminates the need to pass an OperatorClient and avoids dubious writes and status.
-func (c *CertRotationController) RunOnce() error {
-	return c.syncWorker()
-}
-
-func (c *CertRotationController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting CertRotationController - %q", c.name)
-	defer klog.Infof("Shutting down CertRotationController - %q", c.name)
-	c.WaitForReady(ctx.Done())
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	// start a time based thread to ensure we stay up to date
+	targetRefresh := refresher.RecheckChannel()
 	go wait.Until(func() {
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
 		for {
-			c.queue.Add(workQueueKey)
 			select {
-			case <-ticker.C:
+			case <-targetRefresh:
+				syncCtx.Queue().Add(factory.DefaultQueueKey)
 			case <-ctx.Done():
 				return
 			}
 		}
-
 	}, time.Minute, ctx.Done())
 
-	// if we have a need to force rechecking the cert, use this channel to do it.
-	if refresher, ok := c.TargetRotation.CertCreator.(TargetCertRechecker); ok {
-		targetRefresh := refresher.RecheckChannel()
-		go wait.Until(func() {
-			for {
-				select {
-				case <-targetRefresh:
-					c.queue.Add(workQueueKey)
-				case <-ctx.Done():
-					return
-				}
-			}
-
-		}, time.Minute, ctx.Done())
-	}
-
 	<-ctx.Done()
-}
-
-func (c *CertRotationController) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *CertRotationController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v: %v failed with: %v", c.name, dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *CertRotationController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
+	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -14,19 +14,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-const configObserverWorkKey = "key"
 
 // Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
 type Listers interface {
@@ -42,7 +39,6 @@ type Listers interface {
 type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
 
 type ConfigObserver struct {
-
 	// observers are called in an undefined order and their results are merged to
 	// determine the observed configuration.
 	observers []ObserveConfigFunc
@@ -50,31 +46,27 @@ type ConfigObserver struct {
 	operatorClient v1helpers.OperatorClient
 	// listers are used by config observers to retrieve necessary resources
 	listers Listers
-
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 func NewConfigObserver(
 	operatorClient v1helpers.OperatorClient,
 	eventRecorder events.Recorder,
 	listers Listers,
+	informers []factory.Informer,
 	observers ...ObserveConfigFunc,
-) *ConfigObserver {
-	return &ConfigObserver{
+) factory.Controller {
+	c := &ConfigObserver{
 		operatorClient: operatorClient,
-		eventRecorder:  eventRecorder.WithComponentSuffix("config-observer"),
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ConfigObserver"),
-
-		observers: observers,
-		listers:   listers,
+		observers:      observers,
+		listers:        listers,
 	}
+
+	return factory.New().ResyncEvery(time.Second).WithSync(c.sync).WithInformers(append(informers, listersToInformer(listers)...)...).ToController("ConfigObserver", eventRecorder.WithComponentSuffix("config-observer"))
 }
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c ConfigObserver) sync() error {
+func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
@@ -91,7 +83,7 @@ func (c ConfigObserver) sync() error {
 	var observedConfigs []map[string]interface{}
 	for _, i := range rand.Perm(len(c.observers)) {
 		var currErrs []error
-		observedConfig, currErrs := c.observers[i](c.listers, c.eventRecorder, existingConfig)
+		observedConfig, currErrs := c.observers[i](c.listers, syncCtx.Recorder(), existingConfig)
 		observedConfigs = append(observedConfigs, observedConfig)
 		errs = append(errs, currErrs...)
 	}
@@ -115,12 +107,12 @@ func (c ConfigObserver) sync() error {
 	}
 
 	if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
-		c.eventRecorder.Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
 		if _, _, err := v1helpers.UpdateSpec(c.operatorClient, v1helpers.UpdateObservedConfigFn(mergedObservedConfig)); err != nil {
 			// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
 			// but instead reset the errors and only report single error condition.
 			errs = []error{fmt.Errorf("error writing updated observed config: %v", err)}
-			c.eventRecorder.Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+			syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
 		}
 	}
 	configError := v1helpers.NewMultiLineAggregate(errs)
@@ -142,52 +134,23 @@ func (c ConfigObserver) sync() error {
 	return configError
 }
 
-func (c *ConfigObserver) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting ConfigObserver")
-	defer klog.Infof("Shutting down ConfigObserver")
-	if !cache.WaitForCacheSync(ctx.Done(), c.listers.PreRunHasSynced()...) {
-		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
-		return
+// listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
+func listersToInformer(l Listers) []factory.Informer {
+	result := make([]factory.Informer, len(l.PreRunHasSynced()))
+	for i := range l.PreRunHasSynced() {
+		result[i] = &listerInformer{cacheSynced: l.PreRunHasSynced()[i]}
 	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
+	return result
 }
 
-func (c *ConfigObserver) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
+type listerInformer struct {
+	cacheSynced cache.InformerSynced
 }
 
-func (c *ConfigObserver) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
+func (l *listerInformer) AddEventHandler(cache.ResourceEventHandler) {
+	return
 }
 
-// eventHandler queues the operator to check spec and status
-func (c *ConfigObserver) EventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(configObserverWorkKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(configObserverWorkKey) },
-	}
+func (l *listerInformer) HasSynced() bool {
+	return l.cacheSynced()
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/loglevel/logging_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -12,11 +11,19 @@ import (
 
 type LogLevelController struct {
 	operatorClient operatorv1helpers.OperatorClient
+
+	// for unit tests only
+	setLogLevelFn func(operatorv1.LogLevel) error
+	getLogLevelFn func() (operatorv1.LogLevel, bool)
 }
 
 // sets the klog level based on desired state
 func NewClusterOperatorLoggingController(operatorClient operatorv1helpers.OperatorClient, recorder events.Recorder) factory.Controller {
-	c := &LogLevelController{operatorClient: operatorClient}
+	c := &LogLevelController{
+		operatorClient: operatorClient,
+		setLogLevelFn:  SetLogLEvel,
+		getLogLevelFn:  GetLogLevel,
+	}
 	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ToController("LoggingSyncer", recorder)
 }
 
@@ -28,24 +35,36 @@ func (c LogLevelController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return err
 	}
 
-	currentLogLevel := CurrentLogLevel()
+	currentLogLevel, isUnknown := c.getLogLevelFn()
 	desiredLogLevel := detailedSpec.OperatorLogLevel
 
+	// if operator operatorSpec OperatorLogLevel is empty, default to "Normal"
+	// TODO: This should be probably done by defaulting the CR field?
 	if len(desiredLogLevel) == 0 {
 		desiredLogLevel = operatorv1.Normal
 	}
 
-	// When the current loglevel is the desired one, do nothing
-	if currentLogLevel == desiredLogLevel {
+	// correct log level is set and it matches the expected log level from operator operatorSpec, do nothing.
+	if !isUnknown && currentLogLevel == desiredLogLevel {
 		return nil
 	}
 
-	// Set the new loglevel if the operator spec changed
-	if err := SetVerbosityValue(desiredLogLevel); err != nil {
-		syncCtx.Recorder().Warningf("OperatorLoglevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
+	// log level is not specified in operatorSpec and the log verbosity is not set (0), default the log level to V(2).
+	if len(desiredLogLevel) == 0 {
+		desiredLogLevel = currentLogLevel
+	}
+
+	// Set the new loglevel if the operator operatorSpec changed
+	if err := c.setLogLevelFn(desiredLogLevel); err != nil {
+		syncCtx.Recorder().Warningf("OperatorLogLevelChangeFailed", "Unable to change operator log level from %q to %q: %v", currentLogLevel, desiredLogLevel, err)
 		return err
 	}
 
-	syncCtx.Recorder().Eventf("OperatorLoglevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
+	// Do not fire event on every restart.
+	if isUnknown {
+		return nil
+	}
+
+	syncCtx.Recorder().Eventf("OperatorLogLevelChange", "Operator log level changed from %q to %q", currentLogLevel, desiredLogLevel)
 	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/management/management_state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/management/management_state_controller.go
@@ -3,26 +3,18 @@ package management
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"k8s.io/klog"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var workQueueKey = "instance"
 
 // ManagementStateController watches changes of `managementState` field and react in case that field is set to an unsupported value.
 // As each operator can opt-out from supporting `unmanaged` or `removed` states, this controller will add failing condition when the
@@ -30,36 +22,24 @@ var workQueueKey = "instance"
 type ManagementStateController struct {
 	operatorName   string
 	operatorClient operatorv1helpers.OperatorClient
-
-	cachesToSync  []cache.InformerSynced
-	queue         workqueue.RateLimitingInterface
-	eventRecorder events.Recorder
 }
 
 func NewOperatorManagementStateController(
 	name string,
 	operatorClient operatorv1helpers.OperatorClient,
 	recorder events.Recorder,
-) *ManagementStateController {
+) factory.Controller {
 	c := &ManagementStateController{
 		operatorName:   name,
 		operatorClient: operatorClient,
-		eventRecorder:  recorder,
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagementStateController_"+strings.Replace(name, "-", "_", -1)),
 	}
-
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-
-	return c
+	return factory.New().WithInformers(operatorClient.Informer()).WithSync(c.sync).ResyncEvery(time.Second).ToController("ManagementStateController", recorder.WithComponentSuffix("management-state-recorder"))
 }
 
-func (c ManagementStateController) sync() error {
+func (c ManagementStateController) sync(ctx context.Context, syncContext factory.SyncContext) error {
 	detailedSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
+		syncContext.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.operatorName)
 		return nil
 	}
 
@@ -93,53 +73,4 @@ func (c ManagementStateController) sync() error {
 	}
 
 	return nil
-}
-
-func (c *ManagementStateController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting management-state-controller-" + c.operatorName)
-	defer klog.Infof("Shutting down management-state-controller-" + c.operatorName)
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *ManagementStateController) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *ManagementStateController) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *ManagementStateController) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
-	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -22,8 +22,10 @@ import (
 func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Recorder, required *corev1.Namespace) (*corev1.Namespace, bool, error) {
 	existing, err := client.Namespaces().Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Namespaces().Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Namespaces().
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Namespace))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -53,8 +55,10 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, recorder events.Record
 func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, required *corev1.Service) (*corev1.Service, bool, error) {
 	existing, err := client.Services(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Services(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Services(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Service))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -94,8 +98,10 @@ func ApplyService(client coreclientv1.ServicesGetter, recorder events.Recorder, 
 func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required *corev1.Pod) (*corev1.Pod, bool, error) {
 	existing, err := client.Pods(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Pods(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Pods(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Pod))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -123,8 +129,10 @@ func ApplyPod(client coreclientv1.PodsGetter, recorder events.Recorder, required
 func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder events.Recorder, required *corev1.ServiceAccount) (*corev1.ServiceAccount, bool, error) {
 	existing, err := client.ServiceAccounts(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ServiceAccounts(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.ServiceAccounts(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ServiceAccount))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -150,8 +158,10 @@ func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, recorder eve
 func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, required *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
 	existing, err := client.ConfigMaps(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.ConfigMaps(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.ConfigMaps(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.ConfigMap))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {
@@ -230,8 +240,10 @@ func ApplySecret(client coreclientv1.SecretsGetter, recorder events.Recorder, re
 
 	existing, err := client.Secrets(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		actual, err := client.Secrets(required.Namespace).Create(required)
-		reportCreateEvent(recorder, required, err)
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Secrets(requiredCopy.Namespace).
+			Create(resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*corev1.Secret))
+		reportCreateEvent(recorder, requiredCopy, err)
 		return actual, true, err
 	}
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
@@ -2,6 +2,7 @@ package resourcemerge
 
 import (
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -13,6 +14,23 @@ func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required meta
 	SetStringIfSet(modified, &existing.Name, required.Name)
 	MergeMap(modified, &existing.Labels, required.Labels)
 	MergeMap(modified, &existing.Annotations, required.Annotations)
+}
+
+// WithCleanLabelsAndAnnotations cleans the metadata off the removal annotations/labels
+// (those that end with trailing "-")
+func WithCleanLabelsAndAnnotations(obj metav1.Object) metav1.Object {
+	obj.SetAnnotations(cleanRemovalKeys(obj.GetAnnotations()))
+	obj.SetLabels(cleanRemovalKeys(obj.GetLabels()))
+	return obj
+}
+
+func cleanRemovalKeys(required map[string]string) map[string]string {
+	for k := range required {
+		if strings.HasSuffix(k, "-") {
+			delete(required, k)
+		}
+	}
+	return required
 }
 
 func stringPtr(val string) *string {
@@ -124,7 +142,13 @@ func MergeMap(modified *bool, existing *map[string]string, required map[string]s
 	for k, v := range required {
 		if existingV, ok := (*existing)[k]; !ok || v != existingV {
 			*modified = true
-			(*existing)[k] = v
+			// if "required" map contains a key with "-" as suffix, remove that
+			// key from the existing map instead of replacing the value
+			if strings.HasSuffix(k, "-") {
+				delete(*existing, strings.TrimRight(k, "-"))
+			} else {
+				(*existing)[k] = v
+			}
 		}
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 	"time"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/util/workqueue"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/condition"
@@ -28,6 +28,7 @@ import (
 // ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
 // It will also mirror deletions by deleting destinations.
 type ResourceSyncController struct {
+	name string
 	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
 	syncRuleLock sync.RWMutex
 	// configMapSyncRules is a map from destination location to source location
@@ -43,12 +44,12 @@ type ResourceSyncController struct {
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
 	operatorConfigClient       v1helpers.OperatorClient
 
-	recorder          events.Recorder
-	queue             workqueue.RateLimitingInterface
-	controllerFactory *factory.Factory
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
 }
 
 var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
 
 // NewResourceSyncController creates ResourceSyncController.
 func NewResourceSyncController(
@@ -59,6 +60,7 @@ func NewResourceSyncController(
 	eventRecorder events.Recorder,
 ) *ResourceSyncController {
 	c := &ResourceSyncController{
+		name:                 "ResourceSyncController",
 		operatorConfigClient: operatorConfigClient,
 
 		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
@@ -68,27 +70,33 @@ func NewResourceSyncController(
 
 		configMapGetter: configMapsGetter,
 		secretGetter:    secretsGetter,
-		recorder:        eventRecorder,
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
 	}
 
-	syncCtx := factory.NewSyncContext(c.Name(), eventRecorder.WithComponentSuffix("resource-sync-controller"))
-	c.controllerFactory = factory.New().ResyncEvery(time.Second).WithInformers(operatorConfigClient.Informer()).WithSyncContext(syncCtx)
-
-	// we need queue for ResourceSyncer interface so SyncConfigMap and SyncSecret can be called outside the controller.
-	c.queue = syncCtx.Queue()
-
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
 	for namespace := range kubeInformersForNamespaces.Namespaces() {
 		if len(namespace) == 0 {
 			continue
 		}
-		informers := kubeInformersForNamespaces.InformersFor(namespace)
-		c.controllerFactory.WithInformers(
-			informers.Core().V1().ConfigMaps().Informer(),
-			informers.Core().V1().Secrets().Informer(),
-		)
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
 	}
 
+	f := factory.New().WithSync(c.Sync).WithSyncContext(c.syncCtx).WithInformers(informers...).ResyncEvery(time.Second).ToController(c.name, eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.runFn = f.Run
+
 	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.name
 }
 
 func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
@@ -104,7 +112,7 @@ func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocat
 	c.configMapSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(factory.QueueKey(c.Name()))
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
 	return nil
 }
 
@@ -121,17 +129,8 @@ func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation
 	c.secretSyncRules[destination] = source
 
 	// make sure the new rule is picked up
-	c.queue.Add(factory.QueueKey(c.Name()))
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
 	return nil
-}
-
-// Run is used for unit testing
-func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
-	c.controllerFactory.WithSync(c.Sync).ToController(c.Name(), c.recorder.WithComponentSuffix("resource-sync-controller")).Run(ctx, workers)
-}
-
-func (c *ResourceSyncController) Name() string {
-	return "ResourceSyncController"
 }
 
 func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
@@ -248,7 +247,7 @@ type ControllerSyncRules struct {
 	Configs ResourceSyncRuleList `json:"configs"`
 }
 
-// ServeSyncRules provides a handler function to return the Sync rules of the controller
+// ServeSyncRules provides a handler function to return the sync rules of the controller
 func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -660,7 +660,7 @@ func (c *InstallerController) ensureInstallerPod(nodeName string, operatorSpec *
 	}
 
 	args := []string{
-		fmt.Sprintf("-v=%d", loglevel.LogLevelToKlog(operatorSpec.LogLevel)),
+		fmt.Sprintf("-v=%d", loglevel.LogLevelToVerbosity(operatorSpec.LogLevel)),
 		fmt.Sprintf("--revision=%d", revision),
 		fmt.Sprintf("--namespace=%s", pod.Namespace),
 		fmt.Sprintf("--pod=%s", c.configMaps[0].Name),

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
@@ -2,34 +2,27 @@ package status
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/klog"
-
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	configv1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
-
-var workQueueKey = "instance"
 
 type VersionGetter interface {
 	// SetVersion is a way to set the version for an operand.  It must be thread-safe
@@ -49,10 +42,15 @@ type StatusSyncer struct {
 	clusterOperatorClient configv1client.ClusterOperatorsGetter
 	clusterOperatorLister configv1listers.ClusterOperatorLister
 
-	cachesToSync    []cache.InformerSynced
-	queue           workqueue.RateLimitingInterface
-	eventRecorder   events.Recorder
-	degradedInertia Inertia
+	controllerFactory *factory.Factory
+	recorder          events.Recorder
+	degradedInertia   Inertia
+}
+
+var _ factory.Controller = &StatusSyncer{}
+
+func (c *StatusSyncer) Name() string {
+	return c.clusterOperatorName
 }
 
 func NewClusterOperatorStatusController(
@@ -64,26 +62,24 @@ func NewClusterOperatorStatusController(
 	versionGetter VersionGetter,
 	recorder events.Recorder,
 ) *StatusSyncer {
-	c := &StatusSyncer{
+	return &StatusSyncer{
 		clusterOperatorName:   name,
 		relatedObjects:        relatedObjects,
 		versionGetter:         versionGetter,
 		clusterOperatorClient: clusterOperatorClient,
 		clusterOperatorLister: clusterOperatorInformer.Lister(),
 		operatorClient:        operatorClient,
-		eventRecorder:         recorder.WithComponentSuffix("status-controller"),
 		degradedInertia:       MustNewInertia(2 * time.Minute).Inertia,
-
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "StatusSyncer_"+strings.Replace(name, "-", "_", -1)),
+		controllerFactory: factory.New().ResyncEvery(time.Second).WithInformers(
+			operatorClient.Informer(),
+			clusterOperatorInformer.Informer(),
+		),
+		recorder: recorder.WithComponentSuffix("status-controller"),
 	}
+}
 
-	operatorClient.Informer().AddEventHandler(c.eventHandler())
-	clusterOperatorInformer.Informer().AddEventHandler(c.eventHandler())
-
-	c.cachesToSync = append(c.cachesToSync, operatorClient.Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, clusterOperatorInformer.Informer().HasSynced)
-
-	return c
+func (c *StatusSyncer) Run(ctx context.Context, workers int) {
+	c.controllerFactory.WithPostStartHooks(c.watchVersionGetterPostRunHook).WithSync(c.Sync).ToController("StatusSyncer_"+c.Name(), c.recorder).Run(ctx, workers)
 }
 
 // WithDegradedInertia returns a copy of the StatusSyncer with the
@@ -96,10 +92,10 @@ func (c *StatusSyncer) WithDegradedInertia(inertia Inertia) *StatusSyncer {
 
 // sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
 // must be information that is logically "owned" by another component.
-func (c StatusSyncer) sync() error {
+func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	detailedSpec, currentDetailedStatus, _, err := c.operatorClient.GetOperatorState()
 	if apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
+		syncCtx.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for clusteroperator/%s", c.clusterOperatorName)
 		if err := c.clusterOperatorClient.ClusterOperators().Delete(c.clusterOperatorName, nil); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -111,7 +107,7 @@ func (c StatusSyncer) sync() error {
 
 	originalClusterOperatorObj, err := c.clusterOperatorLister.Get(c.clusterOperatorName)
 	if err != nil && !apierrors.IsNotFound(err) {
-		c.eventRecorder.Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
+		syncCtx.Recorder().Warningf("StatusFailed", "Unable to get current operator status for clusteroperator/%s: %v", c.clusterOperatorName, err)
 		return err
 	}
 
@@ -125,11 +121,11 @@ func (c StatusSyncer) sync() error {
 		if apierrors.IsNotFound(createErr) {
 			// this means that the API isn't present.  We did not fail.  Try again later
 			klog.Infof("ClusterOperator API not created")
-			c.queue.AddRateLimited(workQueueKey)
+			syncCtx.Queue().AddRateLimited(factory.DefaultQueueKey)
 			return nil
 		}
 		if createErr != nil {
-			c.eventRecorder.Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
+			syncCtx.Recorder().Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
 			return createErr
 		}
 	}
@@ -149,7 +145,7 @@ func (c StatusSyncer) sync() error {
 		if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 			return updateErr
 		}
-		c.eventRecorder.Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+		syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for operator %s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
 		return nil
 	}
 
@@ -165,7 +161,7 @@ func (c StatusSyncer) sync() error {
 		previousVersion := operatorv1helpers.SetOperandVersion(&clusterOperatorObj.Status.Versions, configv1.OperandVersion{Name: operand, Version: version})
 		if previousVersion != version {
 			// having this message will give us a marker in events when the operator updated compared to when the operand is updated
-			c.eventRecorder.Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
+			syncCtx.Recorder().Eventf("OperatorVersionChanged", "clusteroperator/%s version %q changed from %q to %q", c.clusterOperatorName, operand, previousVersion, version)
 		}
 	}
 
@@ -178,7 +174,7 @@ func (c StatusSyncer) sync() error {
 	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(clusterOperatorObj); err != nil {
 		return updateErr
 	}
-	c.eventRecorder.Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
+	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))
 	return nil
 }
 
@@ -192,71 +188,19 @@ func OperatorConditionToClusterOperatorCondition(condition operatorv1.OperatorCo
 	}
 }
 
-func (c *StatusSyncer) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	klog.Infof("Starting StatusSyncer-" + c.clusterOperatorName)
-	defer klog.Infof("Shutting down StatusSyncer-" + c.clusterOperatorName)
-	if !cache.WaitForCacheSync(ctx.Done(), c.cachesToSync...) {
-		return
-	}
-
-	// start watching for version changes
-	go c.watchVersionGetter(ctx.Done())
-
-	// doesn't matter what workers say, only start one.
-	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
-
-	<-ctx.Done()
-}
-
-func (c *StatusSyncer) watchVersionGetter(stopCh <-chan struct{}) {
+func (c *StatusSyncer) watchVersionGetterPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
 	defer utilruntime.HandleCrash()
 
 	versionCh := c.versionGetter.VersionChangedChannel()
 	// always kick at least once
-	c.queue.Add(workQueueKey)
+	syncCtx.Queue().Add(factory.DefaultQueueKey)
 
 	for {
 		select {
-		case <-stopCh:
-			return
+		case <-ctx.Done():
+			return nil
 		case <-versionCh:
-			c.queue.Add(workQueueKey)
+			syncCtx.Queue().Add(factory.DefaultQueueKey)
 		}
-	}
-}
-
-func (c *StatusSyncer) runWorker(_ context.Context) {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *StatusSyncer) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-
-	err := c.sync()
-	if err == nil {
-		c.queue.Forget(dsKey)
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
-	c.queue.AddRateLimited(dsKey)
-
-	return true
-}
-
-// eventHandler queues the operator to check spec and status
-func (c *StatusSyncer) eventHandler() cache.ResourceEventHandler {
-	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
-		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -43,7 +43,7 @@ func (fakeSharedIndexInformer) Run(stopCh <-chan struct{}) {
 }
 
 func (fakeSharedIndexInformer) HasSynced() bool {
-	panic("implement me")
+	return true
 }
 
 func (fakeSharedIndexInformer) LastSyncResourceVersion() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200309133644-48193d0ad816
+# github.com/openshift/library-go v0.0.0-20200317103838-27356bc78c87
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
* openshift/library-go@3a6456f: resourcemerge: Allow removing annotations/labels
* openshift/library-go@423e202: factory: allow for post-start hooks for custom triggers
* openshift/library-go@7c9065e: implements a generic workload controller
* openshift/library-go@522f72d: go mod tidy
* openshift/library-go@07fd01b: adds precondition function
* openshift/library-go@34fe6fc: factory: remove support for runtime object in queue
* openshift/library-go@07eabbf: nsfinalizer: migrate controller to factory
* openshift/library-go@488e1fa: apiservice: migrate controller to factory
* openshift/library-go@38b127e: certrotation: migrate controller to factory
* openshift/library-go@3f9a525: configobserver: migrate controller to factory
* openshift/library-go@5f7087d: management: migrate controller to factory
* openshift/library-go@7f456e6: staleconditions: migrate controller to factory
* openshift/library-go@f17c0ee: status: migrate controller to factory
* openshift/library-go@892bfb1: resourcesync: adjust to queue key
* openshift/library-go@fa685ad: leaderelection: do not fatal on leader election lost
* openshift/library-go@c95f7e3: allows for setting an optional prefix for condition's type field for the generic workload ctrl
* openshift/library-go@3e49782: delegates creation of common informers down to workload controller
* openshift/library-go@a43f112: logging: properly set log level
* openshift/library-go@1add03a: resourcesynccontroller: fix unit test flakes