### PR TITLE
make the connectivity check controller re-useable

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -2,71 +2,65 @@ package connectivitycheckcontroller
 
 import (
 	"context"
-	"net"
-	"net/url"
 	"regexp"
-	"strconv"
-	"strings"
 
-	"github.com/ghodss/yaml"
 	v1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/api/operatorcontrolplane/v1alpha1"
 	operatorcontrolplaneclient "github.com/openshift/client-go/operatorcontrolplane/clientset/versioned"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 )
 
 type ConnectivityCheckController interface {
 	factory.Controller
+
+	WithPodNetworkConnectivityCheckFn(podNetworkConnectivityCheckFn PodNetworkConnectivityCheckFunc) ConnectivityCheckController
 }
 
 func NewConnectivityCheckController(
-	kubeClient kubernetes.Interface,
-	operatorClient v1helpers.StaticPodOperatorClient,
-	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	operatorClient v1helpers.OperatorClient,
 	operatorcontrolplaneClient *operatorcontrolplaneclient.Clientset,
+	triggers []factory.Informer,
 	recorder events.Recorder,
 ) ConnectivityCheckController {
 	c := &connectivityCheckController{
-		kubeClient:                 kubeClient,
 		operatorClient:             operatorClient,
 		operatorcontrolplaneClient: operatorcontrolplaneClient,
-		endpointsLister:            kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Endpoints().Lister(),
-		serviceLister:              kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Services().Lister(),
 	}
+
+	allTriggers := []factory.Informer{operatorClient.Informer()}
+	allTriggers = append(allTriggers, triggers...)
+
 	c.Controller = factory.New().
 		WithSync(c.Sync).
-		WithInformers(
-			operatorClient.Informer(),
-			kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Endpoints().Informer(),
-			kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Services().Informer(),
-		).
+		WithInformers(allTriggers...).
 		ToController("ConnectivityCheckController", recorder.WithComponentSuffix("connectivity-check-controller"))
 	return c
 }
 
 type connectivityCheckController struct {
 	factory.Controller
-	kubeClient                 kubernetes.Interface
-	operatorClient             v1helpers.StaticPodOperatorClient
+	operatorClient             v1helpers.OperatorClient
 	operatorcontrolplaneClient *operatorcontrolplaneclient.Clientset
-	endpointsLister            corev1listers.EndpointsLister
-	serviceLister              corev1listers.ServiceLister
+
+	podNetworkConnectivityCheckFn PodNetworkConnectivityCheckFunc
+}
+
+type PodNetworkConnectivityCheckFunc func(ctx context.Context, syncContext factory.SyncContext) ([]*v1alpha1.PodNetworkConnectivityCheck, error)
+
+func (c *connectivityCheckController) WithPodNetworkConnectivityCheckFn(podNetworkConnectivityCheckFn PodNetworkConnectivityCheckFunc) ConnectivityCheckController {
+	c.podNetworkConnectivityCheckFn = podNetworkConnectivityCheckFn
+	return c
 }
 
 func (c *connectivityCheckController) Sync(ctx context.Context, syncContext factory.SyncContext) error {
-	operatorSpec, _, _, err := c.operatorClient.GetStaticPodOperatorState()
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
 	if err != nil {
 		return err
 	}
@@ -80,42 +74,13 @@ func (c *connectivityCheckController) Sync(ctx context.Context, syncContext fact
 		syncContext.Recorder().Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorSpec.ManagementState)
 		return nil
 	}
-	managePodNetworkConnectivityChecks(ctx, c.kubeClient, c.operatorcontrolplaneClient, operatorSpec, c.endpointsLister, c.serviceLister, syncContext.Recorder())
-	return nil
-}
 
-func managePodNetworkConnectivityChecks(ctx context.Context, client kubernetes.Interface,
-	operatorcontrolplaneClient *operatorcontrolplaneclient.Clientset,
-	operatorSpec *operatorv1.StaticPodOperatorSpec, endpointsLister corev1listers.EndpointsLister,
-	serviceLister corev1listers.ServiceLister, recorder events.Recorder) {
-
-	var templates []*v1alpha1.PodNetworkConnectivityCheck
-	// each storage endpoint
-	templates = append(templates, getTemplatesForStorageEndpoints(operatorSpec, recorder)...)
-	// oas service IP
-	templates = append(templates, getTemplatesForOpenShiftAPIServerService(serviceLister, recorder)...)
-	// each oas endpoint
-	templates = append(templates, getTemplatesForOpenShiftAPIServerServiceEndpoints(endpointsLister, recorder)...)
-
-	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
-	})
+	checks, err := c.podNetworkConnectivityCheckFn(ctx, syncContext)
 	if err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "failed to list master nodes: %v", err)
-	}
-	// create each check per static pod
-	var checks []*v1alpha1.PodNetworkConnectivityCheck
-	for _, node := range nodes.Items {
-		staticPodName := "kube-apiserver-" + node.Name
-		for _, template := range templates {
-			check := template.DeepCopy()
-			check.Name = strings.Replace(check.Name, "$(SOURCE)", staticPodName, -1)
-			check.Spec.SourcePod = staticPodName
-			checks = append(checks, check)
-		}
+		return err
 	}
 
-	pnccClient := operatorcontrolplaneClient.ControlplaneV1alpha1().PodNetworkConnectivityChecks(operatorclient.TargetNamespace)
+	pnccClient := c.operatorcontrolplaneClient.ControlplaneV1alpha1().PodNetworkConnectivityChecks(operatorclient.TargetNamespace)
 	for _, check := range checks {
 		_, err := pnccClient.Get(ctx, check.Name, metav1.GetOptions{})
 		if err == nil {
@@ -126,121 +91,22 @@ func managePodNetworkConnectivityChecks(ctx context.Context, client kubernetes.I
 			_, err = pnccClient.Create(ctx, check, metav1.CreateOptions{})
 		}
 		if err != nil {
-			recorder.Warningf("EndpointDetectionFailure", "%s: %v", resourcehelper.FormatResourceForCLIWithNamespace(check), err)
+			syncContext.Recorder().Warningf("EndpointDetectionFailure", "%s: %v", resourcehelper.FormatResourceForCLIWithNamespace(check), err)
 			continue
 		}
-		recorder.Eventf("EndpointCheckCreated", "Created %s because it was missing.", resourcehelper.FormatResourceForCLIWithNamespace(check))
+		syncContext.Recorder().Eventf("EndpointCheckCreated", "Created %s because it was missing.", resourcehelper.FormatResourceForCLIWithNamespace(check))
 	}
-}
 
-func getTemplatesForOpenShiftAPIServerService(serviceLister corev1listers.ServiceLister, recorder events.Recorder) []*v1alpha1.PodNetworkConnectivityCheck {
-	var templates []*v1alpha1.PodNetworkConnectivityCheck
-	for _, address := range listAddressesForOpenShiftAPIServerService(serviceLister, recorder) {
-		templates = append(templates, newPodNetworkProductivityCheck("openshift-apiserver-service", address))
-	}
-	return templates
-}
+	// TODO for checks which longer exist, mark them as completed
 
-func listAddressesForOpenShiftAPIServerService(serviceLister corev1listers.ServiceLister, recorder events.Recorder) []string {
-	service, err := serviceLister.Services("openshift-apiserver").Get("api")
-	if err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "unable to determine openshift-apiserver service endpoint: %v", err)
-		return nil
-	}
-	for _, port := range service.Spec.Ports {
-		if port.TargetPort.IntValue() == 6443 {
-			return []string{net.JoinHostPort(service.Spec.ClusterIP, strconv.Itoa(int(port.Port)))}
-		}
-	}
-	return []string{net.JoinHostPort(service.Spec.ClusterIP, "443")}
-}
+	// TODO reap old connectivity checks
 
-func getTemplatesForOpenShiftAPIServerServiceEndpoints(endpointsLister corev1listers.EndpointsLister, recorder events.Recorder) []*v1alpha1.PodNetworkConnectivityCheck {
-	var templates []*v1alpha1.PodNetworkConnectivityCheck
-	for _, address := range listAddressesForOpenShiftAPIServerServiceEndpoints(endpointsLister, recorder) {
-		templates = append(templates, newPodNetworkProductivityCheck("openshift-apiserver-service-endpoint", address))
-	}
-	return templates
-}
-
-// listAddressesForOpenShiftAPIServerServiceEndpoints returns oas api service endpoints ip
-func listAddressesForOpenShiftAPIServerServiceEndpoints(endpointsLister corev1listers.EndpointsLister, recorder events.Recorder) []string {
-	var results []string
-	endpoints, err := endpointsLister.Endpoints("openshift-apiserver").Get("api")
-	if err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "unable to determine openshift-apiserver service endpoints endpoint: %v", err)
-		return nil
-	}
-	for _, subset := range endpoints.Subsets {
-		for _, address := range subset.Addresses {
-			for _, port := range subset.Ports {
-				results = append(results, net.JoinHostPort(address.IP, strconv.Itoa(int(port.Port))))
-			}
-		}
-	}
-	return results
-}
-
-func getTemplatesForStorageEndpoints(operatorSpec *operatorv1.StaticPodOperatorSpec, recorder events.Recorder) []*v1alpha1.PodNetworkConnectivityCheck {
-	var templates []*v1alpha1.PodNetworkConnectivityCheck
-	for _, address := range listAddressesForStorageEndpoints(operatorSpec, recorder) {
-		templates = append(templates, newPodNetworkProductivityCheck("storage-endpoint", address, withTlsClientCert("etcd-client")))
-	}
-	for _, address := range listAddressesForEtcdServerEndpoints(operatorSpec, recorder) {
-		templates = append(templates, newPodNetworkProductivityCheck("etcd-server", address, withTlsClientCert("etcd-client")))
-	}
-	return templates
-}
-
-func listAddressesForStorageEndpoints(operatorSpec *operatorv1.StaticPodOperatorSpec, recorder events.Recorder) []string {
-	var results []string
-	var observedConfig map[string]interface{}
-	if err := yaml.Unmarshal(operatorSpec.ObservedConfig.Raw, &observedConfig); err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "failed to unmarshal the observedConfig: %v", err)
-		return nil
-	}
-	urls, _, err := unstructured.NestedStringSlice(observedConfig, "storageConfig", "urls")
-	if err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "couldn't get the storage config urls from observedConfig: %v", err)
-		return nil
-	}
-	for _, rawStorageConfigURL := range urls {
-		storageConfigURL, err := url.Parse(rawStorageConfigURL)
-		if err != nil {
-			recorder.Warningf("EndpointDetectionFailure", "couldn't parse a storage config url from observedConfig: %v", err)
-			continue
-		}
-		results = append(results, storageConfigURL.Host)
-	}
-	return results
-}
-
-func listAddressesForEtcdServerEndpoints(operatorSpec *operatorv1.StaticPodOperatorSpec, recorder events.Recorder) []string {
-	var results []string
-	var observedConfig map[string]interface{}
-	if err := yaml.Unmarshal(operatorSpec.ObservedConfig.Raw, &observedConfig); err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "failed to unmarshal the observedConfig: %v", err)
-		return nil
-	}
-	urls, _, err := unstructured.NestedStringSlice(observedConfig, "apiServerArguments", "etcd-servers")
-	if err != nil {
-		recorder.Warningf("EndpointDetectionFailure", "couldn't get the etcd server urls from observedConfig: %v", err)
-		return nil
-	}
-	for _, rawStorageConfigURL := range urls {
-		storageConfigURL, err := url.Parse(rawStorageConfigURL)
-		if err != nil {
-			recorder.Warningf("EndpointDetectionFailure", "couldn't parse an etcd server url from observedConfig: %v", err)
-			continue
-		}
-		results = append(results, storageConfigURL.Host)
-	}
-	return results
+	return nil
 }
 
 var checkNameRegex = regexp.MustCompile(`[.:\[\]]+`)
 
-func newPodNetworkProductivityCheck(label, address string, options ...func(*v1alpha1.PodNetworkConnectivityCheck)) *v1alpha1.PodNetworkConnectivityCheck {
+func NewPodNetworkProductivityCheckTemplate(label, address string, options ...func(*v1alpha1.PodNetworkConnectivityCheck)) *v1alpha1.PodNetworkConnectivityCheck {
 	check := &v1alpha1.PodNetworkConnectivityCheck{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "$(SOURCE)-to-" + label + "-" + checkNameRegex.ReplaceAllLiteralString(address, "-"),
@@ -256,7 +122,7 @@ func newPodNetworkProductivityCheck(label, address string, options ...func(*v1al
 	return check
 }
 
-func withTlsClientCert(secretName string) func(*v1alpha1.PodNetworkConnectivityCheck) {
+func WithTlsClientCert(secretName string) func(*v1alpha1.PodNetworkConnectivityCheck) {
 	return func(check *v1alpha1.PodNetworkConnectivityCheck) {
 		if len(secretName) > 0 {
 			check.Spec.TLSClientCert = v1.SecretNameReference{Name: secretName}

--- a/pkg/operator/connectivitycheckcontroller/connectivity_checks.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_checks.go
@@ -1,0 +1,193 @@
+package connectivitycheckcontroller
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/openshift/api/operatorcontrolplane/v1alpha1"
+	operatorcontrolplaneclient "github.com/openshift/client-go/operatorcontrolplane/clientset/versioned"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+func NewKubeAPIServerConnectivityCheckController(
+	kubeClient kubernetes.Interface,
+	operatorClient v1helpers.StaticPodOperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	operatorcontrolplaneClient *operatorcontrolplaneclient.Clientset,
+	recorder events.Recorder,
+) ConnectivityCheckController {
+	templateProvider := &connectivityCheckTemplateProvider{
+		kubeClient:      kubeClient,
+		operatorClient:  operatorClient,
+		endpointsLister: kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Endpoints().Lister(),
+		serviceLister:   kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Services().Lister(),
+	}
+
+	c := NewConnectivityCheckController(
+		operatorClient,
+		operatorcontrolplaneClient,
+		[]factory.Informer{
+			kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Endpoints().Informer(),
+			kubeInformersForNamespaces.InformersFor("openshift-apiserver").Core().V1().Services().Informer(),
+		},
+		recorder).
+		WithPodNetworkConnectivityCheckFn(templateProvider.getPodNetworkConnectivityChecks)
+
+	return c
+}
+
+type connectivityCheckTemplateProvider struct {
+	kubeClient      kubernetes.Interface
+	operatorClient  v1helpers.OperatorClient
+	endpointsLister corev1listers.EndpointsLister
+	serviceLister   corev1listers.ServiceLister
+}
+
+func (c *connectivityCheckTemplateProvider) getPodNetworkConnectivityChecks(ctx context.Context, syncContext factory.SyncContext) ([]*v1alpha1.PodNetworkConnectivityCheck, error) {
+	var templates []*v1alpha1.PodNetworkConnectivityCheck
+	// each storage endpoint
+	etcdEndpoints, err := c.getTemplatesForEtcdEndpoints(syncContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list etcd IPs: %w", err)
+	}
+	templates = append(templates, etcdEndpoints...)
+
+	// oas service IP
+	oasServiceIP, err := c.getTemplatesForOpenShiftAPIServerService(syncContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list openshift-apiserver service IP: %w", err)
+	}
+	templates = append(templates, oasServiceIP...)
+
+	// each oas endpoint
+	oasEndpointIPs, err := c.getTemplatesForOpenShiftAPIServerEndpoints(syncContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list openshift-apiserver endpoint IPs: %w", err)
+	}
+	templates = append(templates, oasEndpointIPs...)
+
+	nodes, err := c.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list master nodes: %w", err)
+	}
+
+	// create each check per static pod
+	var checks []*v1alpha1.PodNetworkConnectivityCheck
+	for _, node := range nodes.Items {
+		staticPodName := "kube-apiserver-" + node.Name
+		for _, template := range templates {
+			check := template.DeepCopy()
+			check.Name = strings.Replace(check.Name, "$(SOURCE)", staticPodName, -1)
+			check.Spec.SourcePod = staticPodName
+			checks = append(checks, check)
+		}
+	}
+
+	return checks, nil
+}
+
+func (c *connectivityCheckTemplateProvider) getTemplatesForOpenShiftAPIServerService(syncContext factory.SyncContext) ([]*v1alpha1.PodNetworkConnectivityCheck, error) {
+	var templates []*v1alpha1.PodNetworkConnectivityCheck
+	ips, err := c.listAddressesForOpenShiftAPIServerService(syncContext)
+	if err != nil {
+		return nil, err
+	}
+	for _, address := range ips {
+		templates = append(templates, NewPodNetworkProductivityCheckTemplate("openshift-apiserver-service", address))
+	}
+	return templates, nil
+}
+
+func (c *connectivityCheckTemplateProvider) listAddressesForOpenShiftAPIServerService(syncContext factory.SyncContext) ([]string, error) {
+	service, err := c.serviceLister.Services("openshift-apiserver").Get("api")
+	if err != nil {
+		return nil, err
+	}
+	for _, port := range service.Spec.Ports {
+		if port.TargetPort.IntValue() == 6443 {
+			return []string{net.JoinHostPort(service.Spec.ClusterIP, strconv.Itoa(int(port.Port)))}, nil
+		}
+	}
+	return []string{net.JoinHostPort(service.Spec.ClusterIP, "443")}, nil
+}
+
+func (c *connectivityCheckTemplateProvider) getTemplatesForOpenShiftAPIServerEndpoints(syncContext factory.SyncContext) ([]*v1alpha1.PodNetworkConnectivityCheck, error) {
+	var templates []*v1alpha1.PodNetworkConnectivityCheck
+	ips, err := c.listAddressesForOpenShiftAPIServerServiceEndpoints(syncContext)
+	if err != nil {
+		return nil, err
+	}
+	for _, address := range ips {
+		templates = append(templates, NewPodNetworkProductivityCheckTemplate("openshift-apiserver-endpoint", address))
+	}
+	return templates, nil
+}
+
+// listAddressesForOpenShiftAPIServerServiceEndpoints returns oas api service endpoints ip
+func (c *connectivityCheckTemplateProvider) listAddressesForOpenShiftAPIServerServiceEndpoints(syncContext factory.SyncContext) ([]string, error) {
+	var results []string
+	endpoints, err := c.endpointsLister.Endpoints("openshift-apiserver").Get("api")
+	if err != nil {
+		return nil, err
+	}
+	for _, subset := range endpoints.Subsets {
+		for _, address := range subset.Addresses {
+			for _, port := range subset.Ports {
+				results = append(results, net.JoinHostPort(address.IP, strconv.Itoa(int(port.Port))))
+			}
+		}
+	}
+	return results, nil
+}
+
+func (c *connectivityCheckTemplateProvider) getTemplatesForEtcdEndpoints(syncContext factory.SyncContext) ([]*v1alpha1.PodNetworkConnectivityCheck, error) {
+	var templates []*v1alpha1.PodNetworkConnectivityCheck
+	ips, err := c.listAddressesForEtcdServerEndpoints(syncContext)
+	if err != nil {
+		return nil, err
+	}
+	for _, address := range ips {
+		templates = append(templates, NewPodNetworkProductivityCheckTemplate("etcd-server", address, WithTlsClientCert("etcd-client")))
+	}
+	return templates, nil
+}
+
+func (c *connectivityCheckTemplateProvider) listAddressesForEtcdServerEndpoints(syncContext factory.SyncContext) ([]string, error) {
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the operatorSpec: %w", err)
+	}
+
+	var results []string
+	var observedConfig map[string]interface{}
+	if err := yaml.Unmarshal(operatorSpec.ObservedConfig.Raw, &observedConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the observedConfig: %w", err)
+	}
+	urls, _, err := unstructured.NestedStringSlice(observedConfig, "apiServerArguments", "etcd-servers")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get the etcd server urls from observedConfig: %w", err)
+	}
+	for _, rawStorageConfigURL := range urls {
+		storageConfigURL, err := url.Parse(rawStorageConfigURL)
+		if err != nil {
+			syncContext.Recorder().Warningf("EndpointDetectionFailure", "couldn't parse an etcd server url from observedConfig: %v", err)
+			continue
+		}
+		results = append(results, storageConfigURL.Host)
+	}
+	return results, nil
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -136,7 +136,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	connectivityCheckController := connectivitycheckcontroller.NewConnectivityCheckController(
+	connectivityCheckController := connectivitycheckcontroller.NewKubeAPIServerConnectivityCheckController(
 		kubeClient,
 		operatorClient,
 		kubeInformersForNamespaces,


### PR DESCRIPTION
Makes the creation, maintenance, and reaping of old connectivity checks re-useable and localizes the custom logic.

/assign @sanchezl 