### PR TITLE
Bug 1888861: set servicesSubnet correctly in dual-stack clusters

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -21,8 +21,10 @@ servingInfo:
       keyFile: /etc/kubernetes/secrets/kube-apiserver-lb-server.key
     - certFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.crt
       keyFile: /etc/kubernetes/secrets/kube-apiserver-internal-lb-server.key
-{{if .ServiceCIDR | len | ne 0}}
-servicesSubnet: {{index .ServiceCIDR 0}}{{end}}
+{{- if .ServiceCIDR | len}}
+servicesSubnet: {{index .ServiceCIDR 0 -}}
+{{- if .ServiceCIDR | len | eq 2}},{{index .ServiceCIDR 1}}{{end -}}
+{{- end}}
 admission:
   pluginConfig:
     {{if .ServiceCIDR }}
@@ -53,6 +55,9 @@ apiServerArguments:
     - "ServiceNodeExclusion=true"
     - "SCTPSupport=true"
     - "LegacyNodeRoleBehavior=false"
+{{- if .ServiceCIDR | len | eq 2}}
+    - "IPv6DualStack=true"
+{{- end}}
   kubelet-certificate-authority:
     - /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
   kubelet-client-certificate:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openshift/api v0.0.0-20200929165121-b7210d15c07d
 	github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
-	github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7
+	github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,6 @@ require (
 	k8s.io/client-go v0.19.0
 	k8s.io/component-base v0.19.0
 	k8s.io/klog/v2 v2.3.0
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/kube-storage-version-migrator v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7 h1:mO
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rfjtc+o+jVG/29Aclnf3XIF7akxXvadwR0=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
-github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7 h1:GpzroZdyrAqJgJw4cvgPMgrbpdhxODliIh6h3zlt3Aw=
-github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
+github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe h1:m7JIlGuocsPkfaTxhs7QhJH1K8kFaQpxmxnBTgpv0+Q=
+github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/observe_network.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/network/observe_network.go
@@ -40,24 +40,24 @@ func GetClusterCIDRs(lister configlistersv1.NetworkLister, recorder events.Recor
 	return clusterCIDRs, nil
 }
 
-// GetServiceCIDR reads the service IP range from the global network configuration resource. Emits events if CIDRs are not found.
-func GetServiceCIDR(lister configlistersv1.NetworkLister, recorder events.Recorder) (string, error) {
+// GetServiceCIDRs reads the service IP ranges from the global network configuration resource. Emits events if CIDRs are not found.
+func GetServiceCIDRs(lister configlistersv1.NetworkLister, recorder events.Recorder) ([]string, error) {
 	network, err := lister.Get("cluster")
 	if errors.IsNotFound(err) {
 		recorder.Warningf("GetServiceCIDRFailed", "Required networks.%s/cluster not found", configv1.GroupName)
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
 		recorder.Warningf("GetServiceCIDRFailed", "error getting networks.%s/cluster: %v", configv1.GroupName, err)
-		return "", err
+		return nil, err
 	}
 
 	if len(network.Status.ServiceNetwork) == 0 || len(network.Status.ServiceNetwork[0]) == 0 {
 		recorder.Warningf("GetServiceCIDRFailed", "Required status.serviceNetwork field is not set in networks.%s/cluster", configv1.GroupName)
-		return "", fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
+		return nil, fmt.Errorf("networks.%s/cluster: status.serviceNetwork not found", configv1.GroupName)
 	}
 
-	return network.Status.ServiceNetwork[0], nil
+	return network.Status.ServiceNetwork, nil
 }
 
 // GetExternalIPPolicy retrieves the ExternalIPPolicy for the cluster.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/o
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
-# github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7
+# github.com/openshift/library-go v0.0.0-20201019155101-ee5a7c478ffe
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
In a dual-stack cluster, kube-apiserver needs to know about both service CIDR ranges.

I considered just ignoring the bootstrap config, since we don't currently ever need dual-stack services to work at bootstrap time, but maybe we will in the future? (Note that for the runtime config we require the user to enable the feature gate explicitly via an install manifest, since it's still alpha, but it's difficult to figure out if they have done that from the bootstrap code so I just enabled it unconditionally in the bootstrap config if they specified dual-stack service CIDRs.)

/hold
depends on https://github.com/openshift/library-go/pull/925
