### PR TITLE
kube-apiserver-cert-syncer-kubeconfig: point to serving cert

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/kubeconfig-cm.yaml
+++ b/bindata/v4.1.0/kube-apiserver/kubeconfig-cm.yaml
@@ -8,7 +8,7 @@ data:
     apiVersion: v1
     clusters:
       - cluster:
-          certificate-authority: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/ca.crt
+          certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-server-ca/ca-bundle.crt
           server: https://localhost:6443
           tls-server-name: localhost-recovery
         name: loopback

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -357,7 +357,7 @@ data:
     apiVersion: v1
     clusters:
       - cluster:
-          certificate-authority: /etc/kubernetes/static-pod-resources/secrets/localhost-recovery-client-token/ca.crt
+          certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-server-ca/ca-bundle.crt
           server: https://localhost:6443
           tls-server-name: localhost-recovery
         name: loopback


### PR DESCRIPTION
The service account gets the service-account CA that is valid at the point of creation. So if the localhost-recovery CA is not yet part of the kube-apiserver serving CA (which is the case during bootstrapping), this service-account won't work with the localhost-recovery endpoints.

The serving CA bundle though is always correct as it changes with time.

Fixes https://github.com/openshift/cluster-kube-apiserver-operator/pull/663/commits/2a44f96452f248818ff4c2467d51eef50fd139f2#r456357777

Partly reverts https://github.com/openshift/cluster-kube-apiserver-operator/pull/663.