### PR TITLE
auth-config-observation: fix unstructured issuer slice type

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -113,7 +113,7 @@ func unstructuredConfigForIssuer(issuer string) map[string]interface{} {
 	}
 	return map[string]interface{}{
 		"apiServerArguments": map[string]interface{}{
-			"service-account-issuer": []string{
+			"service-account-issuer": []interface{}{
 				issuer,
 			},
 		},


### PR DESCRIPTION
Fix flipping like:

```
- "service-account-issuer": []interface{}{string("https://ci-op-dgz95p2d-067ff-pxnzv-oidc.s3.amazonaws.com")},
+ "service-account-issuer": []string{"https://ci-op-dgz95p2d-067ff-pxnzv-oidc.s3.amazonaws.com"}
```