### PR TITLE
Bug 1876166: disable kube-apiserver connectivity checks 

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -54,7 +54,7 @@ func NewKubeAPIServerConnectivityCheckController(
 				configInformers.Config().V1().Infrastructures().Informer(),
 			},
 			recorder,
-			true,
+			false,
 		),
 	}
 	generator := &connectivityCheckTemplateProvider{


### PR DESCRIPTION
Disable the ConnectivityCheckController.