### PR TITLE
version: fix build_info metrics reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20200408213141-2cf49d05c5e2
 	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae
+	github.com/openshift/library-go v0.0.0-20200414135834-ccc4bb27d032
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1Gd
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca h1:YNtyJnE53QuEUSjl7L1AARocI021o7cU2bvh4prDtiE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca/go.mod h1:unEnEWccGeVxaXSRsWTjRsNxMqYXmuQjzjcPFQ91H9M=
-github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae h1:QE9zls9gSMcB8LYWi2mFvVaiAcI4ECg6b45/OYHGe9E=
-github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
+github.com/openshift/library-go v0.0.0-20200414135834-ccc4bb27d032 h1:DFlzobaf+Sy22sUz5oCoFcpzv4pLcjUgUEPLDSitnX0=
+github.com/openshift/library-go v0.0.0-20200414135834-ccc4bb27d032/go.mod h1:CfydoH0B+RYs22uQZQ36A1mz5m5zhucpMGh8t5s71v4=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,9 +1,6 @@
 package version
 
 import (
-	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
-
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -20,29 +17,25 @@ var (
 	minorFromGit string
 	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 	buildDate string
+
+	gitTreeState string
+	goVersion    string
+	compiler     string
+	platform     string
 )
 
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func Get() version.Info {
 	return version.Info{
-		Major:      majorFromGit,
-		Minor:      minorFromGit,
-		GitCommit:  commitFromGit,
-		GitVersion: versionFromGit,
-		BuildDate:  buildDate,
+		Major:        majorFromGit,
+		Minor:        minorFromGit,
+		GitVersion:   versionFromGit,
+		GitCommit:    commitFromGit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    goVersion,
+		Compiler:     compiler,
+		Platform:     platform,
 	}
-}
-
-func init() {
-	buildInfo := metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Name: "openshift_cluster_kube_apiserver_operator_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Cluster Kube-API-Server Operator was built.",
-		},
-		[]string{"major", "minor", "gitCommit", "gitVersion"},
-	)
-	buildInfo.WithLabelValues(majorFromGit, minorFromGit, commitFromGit, versionFromGit).Set(1)
-
-	legacyregistry.MustRegister(buildInfo)
 }

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/version"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/kubernetes"
@@ -71,6 +75,8 @@ type ControllerBuilder struct {
 	authenticationConfig *operatorv1alpha1.DelegatedAuthentication
 	authorizationConfig  *operatorv1alpha1.DelegatedAuthorization
 	healthChecks         []healthz.HealthChecker
+
+	versionInfo *version.Info
 
 	// nonZeroExitFn takes a function that exit the process with non-zero code.
 	// This stub exists for unit test where we can check if the graceful termination work properly.
@@ -134,6 +140,12 @@ func (b *ControllerBuilder) WithLeaderElection(leaderElection configv1.LeaderEle
 	return b
 }
 
+// WithVersion accepts a getting that provide binary version information that is used to report build_info information to prometheus
+func (b *ControllerBuilder) WithVersion(info version.Info) *ControllerBuilder {
+	b.versionInfo = &info
+	return b
+}
+
 // WithServer adds a server that provides metrics and healthz
 func (b *ControllerBuilder) WithServer(servingInfo configv1.HTTPServingInfo, authenticationConfig operatorv1alpha1.DelegatedAuthentication, authorizationConfig operatorv1alpha1.DelegatedAuthorization) *ControllerBuilder {
 	b.servingInfo = servingInfo.DeepCopy()
@@ -192,6 +204,23 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 			eventRecorder.Warningf("OperatorRestart", "Restarted because of %s", action.String(file))
 			return originalFileObserverReactorFn(file, action)
 		}
+	}
+
+	// report the binary version metrics to prometheus
+	if b.versionInfo != nil {
+		buildInfo := metrics.NewGaugeVec(
+			&metrics.GaugeOpts{
+				Name: strings.Replace(b.componentNamespace, "-", "_", -1) + "_build_info",
+				Help: "A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, " +
+					"and compiler from which " + b.componentName + " was built, and platform on which it is running.",
+				StabilityLevel: metrics.ALPHA,
+			},
+			[]string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+		)
+		legacyregistry.MustRegister(buildInfo)
+		buildInfo.WithLabelValues(b.versionInfo.Major, b.versionInfo.Minor, b.versionInfo.GitVersion, b.versionInfo.GitCommit, b.versionInfo.GitTreeState, b.versionInfo.BuildDate, b.versionInfo.GoVersion,
+			b.versionInfo.Compiler, b.versionInfo.Platform).Set(1)
+		klog.Infof("%s version %s-%s", b.componentName, b.versionInfo.GitVersion, b.versionInfo.GitCommit)
 	}
 
 	kubeConfig := ""

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -1,7 +1,6 @@
 package controllercmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -198,6 +197,11 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			config.ServingInfo.KeyFile = filepath.Join(certDir, "tls.key")
 		} else {
 			klog.Warningf("Using insecure, self-signed certificates")
+			// If we generate our own certificates, then we want to specify empty content to avoid a starting race.  This way,
+			// if any change comes in, we will properly restart
+			startingFileContent[filepath.Join(certDir, "tls.crt")] = []byte{}
+			startingFileContent[filepath.Join(certDir, "tls.key")] = []byte{}
+
 			temporaryCertDir, err := ioutil.TempDir("", "serving-cert-")
 			if err != nil {
 				return nil, nil, err
@@ -213,11 +217,10 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			if err != nil {
 				return nil, nil, err
 			}
-			certDir = temporaryCertDir
 
 			// force the values to be set to where we are writing the certs
-			config.ServingInfo.CertFile = filepath.Join(certDir, "tls.crt")
-			config.ServingInfo.KeyFile = filepath.Join(certDir, "tls.key")
+			config.ServingInfo.CertFile = filepath.Join(temporaryCertDir, "tls.crt")
+			config.ServingInfo.KeyFile = filepath.Join(temporaryCertDir, "tls.key")
 			// nothing can trust this, so we don't really care about hostnames
 			servingCert, err := ca.MakeServerCert(sets.NewString("localhost"), 30)
 			if err != nil {
@@ -226,16 +229,6 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			if err := servingCert.WriteCertConfigFile(config.ServingInfo.CertFile, config.ServingInfo.KeyFile); err != nil {
 				return nil, nil, err
 			}
-			crtContent := &bytes.Buffer{}
-			keyContent := &bytes.Buffer{}
-			if err := servingCert.WriteCertConfig(crtContent, keyContent); err != nil {
-				return nil, nil, err
-			}
-
-			// If we generate our own certificates, then we want to specify empty content to avoid a starting race.  This way,
-			// if any change comes in, we will properly restart
-			startingFileContent[filepath.Join(certDir, "tls.crt")] = crtContent.Bytes()
-			startingFileContent[filepath.Join(certDir, "tls.key")] = keyContent.Bytes()
 		}
 	}
 	return startingFileContent, observedFiles, nil
@@ -273,6 +266,7 @@ func (c *ControllerCommandConfig) StartController(ctx context.Context) error {
 		WithKubeConfigFile(c.basicFlags.KubeConfigFile, nil).
 		WithComponentNamespace(c.basicFlags.Namespace).
 		WithLeaderElection(config.LeaderElection, c.basicFlags.Namespace, c.componentName+"-lock").
+		WithVersion(c.version).
 		WithRestartOnChange(exitOnChangeReactorCh, startingFileContent, observedFiles...)
 
 	if !c.DisableServing {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig/secret.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig/secret.go
@@ -70,5 +70,6 @@ func ToSecret(ns, name string, encryptionCfg *apiserverconfigv1.EncryptionConfig
 		Data: map[string][]byte{
 			EncryptionConfSecretName: rawEncryptionCfg,
 		},
+		Type: corev1.SecretTypeOpaque,
 	}, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
@@ -98,6 +98,7 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 		Data: map[string][]byte{
 			EncryptionSecretKeyDataKey: bs,
 		},
+		Type: corev1.SecretTypeOpaque,
 	}
 
 	if !ks.Migrated.Timestamp.IsZero() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200402123743-4015ba624cae
+# github.com/openshift/library-go v0.0.0-20200414135834-ccc4bb27d032
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Attempt to fix the build_info metrics that we lost, probably before 1.18 rebase.

The helper PR for library-go: https://github.com/openshift/library-go/pull/771