### PR TITLE
Support configuring ServicesNodePortRange via network config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20200714125145-93040c6967eb
 	github.com/openshift/build-machinery-go v0.0.0-20200713135615-1f43d26dccc7
 	github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73
-	github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78
+	github.com/openshift/library-go v0.0.0-20200630145007-34ebc8778b33
 	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,7 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/openshift/api v0.0.0-20200521101457-60c476765272/go.mod h1:TkhafijfTiRi1Q3120/ZSE4oIWKQ4DGRh3byPywv4Mw=
 github.com/openshift/api v0.0.0-20200605231317-fb2a6ca106ae/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
+github.com/openshift/api v0.0.0-20200619200343-6cafd5cd116b/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
 github.com/openshift/api v0.0.0-20200714125145-93040c6967eb h1:pmoSPRqZ6IPFa+kFA98cqWsnP7TiPdFUYteSuK/DDzU=
 github.com/openshift/api v0.0.0-20200714125145-93040c6967eb/go.mod h1:vWmWTm4y7XR3wkLR+bDDjRbvkBfx2yP7yve6kfb7+Ts=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
@@ -312,8 +313,9 @@ github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73 h1:JePLt9EpNLF
 github.com/openshift/client-go v0.0.0-20200608144219-584632b8fc73/go.mod h1:+66gk3dEqw9e+WoiXjJFzWlS1KGhj9ZRHi/RI/YG/ZM=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca h1:YNtyJnE53QuEUSjl7L1AARocI021o7cU2bvh4prDtiE=
 github.com/openshift/kubernetes-kube-storage-version-migrator v0.0.3-0.20200312103335-32e07ea4f8ca/go.mod h1:unEnEWccGeVxaXSRsWTjRsNxMqYXmuQjzjcPFQ91H9M=
-github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78 h1:TiftgJc3FYZwvW05TpRCZoHNPvIzg7Vz5hunqdFw9sI=
-github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78/go.mod h1:gckhmPaUyPXT9HFUIeA8YgUzn3OzM5PhS2azW+Y8VmU=
+github.com/openshift/library-go v0.0.0-20200630145007-34ebc8778b33 h1:b5RP11252J39kHguNzDtsxuXfkFdfcGiyWk1TAW6W/I=
+github.com/openshift/library-go v0.0.0-20200630145007-34ebc8778b33/go.mod h1:wSK2uzh8YB+2SByXnzgK5i49W5FZLEF5jDAm7AKoiSw=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -136,6 +136,7 @@ func NewConfigObserver(
 			network.ObserveRestrictedCIDRs,
 			network.ObserveServicesSubnet,
 			network.ObserveExternalIPPolicy,
+			network.ObserveServicesNodePortRange,
 			proxy.NewProxyObserveFunc([]string{"targetconfigcontroller", "proxy"}),
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/interfaces.go
@@ -2,11 +2,14 @@ package v1helpers
 
 import (
 	operatorv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
 type OperatorClient interface {
 	Informer() cache.SharedIndexInformer
+	// GetObjectMeta return the operator metadata.
+	GetObjectMeta() (meta *metav1.ObjectMeta, err error)
 	// GetOperatorState returns the operator spec, status and the resource version, potentially from a lister.
 	GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error)
 	// UpdateOperatorSpec updates the spec of the operator, assuming the given resource version.

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -83,6 +83,10 @@ type fakeStaticPodOperatorClient struct {
 
 func (c *fakeStaticPodOperatorClient) Informer() cache.SharedIndexInformer {
 	return &fakeSharedIndexInformer{}
+
+}
+func (c *fakeStaticPodOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("not supported")
 }
 
 func (c *fakeStaticPodOperatorClient) GetStaticPodOperatorState() (*operatorv1.StaticPodOperatorSpec, *operatorv1.StaticPodOperatorStatus, string, error) {
@@ -199,6 +203,10 @@ type fakeOperatorClient struct {
 
 func (c *fakeOperatorClient) Informer() cache.SharedIndexInformer {
 	return &fakeSharedIndexInformer{}
+}
+
+func (c *fakeOperatorClient) GetObjectMeta() (*metav1.ObjectMeta, error) {
+	panic("not supported")
 }
 
 func (c *fakeOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20200617100204-823c70af3f78
+# github.com/openshift/library-go v0.0.0-20200630145007-34ebc8778b33
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
This PR adds support for configuring the servicesNodePortRange of the KubeAPIServerConfig via the network config API. This is necessary to handle cases where the default range (30000-32767) is not sufficient for users who have more services in their cluster than the range can handle.