### PR TITLE
Set flags instead of different config format

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -1,24 +1,8 @@
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
-aggregatorConfig:
-  proxyClientInfo:
-    certFile: /etc/kubernetes/secrets/apiserver-proxy.crt
-    keyFile: /etc/kubernetes/secrets/apiserver-proxy.key
-authConfig:
-  requestHeader:
-    clientCA: /etc/kubernetes/secrets/aggregator-signer.crt
-kubeletClientInfo:
-  ca: /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
-  certFile: /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.crt
-  keyFile: /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.key
-serviceAccountPublicKeyFiles:
-- /etc/kubernetes/secrets/service-account.pub
 servingInfo:
   bindAddress: "{{.BindAddress}}"
   bindNetwork: {{.BindNetwork}}
-  certFile: /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
-  clientCA: /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
-  keyFile: /etc/kubernetes/secrets/kube-apiserver-service-network-server.key
   namedCertificates:
     - names:
       - "kubernetes"
@@ -38,9 +22,6 @@ servingInfo:
     - certFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.crt
       keyFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.key
 storageConfig:
-  ca: /etc/kubernetes/secrets/{{.EtcdServingCA}}
-  certFile: /etc/kubernetes/secrets/etcd-client.crt
-  keyFile: /etc/kubernetes/secrets/etcd-client.key
   urls: {{range .EtcdServerURLs}}
   - {{.}}{{end}}
 {{if .ServiceCIDR | len | ne 0}}
@@ -57,6 +38,14 @@ admission:
         - {{.}}{{end}}
     {{end}}
 apiServerArguments:
+  client-ca-file:
+    - /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
+  etcd-cafile:
+    - /etc/kubernetes/secrets/{{.EtcdServingCA}}
+  etcd-certfile:
+    - /etc/kubernetes/secrets/etcd-client.crt
+  etcd-keyfile:
+    - /etc/kubernetes/secrets/etcd-client.key
   feature-gates:
     - "APIPriorityAndFairness=true"
     - "RotateKubeletServerCertificate=true"
@@ -65,3 +54,21 @@ apiServerArguments:
     - "ServiceNodeExclusion=true"
     - "SCTPSupport=true"
     - "LegacyNodeRoleBehavior=false"
+  kubelet-certificate-authority:
+    - /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
+  kubelet-client-certificate:
+    - /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.crt
+  kubelet-client-key:
+    - /etc/kubernetes/secrets/kube-apiserver-to-kubelet-client.key
+  proxy-client-cert-file:
+    - /etc/kubernetes/secrets/apiserver-proxy.crt
+  proxy-client-key-file:
+    - /etc/kubernetes/secrets/apiserver-proxy.key
+  requestheader-client-ca-file:
+    - /etc/kubernetes/secrets/aggregator-signer.crt
+  service-account-key-file:
+    - /etc/kubernetes/secrets/service-account.pub
+  tls-cert-file:
+    - /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
+  tls-private-key-file:
+    - /etc/kubernetes/secrets/kube-apiserver-service-network-server.key

--- a/bindata/v4.1.0/config/config-overrides.yaml
+++ b/bindata/v4.1.0/config/config-overrides.yaml
@@ -10,8 +10,11 @@ apiServerArguments:
     - https://kubernetes.default.svc
   service-account-signing-key-file:
     - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
-  service-account-key-file:
-    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
-      # The following path contains the public keys needed to verify bound sa
-      # tokens. This is only supported post-bootstrap.
-    - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+serviceAccountPublicKeyFiles:
+  # this being a directory means we cannot directly use the upstream flags.
+  # TODO make a configobserver that writes the individual values that we need.
+  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  # The following path contains the public keys needed to verify bound sa
+  # tokens. This is only supported post-bootstrap.
+  - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+

--- a/bindata/v4.1.0/config/config-overrides.yaml
+++ b/bindata/v4.1.0/config/config-overrides.yaml
@@ -5,13 +5,13 @@ apiServerArguments:
   # tokens. This is only supported post-bootstrap so these
   # values must not appear in defaultconfig.yaml.
   service-account-issuer:
-  - https://kubernetes.default.svc
+    - https://kubernetes.default.svc
   api-audiences:
-  - https://kubernetes.default.svc
+    - https://kubernetes.default.svc
   service-account-signing-key-file:
-  - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
-serviceAccountPublicKeyFiles:
-  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
-  # The following path contains the public keys needed to verify bound sa
-  # tokens. This is only supported post-bootstrap.
-  - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+    - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
+  service-account-key-file:
+    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+      # The following path contains the public keys needed to verify bound sa
+      # tokens. This is only supported post-bootstrap.
+    - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -9,11 +9,28 @@ admission:
         externalIPNetworkCIDRs: null
         kind: ExternalIPRangerAdmissionConfig
       location: ""
-aggregatorConfig:
-  proxyClientInfo:
-    certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
-    keyFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
 apiServerArguments:
+  allow-privileged:
+    - "true"
+  anonymous-auth:
+    - "true"
+  authorization-mode:
+    - Scope
+    - SystemMasters
+    - RBAC
+    - Node
+  audit-log-format:
+    - json
+  audit-log-maxbackup:
+    - "10"
+  audit-log-maxsize:
+    - "100"
+  audit-log-path:
+    - /var/log/kube-apiserver/audit.log
+  audit-policy-file: # this matches where .auditConfig.policyConfiguration is currently written.  We should update this.
+    - openshift.local.audit/policy.yaml
+  client-ca-file:
+    - /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   enable-admission-plugins:
     - CertificateApproval
     - CertificateSigning
@@ -62,33 +79,86 @@ apiServerArguments:
   # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
   enable-aggregator-routing:
     - "true"
+  enable-logs-handler:
+    - "false"
+  enable-swagger-ui:
+    - "true"
+  endpoint-reconciler-type:
+    - "lease"
+  etcd-cafile:
+    - /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
+  etcd-certfile:
+    - /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
+  etcd-keyfile:
+    - /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
+  etcd-prefix:
+    - kubernetes.io
+  event-ttl:
+    - 3h
   goaway-chance:
     - "0"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+  insecure-port:
+    - "0"
+  kubelet-certificate-authority:
+    - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
+  kubelet-client-certificate:
+    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
+  kubelet-client-key:
+    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+  kubelet-https:
+    - "true"
   kubelet-preferred-address-types:
     - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
+  kubelet-read-only-port:
+    - "0"
+  kubernetes-service-node-port:
+    - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
     - "1000"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
     - "3000"
+  min-request-timeout:
+    - "3600"
+  proxy-client-cert-file:
+    - /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
+  proxy-client-key-file:
+    - /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
+  requestheader-allowed-names:
+    - kube-apiserver-proxy
+    - system:kube-apiserver-proxy
+    - system:openshift-aggregator
+  requestheader-client-ca-file:
+    - /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
+  requestheader-extra-headers-prefix:
+    - X-Remote-Extra-
+  requestheader-group-headers:
+    - X-Remote-Group
+  requestheader-username-headers:
+    - X-Remote-User
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
+  service-account-lookup:
+    - "true"
+  service-account-key-file:
+    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  service-node-port-range:
+    - 30000-32767
   shutdown-delay-duration:
     - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   storage-backend:
     - etcd3
   storage-media-type:
     - application/vnd.kubernetes.protobuf
+  tls-cert-file:
+    - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
+  tls-private-key-file:
+    - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
 auditConfig:
-  auditFilePath: "/var/log/kube-apiserver/audit.log"
-  enabled: true
-  logFormat: "json"
-  maximumFileSizeMegabytes: 100
-  maximumRetainedFiles: 10
   policyConfiguration:
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
@@ -122,46 +192,13 @@ auditConfig:
       - "RequestReceived"
 authConfig:
   oauthMetadataFile: ""
-  requestHeader:
-    clientCA: /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
-    clientCommonNames:
-    - kube-apiserver-proxy
-    - system:kube-apiserver-proxy
-    - system:openshift-aggregator
-    extraHeaderPrefixes:
-    - X-Remote-Extra-
-    groupHeaders:
-    - X-Remote-Group
-    usernameHeaders:
-    - X-Remote-User
-  webhookTokenAuthenticators: null
 consolePublicURL: ""
-kubeletClientInfo:
-  ca: /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
-  port: 10250
 projectConfig:
   defaultNodeSelector: ""
-servicesNodePortRange: 30000-32767
-servicesSubnet: 10.3.0.0/16 # ServiceCIDR
+servicesSubnet: 10.3.0.0/16 # ServiceCIDR # set by observe_network.go
 servingInfo:
-  bindAddress: 0.0.0.0:6443
-  bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
-  clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
-  maxRequestsInFlight: 1200
-  namedCertificates: null
-  requestTimeoutSeconds: 3600
-serviceAccountPublicKeyFiles:
-  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  bindAddress: 0.0.0.0:6443 # set by observe_network.go
+  bindNetwork: tcp4 # set by observe_network.go
+  namedCertificates: null # set by observe_apiserver.go
 storageConfig:
-  ca: /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
   urls: null
-userAgentMatchingConfig:
-  defaultRejectionMessage: ""
-  deniedClients: null
-  requiredClients: null

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -59,30 +59,30 @@ apiServerArguments:
     - security.openshift.io/SCCExecRestrictions
     - security.openshift.io/SecurityContextConstraint
     - security.openshift.io/ValidateSecurityContextConstraints
-  storage-backend:
-  - etcd3
-  storage-media-type:
-  - application/vnd.kubernetes.protobuf
   # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
   enable-aggregator-routing:
-  - "true"
-  shutdown-delay-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+    - "true"
+  goaway-chance:
+    - "0"
   http2-max-streams-per-connection:
-  - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+    - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-preferred-address-types:
-  - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
-  # value needed to be bumped for scale tests.  The kube-apiserver did ok here
-  max-requests-inflight:
-  - "3000"
+    - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-  - "1000"
+    - "1000"
+  # value needed to be bumped for scale tests.  The kube-apiserver did ok here
+  max-requests-inflight:
+    - "3000"
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
-  goaway-chance:
-    - "0"
+  shutdown-delay-duration:
+    - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  storage-backend:
+    - etcd3
+  storage-media-type:
+    - application/vnd.kubernetes.protobuf
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -159,6 +159,7 @@ apiServerArguments:
   tls-private-key-file:
     - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
 auditConfig:
+  enabled: true
   policyConfiguration:
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy

--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -144,8 +144,6 @@ apiServerArguments:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
   service-account-lookup:
     - "true"
-  service-account-key-file:
-    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
   service-node-port-range:
     - 30000-32767
   shutdown-delay-duration:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -75,16 +75,16 @@ apiServerArguments:
   # tokens. This is only supported post-bootstrap so these
   # values must not appear in defaultconfig.yaml.
   service-account-issuer:
-  - https://kubernetes.default.svc
+    - https://kubernetes.default.svc
   api-audiences:
-  - https://kubernetes.default.svc
+    - https://kubernetes.default.svc
   service-account-signing-key-file:
-  - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
-serviceAccountPublicKeyFiles:
-  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
-  # The following path contains the public keys needed to verify bound sa
-  # tokens. This is only supported post-bootstrap.
-  - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+    - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
+  service-account-key-file:
+    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+      # The following path contains the public keys needed to verify bound sa
+      # tokens. This is only supported post-bootstrap.
+    - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
 `)
 
 func v410ConfigConfigOverridesYamlBytes() ([]byte, error) {
@@ -113,11 +113,28 @@ admission:
         externalIPNetworkCIDRs: null
         kind: ExternalIPRangerAdmissionConfig
       location: ""
-aggregatorConfig:
-  proxyClientInfo:
-    certFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
-    keyFile: /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
 apiServerArguments:
+  allow-privileged:
+    - "true"
+  anonymous-auth:
+    - "true"
+  authorization-mode:
+    - Scope
+    - SystemMasters
+    - RBAC
+    - Node
+  audit-log-format:
+    - json
+  audit-log-maxbackup:
+    - "10"
+  audit-log-maxsize:
+    - "100"
+  audit-log-path:
+    - /var/log/kube-apiserver/audit.log
+  audit-policy-file: # this matches where .auditConfig.policyConfiguration is currently written.  We should update this.
+    - openshift.local.audit/policy.yaml
+  client-ca-file:
+    - /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
   enable-admission-plugins:
     - CertificateApproval
     - CertificateSigning
@@ -166,33 +183,86 @@ apiServerArguments:
   # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
   enable-aggregator-routing:
     - "true"
+  enable-logs-handler:
+    - "false"
+  enable-swagger-ui:
+    - "true"
+  endpoint-reconciler-type:
+    - "lease"
+  etcd-cafile:
+    - /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
+  etcd-certfile:
+    - /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
+  etcd-keyfile:
+    - /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
+  etcd-prefix:
+    - kubernetes.io
+  event-ttl:
+    - 3h
   goaway-chance:
     - "0"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+  insecure-port:
+    - "0"
+  kubelet-certificate-authority:
+    - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
+  kubelet-client-certificate:
+    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
+  kubelet-client-key:
+    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+  kubelet-https:
+    - "true"
   kubelet-preferred-address-types:
     - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
+  kubelet-read-only-port:
+    - "0"
+  kubernetes-service-node-port:
+    - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
     - "1000"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
     - "3000"
+  min-request-timeout:
+    - "3600"
+  proxy-client-cert-file:
+    - /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.crt
+  proxy-client-key-file:
+    - /etc/kubernetes/static-pod-certs/secrets/aggregator-client/tls.key
+  requestheader-allowed-names:
+    - kube-apiserver-proxy
+    - system:kube-apiserver-proxy
+    - system:openshift-aggregator
+  requestheader-client-ca-file:
+    - /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
+  requestheader-extra-headers-prefix:
+    - X-Remote-Extra-
+  requestheader-group-headers:
+    - X-Remote-Group
+  requestheader-username-headers:
+    - X-Remote-User
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
+  service-account-lookup:
+    - "true"
+  service-account-key-file:
+    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  service-node-port-range:
+    - 30000-32767
   shutdown-delay-duration:
     - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   storage-backend:
     - etcd3
   storage-media-type:
     - application/vnd.kubernetes.protobuf
+  tls-cert-file:
+    - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
+  tls-private-key-file:
+    - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
 auditConfig:
-  auditFilePath: "/var/log/kube-apiserver/audit.log"
-  enabled: true
-  logFormat: "json"
-  maximumFileSizeMegabytes: 100
-  maximumRetainedFiles: 10
   policyConfiguration:
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
@@ -226,49 +296,16 @@ auditConfig:
       - "RequestReceived"
 authConfig:
   oauthMetadataFile: ""
-  requestHeader:
-    clientCA: /etc/kubernetes/static-pod-certs/configmaps/aggregator-client-ca/ca-bundle.crt
-    clientCommonNames:
-    - kube-apiserver-proxy
-    - system:kube-apiserver-proxy
-    - system:openshift-aggregator
-    extraHeaderPrefixes:
-    - X-Remote-Extra-
-    groupHeaders:
-    - X-Remote-Group
-    usernameHeaders:
-    - X-Remote-User
-  webhookTokenAuthenticators: null
 consolePublicURL: ""
-kubeletClientInfo:
-  ca: /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
-  port: 10250
 projectConfig:
   defaultNodeSelector: ""
-servicesNodePortRange: 30000-32767
-servicesSubnet: 10.3.0.0/16 # ServiceCIDR
+servicesSubnet: 10.3.0.0/16 # ServiceCIDR # set by observe_network.go
 servingInfo:
-  bindAddress: 0.0.0.0:6443
-  bindNetwork: tcp4
-  certFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt
-  clientCA: /etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt
-  keyFile: /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
-  maxRequestsInFlight: 1200
-  namedCertificates: null
-  requestTimeoutSeconds: 3600
-serviceAccountPublicKeyFiles:
-  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  bindAddress: 0.0.0.0:6443 # set by observe_network.go
+  bindNetwork: tcp4 # set by observe_network.go
+  namedCertificates: null # set by observe_apiserver.go
 storageConfig:
-  ca: /etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt
-  certFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt
-  keyFile: /etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key
   urls: null
-userAgentMatchingConfig:
-  defaultRejectionMessage: ""
-  deniedClients: null
-  requiredClients: null
 `)
 
 func v410ConfigDefaultconfigYamlBytes() ([]byte, error) {

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -263,6 +263,7 @@ apiServerArguments:
   tls-private-key-file:
     - /etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key
 auditConfig:
+  enabled: true
   policyConfiguration:
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -163,30 +163,30 @@ apiServerArguments:
     - security.openshift.io/SCCExecRestrictions
     - security.openshift.io/SecurityContextConstraint
     - security.openshift.io/ValidateSecurityContextConstraints
-  storage-backend:
-  - etcd3
-  storage-media-type:
-  - application/vnd.kubernetes.protobuf
   # switch to direct pod IP routing for aggregated apiservers to avoid service IPs as on source of instability
   enable-aggregator-routing:
-  - "true"
-  shutdown-delay-duration:
-  - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+    - "true"
+  goaway-chance:
+    - "0"
   http2-max-streams-per-connection:
-  - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+    - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-preferred-address-types:
-  - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
-  # value needed to be bumped for scale tests.  The kube-apiserver did ok here
-  max-requests-inflight:
-  - "3000"
+    - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-  - "1000"
+    - "1000"
+  # value needed to be bumped for scale tests.  The kube-apiserver did ok here
+  max-requests-inflight:
+    - "3000"
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
-  goaway-chance:
-    - "0"
+  shutdown-delay-duration:
+    - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
+  storage-backend:
+    - etcd3
+  storage-media-type:
+    - application/vnd.kubernetes.protobuf
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -80,11 +80,14 @@ apiServerArguments:
     - https://kubernetes.default.svc
   service-account-signing-key-file:
     - /etc/kubernetes/static-pod-certs/secrets/bound-service-account-signing-key/service-account.key
-  service-account-key-file:
-    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
-      # The following path contains the public keys needed to verify bound sa
-      # tokens. This is only supported post-bootstrap.
-    - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+serviceAccountPublicKeyFiles:
+  # this being a directory means we cannot directly use the upstream flags.
+  # TODO make a configobserver that writes the individual values that we need.
+  - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
+  # The following path contains the public keys needed to verify bound sa
+  # tokens. This is only supported post-bootstrap.
+  - /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs
+
 `)
 
 func v410ConfigConfigOverridesYamlBytes() ([]byte, error) {
@@ -248,8 +251,6 @@ apiServerArguments:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
   service-account-lookup:
     - "true"
-  service-account-key-file:
-    - /etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs
   service-node-port-range:
     - 30000-32767
   shutdown-delay-duration:


### PR DESCRIPTION
Switch all the "easy" settings to flags instead of config.  There is a little bit more that isn't too hard, but requires config observation changes.  Let's clear the early stuff first.  This makes us more kube-like and will help answer questions about "how do we do benchmark X" and it helps focus our patches.

/assign @sttts