### PR TITLE
Bug 1832143: bump(*): vendor update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
 	github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
-	github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833
+	github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1Gd
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca h1:YNtyJnE53QuEUSjl7L1AARocI021o7cU2bvh4prDtiE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca/go.mod h1:unEnEWccGeVxaXSRsWTjRsNxMqYXmuQjzjcPFQ91H9M=
-github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833 h1:glEuGTvwkQJXfCzVfosZ3oq73L8QltO6Xyxo1oTf5Ig=
-github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
+github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c h1:mo1sYI/JNNgXhoaSzGQdQceyWDC3Q1VYkFMmu1TQ6nc=
+github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
+++ b/vendor/github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers/status.go
@@ -92,6 +92,10 @@ func GetStatusDiff(oldStatus configv1.ClusterOperatorStatus, newStatus configv1.
 		messages = append(messages, fmt.Sprintf("status.extension changed from %q to %q", oldStatus.Extension, newStatus.Extension))
 	}
 
+	if !equality.Semantic.DeepEqual(oldStatus.Versions, newStatus.Versions) {
+		messages = append(messages, fmt.Sprintf("status.versions changed from %q to %q", oldStatus.Versions, newStatus.Versions))
+	}
+
 	if len(messages) == 0 {
 		// ignore errors
 		originalJSON := &bytes.Buffer{}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider/observe_cloudprovider.go
@@ -139,6 +139,7 @@ func getPlatformName(platformType configv1.PlatformType, recorder events.Recorde
 	case configv1.OpenStackPlatformType:
 		cloudProvider = "openstack"
 	case configv1.NonePlatformType:
+	case configv1.OvirtPlatformType:
 	default:
 		// the new doc on the infrastructure fields requires that we treat an unrecognized thing the same bare metal.
 		// TODO find a way to indicate to the user that we didn't honor their choice

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/config/informers/externalversions/internalinterfa
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
-# github.com/openshift/library-go v0.0.0-20200427130628-9b02543ac833
+# github.com/openshift/library-go v0.0.0-20200506083334-710b0bd21d0c
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
* openshift/library-go@f2030b8d: Fix ClusterOperator event when version changes
* openshift/library-go@65abf9cb: Bug 1832143: Prevent noisy events for ovirt cloud provider