### PR TITLE
Copy openshift-tests binary in order to run resourcewatch

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,6 +5,7 @@ ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
 RUN make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.4:base
+COPY --from=registry.svc.ci.openshift.org/ocp/4.5:tests /usr/bin/openshift-tests /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/


### PR DESCRIPTION
This is needed to make the `openshift-tests` binary available during the operator e2e (see https://github.com/openshift/release/pull/8368)