### PR TITLE
Bug 1889308: Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   initContainers:
   - name: setup
     terminationMessagePolicy: FallbackToLogsOnError

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -216,6 +216,7 @@ spec:
         cpu: 10m
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1310,6 +1310,7 @@ spec:
         cpu: 10m
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy we should always set `dnsPolicy: ClusterFirstWithHostNet` when we have `hostNetwork: true`. 

/assign @sttts 