### PR TITLE
Restrict log permissions

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -25,7 +25,7 @@ spec:
     args:
     - |
       echo -n "Fixing audit permissions."
-      chmod 0700 /var/log/kube-apiserver
+      chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/*
     securityContext:
       privileged: true
   containers:

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -22,7 +22,7 @@ spec:
       args:
       - |
         echo -n "Fixing audit permissions."
-        chmod 0700 /var/log/kube-apiserver
+        chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/*
         echo -n "Waiting for port :6443 and :6080 to be released."
         while [ -n "$(ss -Htan '( sport = 6443 or sport = 6080 )')" ]; do
           echo -n "."

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1116,7 +1116,7 @@ spec:
       args:
       - |
         echo -n "Fixing audit permissions."
-        chmod 0700 /var/log/kube-apiserver
+        chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/*
         echo -n "Waiting for port :6443 and :6080 to be released."
         while [ -n "$(ss -Htan '( sport = 6443 or sport = 6080 )')" ]; do
           echo -n "."


### PR DESCRIPTION
While the current log directory permissions are restrictive and correct,
the file permissions are too permissive and it raises flags on
evaluations of the deployment. Let's instead change the permissions to
0600 which is more appropriate for these types of logs.