### PR TITLE
Support user provided service-account-signing-key and issuer

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -72,8 +72,13 @@ apiServerArguments:
     - /etc/kubernetes/secrets/aggregator-signer.crt
   service-account-key-file:
     - /etc/kubernetes/secrets/service-account.pub
+  {{- if .UserProvidedBoundSASigningKey}}
+    - /etc/kubernetes/secrets/bound-service-account-signing-key.pub
+  {{- end}}
   service-account-issuer: {{if .ServiceAccountIssuer}}
     - {{.ServiceAccountIssuer}}{{end}}
+  service-account-signing-key-file: {{if .UserProvidedBoundSASigningKey}}
+    - /etc/kubernetes/secrets/bound-service-account-signing-key.key{{end}}
   tls-cert-file:
     - /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   tls-private-key-file:

--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -72,6 +72,8 @@ apiServerArguments:
     - /etc/kubernetes/secrets/aggregator-signer.crt
   service-account-key-file:
     - /etc/kubernetes/secrets/service-account.pub
+  service-account-issuer: {{if .ServiceAccountIssuer}}
+    - {{.ServiceAccountIssuer}}{{end}}
   tls-cert-file:
     - /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   tls-private-key-file:

--- a/bindata/bootkube/manifests/secret-bound-sa-token-signing-key.yaml
+++ b/bindata/bootkube/manifests/secret-bound-sa-token-signing-key.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: next-bound-service-account-signing-key
+  namespace: openshift-kube-apiserver-operator
+  annotations: {{- if .UserProvidedBoundSASigningKey}}
+    "auth.openshift.io/user-supplied-bound-token-key": "true" {{end}}
+data: 
+{{- if .UserProvidedBoundSASigningKey}}
+  service-account.key: {{ .Assets | load "bound-service-account-signing-key.key" | base64 }}
+  service-account.pub: {{ .Assets | load "bound-service-account-signing-key.pub" | base64 }}
+{{- end}}

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -147,6 +147,8 @@ type TemplateData struct {
 	BindNetwork string
 
 	ServiceAccountIssuer string
+
+	UserProvidedBoundSASigningKey bool
 }
 
 // Run contains the logic of the render command.
@@ -176,6 +178,11 @@ func (r *renderOpts) Run() error {
 			if err := discoverServiceAccountIssuer(clusterAuthFileData, &renderConfig); err != nil {
 				return fmt.Errorf("unable to parse service-account issuers from config %q: %v", r.clusterAuthFile, err)
 			}
+		}
+	}
+	if _, err := os.Stat(filepath.Join(r.generic.AssetInputDir, "bound-service-account-signing-key.key")); err == nil {
+		if _, err := os.Stat(filepath.Join(r.generic.AssetInputDir, "bound-service-account-signing-key.pub")); err == nil {
+			renderConfig.UserProvidedBoundSASigningKey = true
 		}
 	}
 	if len(renderConfig.ClusterCIDR) > 0 {


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/CO-1266

render: read service-account-issuer from authentication config file

We need to support user-provided service-account-issuer for supporting user's pre existing IAM OIDC provider.
The user will provider the authentications.config.openshift.io/cluster object with the issuer at install-time
and the bootstrap-kube-apiserver should use that issuer to prevent in divergence from the real kube-apiserver.

So the render command accepts a flag pointing to a file for authentication object, which the render command reads
to extract the issuer from the spec and updates the bootstrap-apiserver-config.

 render: accept user provided bound-service-account-signing keys for kube-apiserver

To support pre-existing IAM OIDC provider on AWS, we need an option to configure the kube-apiserver with user-provided keys for service-account-signing-keys.
This enables that the tokens issued by the cluster's kube-apiserver will be trusted by AWS IAM as setup by the OIDC provider.

When the render sees that the user has provided `bound-service-account-signing-key.{key,pub}`, the renderer configures the
bootstrap kube-apiserver with that specific service-account-signing-key and also creates the `next-bound-service-account-signing-key` secret
which will be pushed to the cluster and used by the kube-apiserver-operator to re-use those user provided keys for in-cluster kube-apiserver.

The [NewBoundSATokenSignerController][NewBoundSATokenSignerController] already suports adopting the secret when the keys are already set, and this allows the kap-o to create all the rest of the
public ConfigMap and operand Secret from this user-provided secret.

[NewBoundSATokenSignerController]: https://github.com/openshift/cluster-kube-apiserver-operator/blob/0cf5528e6410ed723ab9be701d8e9f3e7a50627b/pkg/operator/boundsatokensignercontroller/controller.go#L56-L57

