### PR TITLE
Revert "Set dnsPolicy ClusterFirstWithHostNet to match hostNetwork"

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -12,7 +12,6 @@ metadata:
 spec:
   restartPolicy: Always
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   initContainers:
   - name: setup
     terminationMessagePolicy: FallbackToLogsOnError

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -216,7 +216,6 @@ spec:
         cpu: 10m
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1310,7 +1310,6 @@ spec:
         cpu: 10m
   terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
This reverts commit 108e3673289e0a6d2c3493c4b711c203daba87cd (#987) which is causing that our static pods have in-cluster dns server injected (see https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/pkg/kubelet/network/dns/dns.go#L348-L352), which is problematic during upgrades. I'm talking with the node team how and if this is going to be solved in kubelet. 

/assign @sttts 