### PR TITLE
add current profile annotations to CVO manifests

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -2,6 +2,8 @@ apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
 kind: PriorityLevelConfiguration
 metadata:
   name: openshift-aggregated-api-delegated-auth
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   limited:
     assuredConcurrencyShares: 20
@@ -17,6 +19,8 @@ apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
 kind: PriorityLevelConfiguration
 metadata:
   name: openshift-control-plane-operators
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   limited:
     assuredConcurrencyShares: 10
@@ -32,6 +36,8 @@ apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
 kind: FlowSchema
 metadata:
   name: openshift-monitoring-metrics
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   distinguisherMethod:
     type: ByUser
@@ -54,6 +60,8 @@ apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
 kind: FlowSchema
 metadata:
   name: openshift-kube-apiserver-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   distinguisherMethod:
     type: ByUser


### PR DESCRIPTION
This is matches openshift/enhancements#414 and doesn't change existing behavior

---

Initial annotations were added a month ago via https://github.com/openshift/cluster-kube-apiserver-operator/pull/957. This file was added recently and probably the two PRs were interleaved.