### PR TITLE
kubelet-client secret dynamic reload

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -88,8 +88,8 @@ authConfig:
 consolePublicURL: ""
 kubeletClientInfo:
   ca: /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+  certFile: /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt
+  keyFile: /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key
   port: 10250
 projectConfig:
   defaultNodeSelector: ""

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -304,6 +304,7 @@ var CertConfigMaps = []revision.RevisionResource{
 }
 
 var CertSecrets = []revision.RevisionResource{
+	{Name: "kubelet-client"},
 	{Name: "aggregator-client"},
 	{Name: "localhost-serving-cert-certkey"},
 	{Name: "service-network-serving-certkey"},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -287,7 +287,6 @@ var RevisionConfigMaps = []revision.RevisionResource{
 var RevisionSecrets = []revision.RevisionResource{
 	// these need to removed, but if we remove them now, the cluster will die because we don't reload them yet
 	{Name: "etcd-client"},
-	{Name: "kubelet-client"},
 	// etcd encryption
 	{Name: "encryption-config", Optional: true},
 

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -183,8 +183,8 @@ authConfig:
 consolePublicURL: ""
 kubeletClientInfo:
   ca: /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+  certFile: /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt
+  keyFile: /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key
   port: 10250
 projectConfig:
   defaultNodeSelector: ""


### PR DESCRIPTION
With https://github.com/openshift/origin/pull/24646 merged,  a new revision need not be created when `kubelet-client` certificate changes