### PR TITLE
inactivity timeout test waits until all kube-apiservers are on same revision

### DIFF
--- a/test/e2e/token_inactivity_timeout_test.go
+++ b/test/e2e/token_inactivity_timeout_test.go
@@ -105,12 +105,11 @@ func TestTokenInactivityTimeout(t *testing.T) {
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, nil, testTokenTimeouts)
 	})
 
-	updateOAuthConfigInactivityTimeout(t, configClient, &metav1.Duration{Duration: time.Duration(configInactivityTimeout) * time.Second})
-	test.WaitForKubeAPIServerStartProgressing(t, configClient)
-	test.WaitForAPIServerToStabilizeOnTheSameRevision(t, kubeClient.CoreV1().Pods("openshift-kube-apiserver"))
-
 	// With only OAuth config timeout.
 	t.Run("with-inactivity-timeout", func(t *testing.T) {
+		updateOAuthConfigInactivityTimeout(t, configClient, &metav1.Duration{Duration: time.Duration(configInactivityTimeout) * time.Second})
+		test.WaitForKubeAPIServerStartProgressing(t, configClient)
+		test.WaitForAPIServerToStabilizeOnTheSameRevision(t, kubeClient.CoreV1().Pods("openshift-kube-apiserver"))
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, nil, testInactivityTimeoutScenarios)
 	})
 
@@ -119,12 +118,11 @@ func TestTokenInactivityTimeout(t *testing.T) {
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, &oauthClientTimeout, testInactivityTimeoutScenarios)
 	})
 
-	updateOAuthConfigInactivityTimeout(t, configClient, nil)
-	test.WaitForKubeAPIServerStartProgressing(t, configClient)
-	test.WaitForAPIServerToStabilizeOnTheSameRevision(t, kubeClient.CoreV1().Pods("openshift-kube-apiserver"))
-
 	// No OAuthClient timeout and no OAuth config timeout.
 	t.Run("unset-inactivity-timeout-client-timeout", func(t *testing.T) {
+		updateOAuthConfigInactivityTimeout(t, configClient, nil)
+		test.WaitForKubeAPIServerStartProgressing(t, configClient)
+		test.WaitForAPIServerToStabilizeOnTheSameRevision(t, kubeClient.CoreV1().Pods("openshift-kube-apiserver"))
 		checkTokenAccess(t, userClient, oauthClientClient, configInactivityTimeout, nil, testTokenTimeouts)
 	})
 


### PR DESCRIPTION
Currently all the inactivity timeout test failures are due to kube-apiserver not rolling out in anticipated time. One of the reasons for this delay could be a new revision being created while another one is in progress. This change aims to cut down this [flakiness](https://github.com/openshift/cluster-kube-apiserver-operator/pull/928).