### PR TITLE
protect openshift traffic by using dedicated flowschema

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,0 +1,78 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: PriorityLevelConfiguration
+metadata:
+  name: openshift-aggregated-api-delegated-auth
+spec:
+  limited:
+    assuredConcurrencyShares: 20
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 16
+      type: Queue
+  type: Limited
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: PriorityLevelConfiguration
+metadata:
+  name: openshift-control-plane-operators
+spec:
+  limited:
+    assuredConcurrencyShares: 10
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 128
+      type: Queue
+  type: Limited
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-monitoring-metrics
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+  - nonResourceRules:
+    - verbs:
+      - '*'
+      nonResourceURLs:
+      - "/metrics"
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-kube-apiserver-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: kube-apiserver-operator
+        namespace: openshift-kube-apiserver-operator


### PR DESCRIPTION
Define dedicated flowschema and priority configuration that will protect openshift specific traffic.
- `SAR` and `tokenreviews` from both `oas` and `oauth` are very important
- kcm, other `oas` and `oauth` requests, `/metrics` requests from openshift-monitoring is pretty important
- openshift controller manager is as important as `kcm`.
- control plane operators are important (kas-o, oas-o, auth operator, etcd operator)
- `workloads-low` goes below the traffic defined above.

Question:
- do we want to include `cvo` in the control plane operators, or are there traffic from any other critical operators that we should protect?

New configuration:
![image](https://user-images.githubusercontent.com/7385775/95126821-02f92980-0725-11eb-864e-31e50f9a992b.png)


After applying the above configuration, we can see that the number of requests from `workload-low` drops. This implies that traffic from oas, `/metrics` call from openshift monitoring, traffic from control plane operators are not being throttled anymore.
![image](https://user-images.githubusercontent.com/7385775/95034887-3b4f2800-0691-11eb-9f85-12bdd7401c65.png)
