### PR TITLE
Bug 1843752: static pod: don't wait for 6080 in apiserver container

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -42,14 +42,14 @@ spec:
             echo "Copying system trust bundle"
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          echo -n "Waiting for port :6443 and :6080 to be released."
+          echo -n "Waiting for port :6443 to be released."
           tries=0
-          while [ -n "$(ss -Htan '( sport = 6443 or sport = 6080 )')" ]; do
+          while [ -n "$(ss -Htan '( sport = 6443 )')" ]; do
             echo -n "."
             sleep 1
             (( tries += 1 ))
             if [[ "${tries}" -gt 105 ]]; then
-              echo "timed out waiting for port :6443 and :6080 to be released"
+              echo "timed out waiting for port :6443 to be released"
               exit 1
             fi
           done

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -479,14 +479,14 @@ spec:
             echo "Copying system trust bundle"
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          echo -n "Waiting for port :6443 and :6080 to be released."
+          echo -n "Waiting for port :6443 to be released."
           tries=0
-          while [ -n "$(ss -Htan '( sport = 6443 or sport = 6080 )')" ]; do
+          while [ -n "$(ss -Htan '( sport = 6443 )')" ]; do
             echo -n "."
             sleep 1
             (( tries += 1 ))
             if [[ "${tries}" -gt 105 ]]; then
-              echo "timed out waiting for port :6443 and :6080 to be released"
+              echo "timed out waiting for port :6443 to be released"
               exit 1
             fi
           done


### PR DESCRIPTION
6080 is occupied by readyz container which does not free the port when the main container restarts (obviously).

Contrary, we probably don't have to wait for 6080 to free up because the readyz container terminate immediately on SIGTERM. Hence, the port has like 70s+ to become available which is more than enough, plus the init container already waits for the port.