### PR TITLE
Bug 1827336: Remove stale condition

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -226,6 +226,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// the static pod operator used to directly set these. this removes those conditions since the static pod operator was updated.
 			// these can be removed in 4.5
 			"Available", "Progressing",
+
+			// We removed the controller that sets the condition `DefaultSecurityContextConstraintsUpgradeable` if any
+			// default SCC has been mutated.
+			// A cluster that already has user-modified default SCCs will have the above condition set. We need to
+			// remove the stale condition.
+			"DefaultSecurityContextConstraintsUpgradeable",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
We removed the controller that sets the condition `DefaultSecurityContextConstraintsUpgradeable` if any default SCC has been mutated. A cluster that already has user-modified default SCCs will have the above condition set. We need to remove the stale condition.

Some user may do force upgrade to OpenShift 4.4, so we need this fix to go in 4.4 to clean the stale condition.