### PR TITLE
Fix kube-apiserver-to-kubelet-signer's refresh date

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -174,7 +174,7 @@ func newCertRotationController(
 			Namespace:              operatorclient.OperatorNamespace,
 			Name:                   "kube-apiserver-to-kubelet-signer",
 			Validity:               1 * 365 * defaultRotationDay, // this comes from the installer
-			Refresh:                8 * 365 * defaultRotationDay, // this means we effectively do not rotate
+			Refresh:                292 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),


### PR DESCRIPTION
[We always rotate after 4/5 of the life time](https://github.com/openshift/cluster-kube-apiserver-operator/blob/d62bbd3dce5400e28968447668b68f54f00dd685/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go#L83). Fixing the refresh date to be explicit helps others to better understand the life cycle.

/cc @deads2k @pweil- 