### PR TITLE
Log non-graceful termination to /var/log/kube-apiserver/termination.log and stdout

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -54,7 +54,7 @@ spec:
             fi
           done
           echo
-          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP}
+          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY}
     resources:
       requests:
         memory: 1Gi

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -256,24 +256,24 @@ func managePod(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, o
 	if argsCount := len(containerArgsWithLoglevel); argsCount > 1 {
 		return nil, false, fmt.Errorf("expected only one container argument, got %d", argsCount)
 	}
-	if !strings.Contains(containerArgsWithLoglevel[0], "exec hyperkube kube-apiserver") {
-		return nil, false, fmt.Errorf("exec hyperkube kube-apiserver not found in first argument %q", containerArgsWithLoglevel[0])
+	if !strings.Contains(containerArgsWithLoglevel[0], "hyperkube kube-apiserver") {
+		return nil, false, fmt.Errorf("hyperkube kube-apiserver not found in first argument %q", containerArgsWithLoglevel[0])
 	}
 
-	containerArgsWithLoglevel[0] = strings.TrimSpace(containerArgsWithLoglevel[0])
+	var verbosity string
 	switch operatorSpec.LogLevel {
 	case operatorv1.Normal:
-		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 2)
+		verbosity = fmt.Sprintf(" -v=%d", 2)
 	case operatorv1.Debug:
-		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 4)
+		verbosity = fmt.Sprintf(" -v=%d", 4)
 	case operatorv1.Trace:
-		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 6)
+		verbosity = fmt.Sprintf(" -v=%d", 6)
 	case operatorv1.TraceAll:
-		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 8)
+		verbosity = fmt.Sprintf(" -v=%d", 8)
 	default:
-		containerArgsWithLoglevel[0] += fmt.Sprintf(" -v=%d", 2)
+		verbosity = fmt.Sprintf(" -v=%d", 2)
 	}
-	required.Spec.Containers[0].Args = containerArgsWithLoglevel
+	required.Spec.Containers[0].Args[0] = strings.ReplaceAll(containerArgsWithLoglevel[0], "${VERBOSITY}", verbosity)
 
 	var observedConfig map[string]interface{}
 	if err := yaml.Unmarshal(operatorSpec.ObservedConfig.Raw, &observedConfig); err != nil {

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -491,7 +491,7 @@ spec:
             fi
           done
           echo
-          exec hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP}
+          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY}
     resources:
       requests:
         memory: 1Gi


### PR DESCRIPTION
This 
- adds a /var/log/kube-apiserver/termination.log file to masters (sitting next to the audit logs we already have). It lists non-graceful terminations for easier CI and customer cluster analysis.
- lets the watch-termination binary create `NonGracefulTermination` events in the openshift-kube-apiserver namespace on next launch.

Container logs alone are not enough because logging during termination is broken, and we lose logs from old pods. So we have to persist the data somewhere on disk.

Etcd is also no option as etcd struggles with the same termination issues and is not reliable.

Depends on https://github.com/openshift/origin/pull/25192.