### PR TITLE
Fix resync periods

### DIFF
--- a/pkg/operator/boundsatokensignercontroller/controller.go
+++ b/pkg/operator/boundsatokensignercontroller/controller.go
@@ -71,7 +71,7 @@ func NewBoundSATokenSignerController(
 		kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().Secrets().Informer(),
 		kubeInformersForNamespaces.InformersFor(targetNamespace).Core().V1().ConfigMaps().Informer(),
 		operatorClient.Informer(),
-	).ResyncEvery(time.Minute).WithSync(ret.sync).ToController("BoundSATokenSignerController", eventRecorder)
+	).ResyncEvery(1*time.Minute).WithSync(ret.sync).ToController("BoundSATokenSignerController", eventRecorder)
 }
 
 func (c *BoundSATokenSignerController) sync(ctx context.Context, syncCtx factory.SyncContext) error {

--- a/pkg/operator/certrotationtimeupgradeablecontroller/certrotationtime_upgradeable.go
+++ b/pkg/operator/certrotationtimeupgradeablecontroller/certrotationtime_upgradeable.go
@@ -3,7 +3,6 @@ package certrotationtimeupgradeablecontroller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -38,7 +37,7 @@ func NewCertRotationTimeUpgradeableController(
 	return factory.New().WithInformers(
 		operatorClient.Informer(),
 		configMapInformer.Informer(),
-	).WithSync(c.sync).ResyncEvery(time.Second).ToController("CertRotationTimeUpgradeableController", eventRecorder.WithComponentSuffix("certRotationTime-upgradeable"))
+	).WithSync(c.sync).ToController("CertRotationTimeUpgradeableController", eventRecorder.WithComponentSuffix("certRotationTime-upgradeable"))
 }
 
 func (c *CertRotationTimeUpgradeableController) sync(ctx context.Context, syncContext factory.SyncContext) error {

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -72,7 +72,7 @@ func NewTargetConfigController(
 		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Informer(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().ConfigMaps().Informer(),
-	).WithSync(c.sync).ResyncEvery(time.Second).ToController("TargetConfigController", eventRecorder.WithComponentSuffix("target-config-controller"))
+	).WithSync(c.sync).ResyncEvery(5*time.Minute).ToController("TargetConfigController", eventRecorder.WithComponentSuffix("target-config-controller"))
 }
 
 func (c TargetConfigController) sync(ctx context.Context, syncContext factory.SyncContext) error {


### PR DESCRIPTION
Resync period for targetconfigcontroller should be higher then 1s. I suspect this is the reason for a lot off throttle messages in the logs.

/cc @deads2k 