### PR TITLE
Bug 1813911: Disable serving for cert regeneration controller to avoid wrong dependency

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -49,6 +49,13 @@ func NewCertRegenerationControllerCommand(ctx context.Context) *cobra.Command {
 
 		return nil
 	})
+
+	// Disable serving for recovery as it introduces a dependency on kube-system::extension-apiserver-authentication
+	// configmap which prevents it to start as the CA bundle is expired.
+	// TODO: Remove when the internal logic can start serving without extension-apiserver-authentication
+	//  	 and live reload extension-apiserver-authentication after it is available
+	ccc.DisableServing = true
+
 	cmd := ccc.NewCommandWithContext(ctx)
 	cmd.Use = "cert-regeneration-controller"
 	cmd.Short = "Start the Cluster Certificate Regeneration Controller"


### PR DESCRIPTION
Fixes
```
E0316 11:09:35.761846       1 configmap_cafile_content.go:246] key failed with : missing content for CA bundle "client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file"
E0316 11:10:06.515529       1 configmap_cafile_content.go:246] kube-system/extension-apiserver-authentication failed with : missing content for CA bundle "client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file"
```

/cc @sttts @deads2k @soltysh 