### PR TITLE
remove priority config openshift-aggregated-api-delegated-auth

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,25 +1,6 @@
 apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
 kind: PriorityLevelConfiguration
 metadata:
-  name: openshift-aggregated-api-delegated-auth
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-spec:
-  limited:
-    assuredConcurrencyShares: 20
-    limitResponse:
-      queuing:
-        handSize: 6
-        queueLengthLimit: 50
-        queues: 16
-      type: Queue
-  type: Limited
----
-apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
-kind: PriorityLevelConfiguration
-metadata:
   name: openshift-control-plane-operators
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"


### PR DESCRIPTION
The `SAR` traffic is being allocated to `exempt` now, so `openshift-aggregated-api-delegated-auth` has been orphaned.