### PR TITLE
Bug 1840597: Revert "remove override for fast cert rotation" for 4.6

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -122,6 +122,10 @@ func newCertRotationController(
 		rotationDay = day
 		klog.Warningf("!!! UNSUPPORTED VALUE SET !!!")
 		klog.Warningf("Certificate rotation base set to %q", rotationDay)
+	} else {
+		// for the development cycle, make the rotation 60 times faster (every twelve hours or so).
+		// This must be reverted before we ship
+		rotationDay = rotationDay / 60
 	}
 
 	certRotator := certrotation.NewCertRotationController(


### PR DESCRIPTION
Reverting https://github.com/openshift/cluster-kube-apiserver-operator/pull/863.