### PR TITLE
audit when `/healthz` is called from anything else than kubelet

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -61,13 +61,16 @@ auditConfig:
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens", "oauthauthorizetokens"]
-    # Don't log authenticated requests to certain non-resource URL paths.
+    # Don't log requests to /healthz from kubelets
     - level: None
-      userGroups: ["system:authenticated", "system:unauthenticated"]
+      userGroups: ["system:nodes"]
+      nonResourceURLs:
+        - "/healthz"
+    # Don't log requests to certain non-resource URL paths.
+    - level: None
       nonResourceURLs:
       - "/api*" # Wildcard matching.
       - "/version"
-      - "/healthz"
       - "/readyz"
     # A catch-all rule to log all other requests at the Metadata level.
     - level: Metadata

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -165,13 +165,16 @@ auditConfig:
       resources:
       - group: "oauth.openshift.io"
         resources: ["oauthaccesstokens", "oauthauthorizetokens"]
-    # Don't log authenticated requests to certain non-resource URL paths.
+    # Don't log requests to /healthz from kubelets
     - level: None
-      userGroups: ["system:authenticated", "system:unauthenticated"]
+      userGroups: ["system:nodes"]
+      nonResourceURLs:
+        - "/healthz"
+    # Don't log requests to certain non-resource URL paths.
+    - level: None
       nonResourceURLs:
       - "/api*" # Wildcard matching.
       - "/version"
-      - "/healthz"
       - "/readyz"
     # A catch-all rule to log all other requests at the Metadata level.
     - level: Metadata


### PR DESCRIPTION
this PR allow us to see what else is using `/healhtz` endpoint in the system. We think that only kubelet should actually use it. 

Hopeful it will help us to prevent issues like  https://bugzilla.redhat.com/show_bug.cgi?id=1844387