### PR TITLE
bug 1837451: prevent goaway chance in kubeapiserver to avoid tripping up golang clients

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -36,6 +36,8 @@ apiServerArguments:
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
+  goaway-chance:
+    - "0"
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -140,6 +140,8 @@ apiServerArguments:
   # need to enable alpha APIs for the priority and fairness feature
   runtime-config:
     - flowcontrol.apiserver.k8s.io/v1alpha1=true
+  goaway-chance:
+    - "0"
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
If I understood https://github.com/golang/go/issues/39086 right, clients don't recover cleanly.  This *may* improve e2e test behavior if the requests were failing because we would not retry.

/assign @sttts 