### PR TITLE
Bug 1874521: connectivity check metrics cannot be aggregated across components 

### DIFF
--- a/pkg/cmd/checkendpoints/cmd.go
+++ b/pkg/cmd/checkendpoints/cmd.go
@@ -3,7 +3,6 @@ package checkendpoints
 import (
 	"context"
 	"os"
-	"strings"
 	"time"
 
 	operatorcontrolplaneclient "github.com/openshift/client-go/operatorcontrolplane/clientset/versioned"
@@ -31,7 +30,7 @@ func NewCheckEndpointsCommand() *cobra.Command {
 			kubeInformers.Core().V1().Secrets(),
 			cctx.EventRecorder,
 		)
-		controller.RegisterMetrics(strings.Replace(namespace, "-", "_", -1) + "_")
+		controller.RegisterMetrics()
 		operatorcontrolplaneInformers.Start(ctx.Done())
 		kubeInformers.Start(ctx.Done())
 		go check.Run(ctx, 1)

--- a/pkg/cmd/checkendpoints/controller/pod_network_connectivity_check_controller.go
+++ b/pkg/cmd/checkendpoints/controller/pod_network_connectivity_check_controller.go
@@ -83,7 +83,7 @@ func (c *controller) Sync(ctx context.Context, syncContext factory.SyncContext) 
 	// create & start status updaters if needed
 	for _, check := range checks {
 		if updater := c.updaters[check.Name]; updater == nil {
-			c.updaters[check.Name] = NewConnectionChecker(check.Name, c.podName, c.newCheckFunc(check.Name), c, c.getClientCerts(check), c.recorder)
+			c.updaters[check.Name] = NewConnectionChecker(check.Name, c.podName, c.podNamespace, c.newCheckFunc(check.Name), c, c.getClientCerts(check), c.recorder)
 			go c.updaters[check.Name].Run(ctx)
 		}
 	}


### PR DESCRIPTION
Implement changes to the metric names and labels as discovered during reviews for better usability.

* Names changed to no longer be specific to the component check-endpoints is being run in. They will always be:
```
pod_network_connectivity_check_count
pod_network_connectivity_check_tcp_connect_latency_gauge
pod_network_connectivity_check_dns_resolve_latency_gauge
```
* `endpoint` labels renamed to `targetEndpoint` to avoid collisions with default label of the same name.
* `component` label added (e.g. openshift-kube-apiserver or openshift-apiserver) 
* `checkName` label added
