### PR TITLE
point-to-point network check: add parameterized namespace

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -172,7 +172,7 @@ spec:
       - --kubeconfig
       - /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
       - --namespace
-      - openshift-kube-apiserver
+      - $(POD_NAMESPACE)
       - --v
       - '2'
     env:
@@ -180,6 +180,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -71,7 +71,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(regeneratecerts.NewRegenerateCertsCommand())
 	cmd.AddCommand(certregenerationcontroller.NewCertRegenerationControllerCommand(ctx))
 	cmd.AddCommand(insecurereadyz.NewInsecureReadyzCommand())
-	cmd.AddCommand(checkendpoints.New())
+	cmd.AddCommand(checkendpoints.NewCheckEndpointsCommand())
 
 	return cmd
 }

--- a/pkg/cmd/checkendpoints/cmd.go
+++ b/pkg/cmd/checkendpoints/cmd.go
@@ -13,13 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func New() *cobra.Command {
+func NewCheckEndpointsCommand() *cobra.Command {
 	config := controllercmd.NewControllerCommandConfig("check-endpoints", version.Get(), func(ctx context.Context, cctx *controllercmd.ControllerContext) error {
+		namespace := os.Getenv("POD_NAMESPACE")
 		operatorcontrolplaneClient := operatorcontrolplaneclient.NewForConfigOrDie(cctx.KubeConfig)
-		operatorcontrolplaneInformers := operatorcontrolplaneinformers.NewSharedInformerFactoryWithOptions(operatorcontrolplaneClient, 10*time.Minute, operatorcontrolplaneinformers.WithNamespace("openshift-kube-apiserver"))
+		operatorcontrolplaneInformers := operatorcontrolplaneinformers.NewSharedInformerFactoryWithOptions(operatorcontrolplaneClient, 10*time.Minute, operatorcontrolplaneinformers.WithNamespace(namespace))
 		check := controller.NewPodNetworkConnectivityCheckController(
 			os.Getenv("POD_NAME"),
-			"openshift-kube-apiserver",
+			namespace,
 			operatorcontrolplaneClient.ControlplaneV1alpha1(),
 			operatorcontrolplaneInformers.Controlplane().V1alpha1().PodNetworkConnectivityChecks(),
 			cctx.EventRecorder,

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -691,7 +691,7 @@ spec:
       - --kubeconfig
       - /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
       - --namespace
-      - openshift-kube-apiserver
+      - $(POD_NAMESPACE)
       - --v
       - '2'
     env:
@@ -699,6 +699,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
     volumeMounts:
       - mountPath: /etc/kubernetes/static-pod-resources
         name: resource-dir


### PR DESCRIPTION
Remove hard-coded namespace from check-endpoints command so that it can be used by other component.s