### PR TITLE
Bug 1838122: add admission webhooks to must-gather for kas-o

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
@@ -35,3 +35,7 @@ status:
     - group: ""
       name: openshift-kube-apiserver
       resource: namespaces
+    - group: admissionregistration.k8s.io
+      resource: mutatingwebhookconfigurations
+    - group: admissionregistration.k8s.io
+      resource: validatingwebhookconfigurations

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -156,7 +156,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			{Resource: "namespaces", Name: operatorclient.GlobalMachineSpecifiedConfigNamespace},
 			{Resource: "namespaces", Name: operatorclient.OperatorNamespace},
 			{Resource: "namespaces", Name: operatorclient.TargetNamespace},
+			{Group: "admissionregistration.k8s.io", Resource: "mutatingwebhookconfigurations"},
+			{Group: "admissionregistration.k8s.io", Resource: "validatingwebhookconfigurations"},
 		},
+
 		configClient.ConfigV1(),
 		configInformers.Config().V1().ClusterOperators(),
 		operatorClient,


### PR DESCRIPTION
We need this information to understand certain bootstrapping loops caused by overly broad admission webhook configuration that prevent restarts.