### PR TITLE
enable etcd latency metrics in kube-apiserver

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -44,7 +44,7 @@ spec:
     interval: 30s
     metricRelabelings:
     - action: drop
-      regex: etcd_(debugging|disk|request|server).*
+      regex: etcd_(debugging|disk|server).*
       sourceLabels:
       - __name__
     - action: drop


### PR DESCRIPTION
kube-apiserver has a histogram `etcd_request_duration_seconds` that measures latency between the kube-apiserver and etcd instance. This metrics is currently dropped by cluster-prometheus. Enable this metrics in OpenShift so we have visibility into etcd latency.

We ensured that this does not enable other unwanted metrcis
> count by(__name__) ({__name__=~"etcd_request.+"})

etcd_request_duration_seconds_bucket
etcd_request_duration_seconds_count
etcd_request_duration_seconds_sum

TODO:
The monitoring team has suggested that we also do a followup PR to sync upstream (`kube-prometheus`) scrape definitions - https://github.com/coreos/kube-prometheus/blob/f4568b06dca6425b0ffda2e90486eb025328bf36/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet#L410
