### PR TITLE
connectivitycheckcontroller: fix incorrect event reason on update

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -96,7 +96,7 @@ func (c *connectivityCheckController) Sync(ctx context.Context, syncContext fact
 				syncContext.Recorder().Warningf("EndpointDetectionFailure", "%s: %v", resourcehelper.FormatResourceForCLIWithNamespace(check), err)
 				continue
 			}
-			syncContext.Recorder().Eventf("EndpointCheckCreated", "Updated %s because it changed.", resourcehelper.FormatResourceForCLIWithNamespace(check))
+			syncContext.Recorder().Eventf("EndpointCheckUpdated", "Updated %s because it changed.", resourcehelper.FormatResourceForCLIWithNamespace(check))
 		}
 		if apierrors.IsNotFound(err) {
 			_, err = pnccClient.Create(ctx, check, metav1.CreateOptions{})


### PR DESCRIPTION
Event indicating endpoint updated should have a reason of `EndpointCheckUpdated`.