### PR TITLE
Wire event watcher for LateConnections events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20200609191024-dca637550e8c
 	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73
-	github.com/openshift/library-go v0.0.0-20200615120640-a506fa41d3fb
+	github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73 h1:JePLt9EpNLF
 github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73/go.mod h1:+66gk3dEqw9e+WoiXjJFzWlS1KGhj9ZRHi/RI/YG/ZM=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca h1:YNtyJnE53QuEUSjl7L1AARocI021o7cU2bvh4prDtiE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca/go.mod h1:unEnEWccGeVxaXSRsWTjRsNxMqYXmuQjzjcPFQ91H9M=
-github.com/openshift/library-go v0.0.0-20200615120640-a506fa41d3fb h1:Y9TC71a5/luZNV/mXu9+opX3w+aYogZpKPQlxUgra4o=
-github.com/openshift/library-go v0.0.0-20200615120640-a506fa41d3fb/go.mod h1:gckhmPaUyPXT9HFUIeA8YgUzn3OzM5PhS2azW+Y8VmU=
+github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78 h1:TiftgJc3FYZwvW05TpRCZoHNPvIzg7Vz5hunqdFw9sI=
+github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78/go.mod h1:gckhmPaUyPXT9HFUIeA8YgUzn3OzM5PhS2azW+Y8VmU=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/terminationobserver/late_connections.go
+++ b/pkg/operator/terminationobserver/late_connections.go
@@ -1,0 +1,28 @@
+package terminationobserver
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics"
+)
+
+// ProcessLateConnectionEvents increment openshift_kube_apiserver_lateconnections_count counter for apiserver reported in LateConnections event.
+// The apiserver received connections very late in the graceful termination process, possibly a sign for a broken load balancer setup.
+func ProcessLateConnectionEvents(event *v1.Event) error {
+	// best-effort to guess the source (apiserver) from event
+	name := event.InvolvedObject.Name
+	if len(name) == 0 {
+		name = event.Source.Component
+	}
+	if len(name) == 0 {
+		name = event.Source.Host
+	}
+	apiServerLateConnectionsCounter.WithLabelValues(event.InvolvedObject.Name).Inc()
+	return nil
+}
+
+var (
+	apiServerLateConnectionsCounter = metrics.NewCounterVec(&metrics.CounterOpts{
+		Name: "openshift_kube_apiserver_lateconnections_count",
+		Help: "Report observed late connection count for each API server instance over time",
+	}, []string{"name"})
+)

--- a/pkg/operator/terminationobserver/termination_observer.go
+++ b/pkg/operator/terminationobserver/termination_observer.go
@@ -70,6 +70,7 @@ func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(apiServerTerminationEventGauge)
 		legacyregistry.MustRegister(apiServerTerminationCounter)
+		legacyregistry.MustRegister(apiServerLateConnectionsCounter)
 	})
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/eventwatch/controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/eventwatch/controller.go
@@ -1,0 +1,152 @@
+package eventwatch
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	// eventAckAnnotationName is an annotation we place on event that was processed by this controller.
+	// This is used to not process same event multiple times.
+	eventAckAnnotationName = "eventwatch.openshift.io/acknowledged"
+)
+
+// Controller observes the events in given informer namespaces and match them with configured event handlers.
+// If the event reason and namespace match the configured, then the process() function is called in handler on that event.
+// The event is then acknowledged via annotation update, so each interesting event is only processed once.
+// The process() function will received the observed event and can update Prometheus counter or manage operator conditions.
+type Controller struct {
+	events      []eventHandler
+	eventClient corev1typed.EventsGetter
+}
+
+type eventHandler struct {
+	reason    string
+	namespace string
+	process   func(event *corev1.Event) error
+}
+
+type Builder struct {
+	eventConfig []eventHandler
+}
+
+// New returns a new event watch controller builder that allow to specify event handlers.
+func New() *Builder {
+	return &Builder{}
+}
+
+// WithEventHandler add handler for event matching the namespace and the reason.
+// This can be called multiple times.
+func (b *Builder) WithEventHandler(namespace, reason string, processEvent func(event *corev1.Event) error) *Builder {
+	b.eventConfig = append(b.eventConfig, eventHandler{
+		reason:    reason,
+		namespace: namespace,
+		process:   processEvent,
+	})
+	return b
+}
+
+// ToController returns a factory controller that can be run.
+// The kubeInformersForTargetNamespace must have informer for namespaces which matching the registered event handlers.
+// The event client is used to update/acknowledge events.
+func (b *Builder) ToController(kubeInformersForTargetNamespace informers.SharedInformerFactory, eventClient corev1typed.EventsGetter, recorder events.Recorder) factory.Controller {
+	c := &Controller{
+		events:      b.eventConfig,
+		eventClient: eventClient,
+	}
+	return factory.New().
+		WithSync(c.sync).
+		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
+			event, ok := obj.(*corev1.Event)
+			if !ok {
+				return ""
+			}
+			return eventKeyFunc(event.Namespace, event.Name, event.Reason)
+		}, kubeInformersForTargetNamespace.Core().V1().Events().Informer()).
+		ToController("EventWatchController", recorder)
+}
+
+func eventKeyFunc(namespace, name, reason string) string {
+	if len(namespace) == 0 || len(name) == 0 || len(reason) == 0 {
+		return ""
+	}
+	return strings.Join([]string{namespace, name, reason}, "/")
+}
+
+func decomposeEventKey(key string) (string, string, string, bool) {
+	parts := strings.Split(key, "/")
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}
+
+func (c *Controller) getEventHandler(eventKey string) *eventHandler {
+	namespace, _, reason, ok := decomposeEventKey(eventKey)
+	if !ok {
+		return nil
+	}
+	for i := range c.events {
+		if c.events[i].namespace == namespace && c.events[i].reason == reason {
+			return &c.events[i]
+		}
+	}
+	return nil
+}
+
+func isAcknowledgedEvent(e *corev1.Event) bool {
+	if e.Annotations == nil {
+		return false
+	}
+	_, ok := e.Annotations[eventAckAnnotationName]
+	return ok
+}
+
+func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	eventHandler := c.getEventHandler(syncCtx.QueueKey())
+	if eventHandler == nil {
+		return nil
+	}
+
+	namespace, name, _, ok := decomposeEventKey(syncCtx.QueueKey())
+	if !ok {
+		klog.Errorf("Unexpected queue key %q", syncCtx.QueueKey())
+		return nil
+	}
+
+	event, err := c.eventClient.Events(namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		klog.Errorf("Event not found %s/%s: %v", namespace, name, err)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if isAcknowledgedEvent(event) {
+		return nil
+	}
+
+	// acknowledge the event, so we won't process it multiple times
+	seenEvent := event.DeepCopy()
+	if seenEvent.Annotations == nil {
+		seenEvent.Annotations = map[string]string{}
+	}
+	seenEvent.Annotations[eventAckAnnotationName] = "true"
+	if _, err := c.eventClient.Events(namespace).Update(ctx, seenEvent, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return eventHandler.process(event)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -154,6 +155,16 @@ func ApplyDirectly(clients *ClientHolder, recorder events.Recorder, manifests As
 				result.Error = fmt.Errorf("missing apiExtensionsClient")
 			}
 			result.Result, result.Changed, result.Error = ApplyCustomResourceDefinitionV1(clients.apiExtensionsClient.ApiextensionsV1(), recorder, t)
+		case *storagev1.StorageClass:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			}
+			result.Result, result.Changed, result.Error = ApplyStorageClass(clients.kubeClient.StorageV1(), recorder, t)
+		case *storagev1.CSIDriver:
+			if clients.kubeClient == nil {
+				result.Error = fmt.Errorf("missing kubeClient")
+			}
+			result.Result, result.Changed, result.Error = ApplyCSIDriver(clients.kubeClient.StorageV1(), recorder, t)
 		default:
 			result.Error = fmt.Errorf("unhandled type %T", requiredObj)
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -85,3 +85,33 @@ func ApplyCSIDriverV1Beta1(client storageclientv1beta1.CSIDriversGetter, recorde
 	reportUpdateEvent(recorder, required, err)
 	return actual, true, err
 }
+
+// ApplyCSIDriver merges objectmeta, does not worry about anything else
+func ApplyCSIDriver(client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+	existing, err := client.CSIDrivers().Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.CSIDrivers().Create(context.TODO(), required, metav1.CreateOptions{})
+		reportCreateEvent(recorder, required, err)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !*modified {
+		return existingCopy, false, nil
+	}
+
+	if klog.V(4) {
+		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
+	}
+
+	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
+	actual, err := client.CSIDrivers().Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	reportUpdateEvent(recorder, required, err)
+	return actual, true, err
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -141,6 +142,10 @@ func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1h
 			ret = ret.AddInformer(informer.Rbac().V1().Roles().Informer())
 		case *rbacv1.RoleBinding:
 			ret = ret.AddInformer(informer.Rbac().V1().RoleBindings().Informer())
+		case *storagev1.StorageClass:
+			ret = ret.AddInformer(informer.Storage().V1().StorageClasses().Informer())
+		case *storagev1.CSIDriver:
+			ret = ret.AddInformer(informer.Storage().V1().CSIDrivers().Informer())
 		default:
 			// if there's a missing case, the caller can add an informer or count on a time based trigger.
 			// if the controller doesn't handle it, then there will be failure from the underlying apply.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200615120640-a506fa41d3fb
+# github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client
@@ -257,6 +257,7 @@ github.com/openshift/library-go/pkg/operator/encryption/secrets
 github.com/openshift/library-go/pkg/operator/encryption/state
 github.com/openshift/library-go/pkg/operator/encryption/statemachine
 github.com/openshift/library-go/pkg/operator/events
+github.com/openshift/library-go/pkg/operator/eventwatch
 github.com/openshift/library-go/pkg/operator/genericoperatorclient
 github.com/openshift/library-go/pkg/operator/loglevel
 github.com/openshift/library-go/pkg/operator/management


### PR DESCRIPTION
This wire event watcher for `LateConnections` event that increase the `openshift_kube_apiserver_lateconnections_count` prometheus metric.

A follow up would be to add Prometheus Alert.

Blocked on https://github.com/openshift/origin/pull/25126
/hold