### PR TITLE
Reduce graceful termination window

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -64,7 +64,7 @@ spec:
     ports:
     - containerPort: 6080
 {{end}}
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 95 # bit more than 30s (minimal termination period) + 60s (apiserver graceful termination)
   volumes:
   - hostPath:
       path: {{ .SecretsHostPath }}

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -22,7 +22,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   shutdown-delay-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  - 30s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-preferred-address-types:

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -149,7 +149,7 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 95 # bit more than 30s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -117,7 +117,7 @@ apiServerArguments:
   enable-aggregator-routing:
   - "true"
   shutdown-delay-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  - 30s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   http2-max-streams-per-connection:
   - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-preferred-address-types:
@@ -572,7 +572,7 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: 95 # bit more than 30s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:


### PR DESCRIPTION
Reduce graceful termination window to speed up kube-apiserver roll out
- set shutdown-delay-duration to 30s (close to worst case scenario by  which an LB should detect /readyz failure) and react. We are saving 40s (previous value=70s)
- consequently, set terminationGracePeriodSeconds to 95 seconds, bit more than 30s (shutdown-delay-duration) + 60s (kube-apiserver graceful termination)
