### PR TITLE
Bug 1861431: LatencySensitive feature gate allows upgrades

### DIFF
--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	featureGatesAllowingUpgrade = sets.NewString("")
+	featureGatesAllowingUpgrade = sets.NewString("", string(configv1.LatencySensitive))
 )
 
 // FeatureUpgradeableController is a controller that sets upgradeable=false if anything outside the allowed list is the specified featuregates.

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
@@ -45,6 +45,16 @@ func TestNewUpgradeableCondition(t *testing.T) {
 				Message: "\"TechPreviewNoUpgrade\" does not allow updates",
 			},
 		},
+		{
+			name:     "latencysensitive",
+			features: string(configv1.LatencySensitive),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "AllowedFeatureGates_LatencySensitive",
+				Status:  "True",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
LatencySensitive FeatureGate should allow upgrades according to
https://github.com/openshift/api/blob/7192180f496aab1f7659d8660fc360498bab498b/config/v1/types_feature.go#L38