### PR TITLE
Bug 1821448: Provide better messaging when Upgradeable is False

### DIFF
--- a/pkg/operator/defaultscccontroller/defaultscccontroller.go
+++ b/pkg/operator/defaultscccontroller/defaultscccontroller.go
@@ -150,7 +150,7 @@ func (c *DefaultSCCController) Sync(key types.NamespacedName) error {
 	}
 
 	if len(mutated) > 0 {
-		klog.Infof("[%s] default scc has been mutated %s", ControllerName, mutated)
+		klog.Infof("[%s] default scc has been mutated %s, please visit https://bugzilla.redhat.com/show_bug.cgi?id=1821905#c22 to resolve the issue", ControllerName, mutated)
 	}
 
 	condition := NewCondition(mutated)


### PR DESCRIPTION
If Upgradeable is False due to default SCC mutation, we should provide better messaging.