### PR TITLE
connectivitycheckcontroller: disable by default

### DIFF
--- a/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -54,7 +54,7 @@ func NewKubeAPIServerConnectivityCheckController(
 				configInformers.Config().V1().Infrastructures().Informer(),
 			},
 			recorder,
-			true,
+			false,
 		),
 	}
 	generator := &connectivityCheckTemplateProvider{


### PR DESCRIPTION
Turning off again as it is preventing 4.6.0 -> 4.7 from completing successfully.