### PR TITLE
BUG 1885353: protect openshift traffic by using dedicated flowschema

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,0 +1,261 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: PriorityLevelConfiguration
+metadata:
+  name: openshift-control-plane-operators
+spec:
+  limited:
+    assuredConcurrencyShares: 10
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 128
+      type: Queue
+  type: Limited
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-monitoring-metrics
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+  - nonResourceRules:
+    - verbs:
+      - '*'
+      nonResourceURLs:
+      - "/metrics"
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-kube-apiserver-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: kube-apiserver-operator
+        namespace: openshift-kube-apiserver-operator
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-apiserver-sar
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2
+  priorityLevelConfiguration:
+    name: exempt
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - authorization.k8s.io
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - '*'
+    - apiGroups:
+      - authentication.k8s.io
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - tokenreviews
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: openshift-apiserver-sa
+        namespace: openshift-apiserver
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-apiserver
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 1000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: openshift-apiserver-sa
+        namespace: openshift-apiserver
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-apiserver-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: openshift-apiserver-operator
+        namespace: openshift-apiserver-operator
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-authentication-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: authentication-operator
+        namespace: openshift-authentication-operator
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-oauth-server
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 1000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: oauth-openshift
+        namespace: openshift-authentication
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-controller-manager
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 1000
+  priorityLevelConfiguration:
+    name: workload-high
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: openshift-controller-manager-sa
+        namespace: openshift-controller-manager
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+kind: FlowSchema
+metadata:
+  name: openshift-etcd-operator
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 2000
+  priorityLevelConfiguration:
+    name: openshift-control-plane-operators
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: etcd-operator
+        namespace: openshift-etcd-operator


### PR DESCRIPTION
Define dedicated flowschema and priority configuration that will protect openshift specific traffic.
- `SAR` from `oas` is very important (exempt)
- kcm, other `oas` requests, `oauth server` requests, metrics requests from openshift-monitoring is pretty important
- control plane operators are important (kas-o, oas-o, auth operator, etcd operator)
- `workloads-low` goes below the traffic defined above.

Question:
- is `tokenreviews` from `oas` as important as `SAR`?
- do we want to include `cvo` in the control plane operators, or are there traffic from any other critical operators that we should protect?

After applying the above configuration, we can see that the number of requests from `workload-low` drops. This implies that traffic from oas, `/metrics` call from openshift monitoring, traffic from control plane operators are not being throttled anymore.
![image](https://user-images.githubusercontent.com/7385775/95034887-3b4f2800-0691-11eb-9f85-12bdd7401c65.png)
