### PR TITLE
bug 1837881: remove humorous help from dev focused command

### DIFF
--- a/pkg/cmd/resourcegraph/resourcegraph.go
+++ b/pkg/cmd/resourcegraph/resourcegraph.go
@@ -14,7 +14,7 @@ import (
 func NewResourceChainCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resource-graph",
-		Short: "Where do resources come from? Ask your mother.",
+		Short: "Provides an often out-dated snapshot of where resources come from.",
 		Run: func(cmd *cobra.Command, args []string) {
 			resources := Resources()
 			g := resources.NewGraph()


### PR DESCRIPTION
Eventually we should probably find a way to auto-update these.  A someday project