### PR TITLE
WIP: Move public-info-viewer ClusterRole and Binding here

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_00_clusterrole-public-info-viewer.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_clusterrole-public-info-viewer.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:public-info-viewer
+rules:
+- nonResourceURLs:
+  - /.well-known
+  - /.well-known/*
+  verbs:
+  - get

--- a/manifests/0000_20_kube-apiserver-operator_00_clusterrolebinding-public-info-viewer.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_clusterrolebinding-public-info-viewer.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:public-info-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:public-info-viewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated


### PR DESCRIPTION
Note: this will race with kube-apiserver for now.