### PR TITLE
Bug 1819246: Set service account issuer to internal dns name of kube apiserver

### DIFF
--- a/bindata/v4.1.0/config/config-overrides.yaml
+++ b/bindata/v4.1.0/config/config-overrides.yaml
@@ -5,9 +5,9 @@ apiServerArguments:
   # tokens. This is only supported post-bootstrap so these
   # values must not appear in defaultconfig.yaml.
   service-account-issuer:
-  - auth.openshift.io
+  - https://kubernetes.default.svc
   api-audiences:
-  - auth.openshift.io
+  - https://kubernetes.default.svc
   service-account-signing-key-file:
   - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
 serviceAccountPublicKeyFiles:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -66,9 +66,9 @@ apiServerArguments:
   # tokens. This is only supported post-bootstrap so these
   # values must not appear in defaultconfig.yaml.
   service-account-issuer:
-  - auth.openshift.io
+  - https://kubernetes.default.svc
   api-audiences:
-  - auth.openshift.io
+  - https://kubernetes.default.svc
   service-account-signing-key-file:
   - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
 serviceAccountPublicKeyFiles:

--- a/test/e2e/bound_sa_token_test.go
+++ b/test/e2e/bound_sa_token_test.go
@@ -206,7 +206,8 @@ func TestTokenRequestAndReview(t *testing.T) {
 		sa.Name,
 		&authenticationv1.TokenRequest{
 			Spec: authenticationv1.TokenRequestSpec{
-				Audiences: []string{"auth.openshift.io"},
+				// Avoid specifying any audiences so that the token will be
+				// issued for the default audience of the issuer.
 			},
 		},
 		metav1.CreateOptions{})
@@ -237,7 +238,7 @@ func TestChangeServiceAccountIssuer(t *testing.T) {
 	// Wait for operator readiness
 	test.WaitForKubeAPIServerClusterOperatorAvailableNotProgressingNotDegraded(t, configClient)
 
-	defaultIssuer := "auth.openshift.io"
+	defaultIssuer := "https://kubernetes.default.svc"
 
 	// Check that the default issuer is set in the operand config
 	require.NoError(t, pollForOperandIssuer(t, coreClient, defaultIssuer))


### PR DESCRIPTION
The default issuer for bound service account tokens is updated to point to the internal dns name of the kube apiserver to ensure compatibility with the `ServiceAccountIssuerDiscovery` feature [1] added in kube 1.18. This fix is intended to be backported to 4.4 (the release that added support for bound service account otkens) before GA to ensure that the default will be compatible from introduction with the discovery feature without having to update the issuer (which would involve reissuing all existing bound tokens).

1: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery

Related change: https://github.com/openshift/api/pull/617