### PR TITLE
[release-4.4] Bug 1813914: Disable serving for cert regeneration controller to avoid wrong dependency

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -49,6 +49,12 @@ func NewCertRegenerationControllerCommand(ctx context.Context) *cobra.Command {
 
 		return nil
 	})
+
+	// Disable serving for recovery as it introduces a dependency on kube-system::extension-apiserver-authentication
+	// configmap which prevents it to start as the CA bundle is expired.
+	// TODO: Make library-go support serving without such dependency.
+	ccc.DisableServing = true
+
 	cmd := ccc.NewCommandWithContext(ctx)
 	cmd.Use = "cert-regeneration-controller"
 	cmd.Short = "Start the Cluster Certificate Regeneration Controller"


### PR DESCRIPTION
backport of https://github.com/openshift/cluster-kube-apiserver-operator/pull/797

/cc @sttts @deads2k @soltysh