### PR TITLE
[release-4.4] Bug 1863076: LatencySensitive feature gate allows upgrades

### DIFF
--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
@@ -22,7 +22,7 @@ import (
 var (
 	featureUpgradeableControllerWorkQueueKey = "key"
 
-	featureGatesAllowingUpgrade = sets.NewString("")
+	featureGatesAllowingUpgrade = sets.NewString("", string(configv1.LatencySensitive))
 )
 
 // FeatureUpgradeableController is a controller that sets upgradeable=false if anything outside the whitelist is the specified featuregates.

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
@@ -45,6 +45,16 @@ func TestNewUpgradeableCondition(t *testing.T) {
 				Message: "\"TechPreviewNoUpgrade\" does not allow updates",
 			},
 		},
+		{
+			name:     "latencysensitive",
+			features: string(configv1.LatencySensitive),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "AllowedFeatureGates_LatencySensitive",
+				Status:  "True",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
LatencySensitive FeatureGate should allow upgrades according to
https://github.com/openshift/api/blob/7192180f496aab1f7659d8660fc360498bab498b/config/v1/types_feature.go#L38

This is a manual cherrypick from the release-4.5 branch

Signed-off-by: Francesco Romani <fromani@redhat.com>