### PR TITLE
Bug 1877106: Connectivity checker creates excessive events and possibly etcd db growth on Azure

### DIFF
--- a/pkg/cmd/checkendpoints/controller/backoff_recorder.go
+++ b/pkg/cmd/checkendpoints/controller/backoff_recorder.go
@@ -1,0 +1,241 @@
+package controller
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// Recorder is a stripped down version of the library-go events.Recorder interface.
+type Recorder interface {
+	Event(reason, message string)
+	Eventf(reason, messageFmt string, args ...interface{})
+	Warning(reason, message string)
+	Warningf(reason, messageFmt string, args ...interface{})
+}
+
+// NewBackoffEventRecorder returns a new Recorder that keeps track of the rate of events
+// being recorded and if the rate is too fast, suspend recording events for a while, keeping
+// events in memory. When event recording is resumed, record a single summary events for all
+// the events for a given event reason. By default, event recording id paused for 30 minutes
+// when the rate of events exceed either 30 events in 30 seconds or 600 events in 10 minutes.
+func NewBackoffEventRecorder(recorder events.Recorder, options ...backoffEventRecorderOptionFunc) Recorder {
+	m := &backoffEventRecorder{
+		recorder:            recorder,
+		shortWindow:         30 * time.Second,
+		longWindow:          10 * time.Minute,
+		backoff:             30 * time.Minute,
+		shortWindowCountMax: 30,
+		longWindowCountMax:  600,
+	}
+	m.shortWindowTicker = time.NewTicker(m.shortWindow)
+	m.longWindowTicker = time.NewTicker(m.longWindow)
+	for _, option := range options {
+		option(m)
+	}
+	return m
+}
+
+// backoffEventRecorderOptionFunc customizes backoffEventRecorder
+type backoffEventRecorderOptionFunc func(recorder *backoffEventRecorder)
+
+// WithShortWindow sets the short window excessive event rate
+func WithShortWindow(duration time.Duration, maxCount int) backoffEventRecorderOptionFunc {
+	return func(recorder *backoffEventRecorder) {
+		if recorder.shortWindowTicker != nil {
+			recorder.shortWindowTicker.Stop()
+		}
+		recorder.shortWindow = duration
+		recorder.shortWindowTicker = time.NewTicker(duration)
+		recorder.shortWindowCountMax = maxCount
+	}
+}
+
+// WithLongWindow sets the long window excessive event rate
+func WithLongWindow(duration time.Duration, maxCount int) backoffEventRecorderOptionFunc {
+	return func(recorder *backoffEventRecorder) {
+		if recorder.longWindowTicker != nil {
+			recorder.longWindowTicker.Stop()
+		}
+		recorder.longWindow = duration
+		recorder.longWindowTicker = time.NewTicker(duration)
+		recorder.longWindowCountMax = maxCount
+	}
+}
+
+// WithBackoff sets the duration of the event backoff
+func WithBackoff(duration time.Duration) backoffEventRecorderOptionFunc {
+	return func(recorder *backoffEventRecorder) {
+		if recorder.backoffTicker != nil {
+			recorder.backoffTicker.Stop()
+		}
+		recorder.backoff = duration
+		recorder.backoffTicker = nil
+	}
+}
+
+func (r *backoffEventRecorder) Event(reason, message string) {
+	r.event(corev1.EventTypeNormal, reason, message)
+}
+
+func (r *backoffEventRecorder) Eventf(reason, messageFmt string, args ...interface{}) {
+	r.Event(reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *backoffEventRecorder) Warning(reason, message string) {
+	r.event(corev1.EventTypeWarning, reason, message)
+}
+
+func (r *backoffEventRecorder) Warningf(reason, messageFmt string, args ...interface{}) {
+	r.Warning(reason, fmt.Sprintf(messageFmt, args...))
+}
+
+// backoffEventRecorder wraps a library-go events.Recorder.
+//
+// Keeps track of the rate of events during a "short" and "long" window
+// of time. If the rate of events is excessive in either window, stop
+// recording events for the backoff duration and keep in memory instead.
+// Once the backoff duration has passed, record the in memory events
+// in summary events grouped by event reason, and resume recording events
+// normally.
+type backoffEventRecorder struct {
+	// the wrapped event recorder
+	recorder events.Recorder
+
+	// lock must be held to update any internal state
+	lock sync.Mutex
+
+	// events waiting to be recorded
+	events map[string]map[string][]eventInfo
+
+	// short excessive event window
+	shortWindow         time.Duration
+	shortWindowCountMax int
+
+	// excessive event long window
+	longWindow         time.Duration
+	longWindowCountMax int
+
+	// backoff delay when excessive events detected
+	backoff time.Duration
+
+	// keep count of events during windows
+	shortWindowCount int
+	longWindowCount  int
+
+	// tickers
+	shortWindowTicker *time.Ticker
+	longWindowTicker  *time.Ticker
+
+	// backoffTicker is nil if no backoff delay is in progress
+	backoffTicker *time.Ticker
+}
+
+// eventInfo correlates an event message with the time when the event recording was requested.
+type eventInfo struct {
+	timestamp time.Time
+	message   string
+}
+
+func (e eventInfo) String() string {
+	return fmt.Sprintf("%s: %s", e.timestamp.Format(time.RFC3339), e.message)
+}
+
+// event records the event, buffers it in-memory, or emits it as part of a summary event.
+func (r *backoffEventRecorder) event(eventType, reason, message string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	// add event to buffer
+	if r.events == nil {
+		r.events = make(map[string]map[string][]eventInfo)
+	}
+	if _, ok := r.events[eventType]; !ok {
+		r.events[eventType] = map[string][]eventInfo{}
+	}
+	r.events[eventType][reason] = append(r.events[eventType][reason], eventInfo{
+		timestamp: time.Now(),
+		message:   message,
+	})
+
+	// handle backoff period
+	if r.backoffTicker != nil {
+		select {
+		case <-r.backoffTicker.C:
+			// backoff period has passed
+			klog.V(1).Info("Resuming connectivity event recording.")
+			r.backoffTicker = nil
+			r.longWindowCount = 0
+			r.shortWindowCount = 0
+		default:
+			// still in backoff period
+			return
+		}
+	}
+
+	// update window event count
+	select {
+	case <-r.shortWindowTicker.C:
+		r.shortWindowCount = 0
+	default:
+		r.shortWindowCount++
+	}
+	select {
+	case <-r.longWindowTicker.C:
+		r.longWindowCount = 0
+	default:
+		r.longWindowCount++
+	}
+
+	// if events are coming in too quickly, start backoff
+	if r.shortWindowCount > r.shortWindowCountMax || r.longWindowCount > r.longWindowCountMax {
+		if r.shortWindowCount > r.shortWindowCountMax {
+			klog.V(1).Infof("More than %d events (%d) in the last %v.", r.shortWindowCountMax, r.shortWindowCount, r.shortWindow)
+		} else {
+			klog.V(1).Infof("More than %d events (%d) in the last %v.", r.longWindowCountMax, r.longWindowCount, r.longWindow)
+		}
+		klog.V(1).Infof("Backing off event recording for the next %v.", r.backoff)
+		r.backoffTicker = time.NewTicker(r.backoff)
+		return
+	}
+
+	// if we made it this far, record the buffered events
+	for eventType, typeEvents := range r.events {
+		for reason, reasonEvents := range typeEvents {
+			sort.Slice(reasonEvents, func(i, j int) bool {
+				return reasonEvents[i].timestamp.Before(reasonEvents[j].timestamp)
+			})
+			messages := joinEventMessages(reasonEvents)
+			switch eventType {
+			case corev1.EventTypeNormal:
+				r.recorder.Event(reason, messages)
+			case corev1.EventTypeWarning:
+				r.recorder.Warning(reason, messages)
+			}
+		}
+	}
+	r.events = map[string]map[string][]eventInfo{}
+
+}
+
+func joinEventMessages(eventInfos []eventInfo) string {
+	switch {
+	case len(eventInfos) == 0:
+		return ""
+	case len(eventInfos) == 1:
+		return eventInfos[0].message
+	}
+	var builder strings.Builder
+	builder.WriteString(eventInfos[0].String())
+	for _, eventInfo := range eventInfos[1:] {
+		builder.WriteString("\n")
+		builder.WriteString(eventInfo.String())
+	}
+	return builder.String()
+}

--- a/pkg/cmd/checkendpoints/controller/backoff_recorder_test.go
+++ b/pkg/cmd/checkendpoints/controller/backoff_recorder_test.go
@@ -1,0 +1,108 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithShortWindow(t *testing.T) {
+
+	shortDuration := 20 * time.Millisecond
+	shortCountMax := 3
+	longDuration := 2 * shortDuration
+	longCountMax := 60
+	backoffDuration := longDuration
+	excessiveEventCount := 10
+
+	inMemoryRecorder := events.NewInMemoryRecorder(t.Name())
+	r := NewBackoffEventRecorder(inMemoryRecorder,
+		WithShortWindow(shortDuration, shortCountMax),
+		WithLongWindow(longDuration, longCountMax),
+		WithBackoff(backoffDuration),
+	)
+
+	// first event
+	r.Eventf(t.Name(), "TEST")
+	// wait short window
+	<-time.After(shortDuration)
+	// excessive events for short window
+	for i := 0; i < shortCountMax+excessiveEventCount; i++ {
+		r.Eventf(t.Name(), "TEST")
+	}
+	// wait for backoff period to end
+	<-time.After(backoffDuration)
+	// some more events
+	for i := 0; i < shortCountMax-1; i++ {
+		r.Eventf(t.Name(), "TEST")
+	}
+	assert.Len(t, inMemoryRecorder.Events(), 1+shortCountMax+1+shortCountMax-1)
+	assert.Len(t, strings.Split(inMemoryRecorder.Events()[1+shortCountMax+1].Message, "\n"), excessiveEventCount, "Summary event expected with 10 messages.")
+	if t.Failed() {
+		t.Logf("%2d | %15v %q", 0, time.Duration(0), inMemoryRecorder.Events()[0].Message)
+		prev := inMemoryRecorder.Events()[0].LastTimestamp
+		for i, event := range inMemoryRecorder.Events()[1:] {
+			t.Logf("%2d | %15v %q", i+1, event.LastTimestamp.Sub(prev.Time), event.Message)
+			prev = event.LastTimestamp
+		}
+	}
+
+}
+
+func TestWithLongWindow(t *testing.T) {
+
+	shortDuration := 20 * time.Millisecond
+	shortCountMax := 3
+	longDuration := 5 * shortDuration
+	longCountMax := (shortCountMax - 1) * 3
+	backoffDuration := longDuration
+	excessiveEventCount := 10
+
+	inMemoryRecorder := events.NewInMemoryRecorder(t.Name())
+	r := NewBackoffEventRecorder(inMemoryRecorder,
+		WithShortWindow(shortDuration, shortCountMax),
+		WithLongWindow(longDuration, longCountMax),
+		WithBackoff(backoffDuration),
+	)
+
+	// fire enough events to trigger long window, slowly enough to no trigger short window
+	for i := 0; i < longCountMax; {
+		// start timer for short window
+		afterShortDuration := time.After(shortDuration)
+		// fire some events, not enough to trigger short window
+		for i := 0; i < shortCountMax-1; i++ {
+			r.Eventf(t.Name(), "TEST")
+		}
+		// wait short window
+		<-afterShortDuration
+		i += shortCountMax - 1
+	}
+
+	// excessive events for long window
+	for i := 0; i < excessiveEventCount; i++ {
+		r.Eventf(t.Name(), "TEST")
+	}
+
+	// wait for backoff period to end
+	<-time.After(backoffDuration)
+
+	// some more events
+	for i := 0; i < 2; i++ {
+		r.Eventf(t.Name(), "TEST")
+	}
+
+	assert.Len(t, inMemoryRecorder.Events(), longCountMax+1+1)
+	assert.Len(t, strings.Split(inMemoryRecorder.Events()[longCountMax].Message, "\n"), excessiveEventCount+1, "Summary event expected with %d messages.", excessiveEventCount+1)
+	if t.Failed() {
+		t.Logf("%2d | %15v %q", 0, time.Duration(0), inMemoryRecorder.Events()[0].Message)
+		prev := inMemoryRecorder.Events()[0].LastTimestamp
+		for i, event := range inMemoryRecorder.Events()[1:] {
+			t.Logf("%2d | %15v %q", i+1, event.LastTimestamp.Sub(prev.Time), event.Message)
+			prev = event.LastTimestamp
+		}
+	}
+
+}

--- a/pkg/cmd/checkendpoints/controller/connection_checker.go
+++ b/pkg/cmd/checkendpoints/controller/connection_checker.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	operatorcontrolplanev1alpha1 "github.com/openshift/api/operatorcontrolplane/v1alpha1"
-	"github.com/openshift/library-go/pkg/operator/events"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -32,7 +31,7 @@ type ConnectionChecker interface {
 type GetCheckFunc func() *operatorcontrolplanev1alpha1.PodNetworkConnectivityCheck
 
 // NewConnectionChecker returns a ConnectionChecker.
-func NewConnectionChecker(name, podName, podNamespace string, getCheck GetCheckFunc, client v1alpha1helpers.PodNetworkConnectivityCheckClient, clientCertGetter CertificatesGetter, recorder events.Recorder) ConnectionChecker {
+func NewConnectionChecker(name, podName, podNamespace string, getCheck GetCheckFunc, client v1alpha1helpers.PodNetworkConnectivityCheckClient, clientCertGetter CertificatesGetter, recorder Recorder) ConnectionChecker {
 	return &connectionChecker{
 		name:             name,
 		podName:          podName,
@@ -62,7 +61,7 @@ type connectionChecker struct {
 
 	client           v1alpha1helpers.PodNetworkConnectivityCheckClient
 	clientCertGetter CertificatesGetter
-	recorder         events.Recorder
+	recorder         Recorder
 	updates          UpdatesManager
 	stop             chan interface{}
 	metrics          MetricsContext
@@ -236,7 +235,7 @@ func manageStatusLogs(check *operatorcontrolplanev1alpha1.PodNetworkConnectivity
 
 // manageStatusOutage returns a status update function that manages the
 // PodNetworkConnectivityCheck.Status.Outage entries based on Successes/Failures log entries.
-func manageStatusOutage(recorder events.Recorder) v1alpha1helpers.UpdateStatusFunc {
+func manageStatusOutage(recorder Recorder) v1alpha1helpers.UpdateStatusFunc {
 	return func(status *operatorcontrolplanev1alpha1.PodNetworkConnectivityCheckStatus) {
 		// This func is kept simple by assuming that only one log entry has been
 		// added since the last time this method was invoked. See checkEndpoint func.

--- a/pkg/cmd/checkendpoints/controller/pod_network_connectivity_check_controller.go
+++ b/pkg/cmd/checkendpoints/controller/pod_network_connectivity_check_controller.go
@@ -36,7 +36,7 @@ type controller struct {
 	checksGetter operatorcontrolplaneclientv1alpha1.PodNetworkConnectivityCheckInterface
 	checkLister  v1alpha1.PodNetworkConnectivityCheckNamespaceLister
 	secretLister v1.SecretLister
-	recorder     events.Recorder
+	recorder     Recorder
 	// each PodNetworkConnectivityCheck gets its own ConnectionChecker
 	updaters map[string]ConnectionChecker
 }
@@ -53,7 +53,7 @@ func NewPodNetworkConnectivityCheckController(podName, podNamespace string,
 		checksGetter: checksGetter.PodNetworkConnectivityChecks(podNamespace),
 		checkLister:  checkInformer.Lister().PodNetworkConnectivityChecks(podNamespace),
 		secretLister: secretInformer.Lister(),
-		recorder:     recorder,
+		recorder:     NewBackoffEventRecorder(recorder),
 		updaters:     map[string]ConnectionChecker{},
 	}
 	c.Controller = factory.New().


### PR DESCRIPTION
If check-endpoints attempts to create:
* more than 30 events in 30 seconds or 
* 600 events in 10 minutes,

then suspend emitting connectivity events for the next 30 minutes to allow the cluster networking to stabilize.