### PR TITLE
add metric reporting to check-endpoints

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -171,6 +171,8 @@ spec:
     args:
       - --kubeconfig
       - /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
+      - --listen
+      - 0.0.0.0:17697
       - --namespace
       - $(POD_NAMESPACE)
       - --v
@@ -187,6 +189,25 @@ spec:
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
+    ports:
+      - name: check-endpoints
+        hostPort: 17697
+        containerPort: 17697
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 17697
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 17697
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
     resources:
       requests:
         memory: 50Mi

--- a/pkg/cmd/checkendpoints/cmd.go
+++ b/pkg/cmd/checkendpoints/cmd.go
@@ -3,6 +3,7 @@ package checkendpoints
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	operatorcontrolplaneclient "github.com/openshift/client-go/operatorcontrolplane/clientset/versioned"
@@ -30,12 +31,12 @@ func NewCheckEndpointsCommand() *cobra.Command {
 			kubeInformers.Core().V1().Secrets(),
 			cctx.EventRecorder,
 		)
+		controller.RegisterMetrics(strings.Replace(namespace, "-", "_", -1) + "_")
 		operatorcontrolplaneInformers.Start(ctx.Done())
 		check.Run(ctx, 1)
 		<-ctx.Done()
 		return nil
 	})
-	config.DisableServing = true
 	config.DisableLeaderElection = true
 	cmd := config.NewCommandWithContext(context.Background())
 	cmd.Use = "check-endpoints"

--- a/pkg/cmd/checkendpoints/controller/metrics.go
+++ b/pkg/cmd/checkendpoints/controller/metrics.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"sync"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/checkendpoints/trace"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	registerMetrics sync.Once
+
+	endpointCheckCounter   *metrics.CounterVec
+	tcpConnectLatencyGauge *metrics.GaugeVec
+	dnsResolveLatencyGauge *metrics.GaugeVec
+)
+
+func RegisterMetrics(prefix string) {
+	registerMetrics.Do(func() {
+		endpointCheckCounter = metrics.NewCounterVec(&metrics.CounterOpts{
+			Name: prefix + "endpoint_check_count",
+			Help: "Report status of endpoint checks for each pod over time.",
+		}, []string{"endpoint", "tcpConnect", "dnsResolve"})
+
+		tcpConnectLatencyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+			Name: prefix + "endpoint_check_tcp_connect_latency_gauge",
+			Help: "Report latency of TCP connect to endpoint for each pod over time.",
+		}, []string{"endpoint"})
+
+		dnsResolveLatencyGauge = metrics.NewGaugeVec(&metrics.GaugeOpts{
+			Name: prefix + "endpoint_check_dns_resolve_latency_gauge",
+			Help: "Report latency of DNS resolve of endpoint for each pod over time.",
+		}, []string{"endpoint"})
+		legacyregistry.MustRegister(endpointCheckCounter)
+		legacyregistry.MustRegister(tcpConnectLatencyGauge)
+		legacyregistry.MustRegister(dnsResolveLatencyGauge)
+	})
+}
+
+func updateMetrics(address string, latency *trace.LatencyInfo, checkErr error) {
+	endpointCheckCounter.With(getCounterMetricLabels(address, latency, checkErr)).Inc()
+	if latency.Connect > 0 {
+		tcpConnectLatencyGauge.WithLabelValues(address).Set(float64(latency.Connect.Nanoseconds()))
+	}
+	if latency.DNS > 0 {
+		dnsResolveLatencyGauge.WithLabelValues(address).Set(float64(latency.DNS.Nanoseconds()))
+	}
+}
+
+func getCounterMetricLabels(address string, latency *trace.LatencyInfo, checkErr error) map[string]string {
+	labels := map[string]string{
+		"endpoint":   address,
+		"dnsResolve": "",
+		"tcpConnect": "",
+	}
+	if isDNSError(checkErr) {
+		labels["dnsResolve"] = "failure"
+		return labels
+	}
+	if latency.DNS != 0 {
+		labels["dnsResolve"] = "success"
+	}
+	if checkErr != nil {
+		labels["tcpConnect"] = "failure"
+		return labels
+	}
+	labels["tcpConnect"] = "success"
+	return labels
+}

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -690,6 +690,8 @@ spec:
     args:
       - --kubeconfig
       - /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
+      - --listen
+      - 0.0.0.0:17697
       - --namespace
       - $(POD_NAMESPACE)
       - --v
@@ -706,6 +708,25 @@ spec:
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir
+    ports:
+      - name: check-endpoints
+        hostPort: 17697
+        containerPort: 17697
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 17697
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 17697
+        path: healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
     resources:
       requests:
         memory: 50Mi


### PR DESCRIPTION
Add the following metrics to the check-endpoint utility:
* _`namespace`_`_endpoint_check_count`
* _`namespace`_`_endpoint_check_tcp_connect_latency_gauge`
* _`namespace`_`_endpoint_check_dns_resolve_latency_gauge`

Removed any dependencies on the kube-apisever pod.

> NOTE: metrics to be scraped by Prometheus in a followup PR
