### PR TITLE
Bug 1806980: remove override for fast cert rotation

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -122,10 +122,6 @@ func newCertRotationController(
 		rotationDay = day
 		klog.Warningf("!!! UNSUPPORTED VALUE SET !!!")
 		klog.Warningf("Certificate rotation base set to %q", rotationDay)
-	} else {
-		// for the development cycle, make the rotation 60 times faster (every twelve hours or so).
-		// This must be reverted before we ship
-		rotationDay = rotationDay / 60
 	}
 
 	certRotator := certrotation.NewCertRotationController(


### PR DESCRIPTION
we need to do this and then revert it for 4.6.  Ideally, we only have this for 4.5