### PR TITLE
Bug 1888862: [4.6] set servicesSubnet correctly in dual-stack clusters

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,8 +21,10 @@ servingInfo:
       keyFile: /etc/kubernetes/secrets/kube-apiserver-lb-server.key
     - certFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.crt
       keyFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.key
-{{if .ServiceCIDR | len | ne 0}}
-servicesSubnet: {{index .ServiceCIDR 0}}{{end}}
+{{- if .ServiceCIDR | len}}
+servicesSubnet: {{index .ServiceCIDR 0 -}}
+{{- if .ServiceCIDR | len | eq 2}},{{index .ServiceCIDR 1}}{{end -}}
+{{- end}}
 admission:
   pluginConfig:
     {{if .ServiceCIDR }}
@@ -53,6 +55,9 @@ apiServerArguments:
     - "ServiceNodeExclusion=true"
     - "SCTPSupport=true"
     - "LegacyNodeRoleBehavior=false"
+{{- if .ServiceCIDR | len | eq 2}}
+    - "IPv6DualStack=true"
+{{- end}}
   kubelet-certificate-authority:
     - /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
   kubelet-client-certificate:

--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,6 @@ require (
 	k8s.io/client-go v0.19.0
 	k8s.io/component-base v0.19.0
 	k8s.io/klog/v2 v2.3.0
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/kube-storage-version-migrator v0.0.3
 )

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -1,10 +1,15 @@
 package network
 
 import (
-	"net"
+	"fmt"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilnet "k8s.io/utils/net"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/network"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -37,13 +42,13 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 		errs = append(errs, err)
 	}
 
-	serviceCIDR, err := network.GetServiceCIDR(listers.NetworkLister, recorder)
+	serviceCIDRs, err := GetServiceCIDRs(listers.NetworkLister, recorder)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
 	// If we weren't able to retrieve cidrs, then return the previous configuration
-	if len(errs) > 0 || len(clusterCIDRs) == 0 || len(serviceCIDR) == 0 {
+	if len(errs) > 0 || len(clusterCIDRs) == 0 || len(serviceCIDRs) == 0 {
 		previouslyObservedConfig := map[string]interface{}{}
 		unstructured.SetNestedMap(previouslyObservedConfig, admissionControllerConfig.Object, configPath...)
 		return previouslyObservedConfig, errs
@@ -59,10 +64,9 @@ func ObserveRestrictedCIDRs(genericListers configobserver.Listers, recorder even
 	//          restrictedCIDRs:
 	//            - 10.3.0.0/16 # ServiceCIDR
 	//            - 10.2.0.0/16 # ClusterCIDR
-	restrictedCIDRs := clusterCIDRs
-	if len(serviceCIDR) > 0 {
-		restrictedCIDRs = append(restrictedCIDRs, serviceCIDR)
-	}
+	var restrictedCIDRs []string
+	restrictedCIDRs = append(restrictedCIDRs, clusterCIDRs...)
+	restrictedCIDRs = append(restrictedCIDRs, serviceCIDRs...)
 
 	if err := unstructured.SetNestedStringSlice(admissionControllerConfig.Object, restrictedCIDRs, "restrictedCIDRs"); err != nil {
 		errs = append(errs, err)
@@ -86,26 +90,21 @@ func ObserveServicesSubnet(genericListers configobserver.Listers, recorder event
 
 	previouslyObservedConfig, errs := extractPreviouslyObservedConfig(existingConfig, servicesSubnetConfigPath, bindAddressConfigPath, bindNetworkConfigPath)
 
-	serviceCIDR, err := network.GetServiceCIDR(listers.NetworkLister, recorder)
+	serviceCIDRs, err := GetServiceCIDRs(listers.NetworkLister, recorder)
 	if err != nil {
 		errs = append(errs, err)
 		return previouslyObservedConfig, errs
 	}
+	servicesSubnet := strings.Join(serviceCIDRs, ",")
 
-	if err := unstructured.SetNestedField(out, serviceCIDR, servicesSubnetConfigPath...); err != nil {
+	if err := unstructured.SetNestedField(out, servicesSubnet, servicesSubnetConfigPath...); err != nil {
 		errs = append(errs, err)
 	}
 	bindAddress := "0.0.0.0:6443"
 	bindNetwork := "tcp4"
-	// TODO: only do this in the single-stack IPv6 case once network.GetServiceCIDR()
-	// supports dual-stack
-	if serviceCIDR != "" {
-		if ip, _, err := net.ParseCIDR(serviceCIDR); err != nil {
-			errs = append(errs, err)
-		} else if ip.To4() == nil {
-			bindAddress = "[::]:6443"
-			bindNetwork = "tcp6"
-		}
+	if len(serviceCIDRs) == 1 && utilnet.IsIPv6CIDRString(serviceCIDRs[0]) {
+		bindAddress = "[::]:6443"
+		bindNetwork = "tcp6"
 	}
 	if err := unstructured.SetNestedField(out, bindAddress, bindAddressConfigPath...); err != nil {
 		errs = append(errs, err)
@@ -244,4 +243,25 @@ func extractPreviouslyObservedConfig(existing map[string]interface{}, paths ...[
 		}
 	}
 	return previous, errs
+}
+
+// GetServiceCIDRs reads the service IP ranges from the global network configuration resource. Emits events if CIDRs are not found.
+// Copied from library-go master.
+func GetServiceCIDRs(lister configlistersv1.NetworkLister, recorder events.Recorder) ([]string, error) {
+	network, err := lister.Get("cluster")
+	if errors.IsNotFound(err) {
+		recorder.Warningf("GetServiceCIDRFailed", "Required networks.%s/cluster not found", configv1.GroupName)
+		return nil, nil
+	}
+	if err != nil {
+		recorder.Warningf("GetServiceCIDRFailed", "error getting networks.%s/cluster: %v", configv1.GroupName, err)
+		return nil, err
+	}
+
+	if len(network.Status.ServiceNetwork) == 0 || len(network.Status.ServiceNetwork[0]) == 0 {
+		recorder.Warningf("GetServiceCIDRFailed", "Required status.serviceNetwork field is not set in networks.%s/cluster", configv1.GroupName)
+		return nil, fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
+	}
+
+	return network.Status.ServiceNetwork, nil
 }


### PR DESCRIPTION
In a dual-stack cluster, kube-apiserver needs to know about both service CIDR ranges.

Backport of #986. Rather than also backporting the library-go portion this just imports the new 4.6 library-go function.