### PR TITLE
Support user provided service-account-signing-key and issuer

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -72,6 +72,13 @@ apiServerArguments:
     - /etc/kubernetes/secrets/aggregator-signer.crt
   service-account-key-file:
     - /etc/kubernetes/secrets/service-account.pub
+  {{- if .UserProvidedBoundSASigningKey}}
+    - /etc/kubernetes/secrets/bound-service-account-signing-key.pub
+  {{- end}}
+  service-account-issuer: {{if .ServiceAccountIssuer}}
+    - {{.ServiceAccountIssuer}}{{end}}
+  service-account-signing-key-file: {{if .UserProvidedBoundSASigningKey}}
+    - /etc/kubernetes/secrets/bound-service-account-signing-key.key{{end}}
   tls-cert-file:
     - /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   tls-private-key-file:

--- a/bindata/bootkube/manifests/secret-bound-sa-token-signing-key.yaml
+++ b/bindata/bootkube/manifests/secret-bound-sa-token-signing-key.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: next-bound-service-account-signing-key
+  namespace: openshift-kube-apiserver-operator
+  annotations: {{- if .UserProvidedBoundSASigningKey}}
+    "auth.openshift.io/user-supplied-bound-token-key": "true" {{end}}
+data: 
+{{- if .UserProvidedBoundSASigningKey}}
+  service-account.key: {{ .Assets | load "bound-service-account-signing-key.key" | base64 }}
+  service-account.pub: {{ .Assets | load "bound-service-account-signing-key.pub" | base64 }}
+{{- end}}

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,6 +39,7 @@ type renderOpts struct {
 	etcdServerURLs    []string
 	etcdServingCA     string
 	clusterConfigFile string
+	clusterAuthFile   string
 }
 
 // NewRenderCommand creates a render command.
@@ -79,6 +81,7 @@ func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&r.etcdServerURLs, "manifest-etcd-server-urls", r.etcdServerURLs, "The etcd server URL, comma separated.")
 	fs.StringVar(&r.etcdServingCA, "manifest-etcd-serving-ca", r.etcdServingCA, "The etcd serving CA.")
 	fs.StringVar(&r.clusterConfigFile, "cluster-config-file", r.clusterConfigFile, "Openshift Cluster API Config file.")
+	fs.StringVar(&r.clusterAuthFile, "cluster-auth-file", r.clusterAuthFile, "Openshift Cluster Authentication API Config file.")
 }
 
 // Validate verifies the inputs.
@@ -142,6 +145,10 @@ type TemplateData struct {
 
 	// BindNetwork is the network (tcp4 or tcp6) to bind to
 	BindNetwork string
+
+	ServiceAccountIssuer string
+
+	UserProvidedBoundSASigningKey bool
 }
 
 // Run contains the logic of the render command.
@@ -160,6 +167,22 @@ func (r *renderOpts) Run() error {
 		}
 		if err = discoverCIDRs(clusterConfigFileData, &renderConfig); err != nil {
 			return fmt.Errorf("unable to parse restricted CIDRs from config %q: %v", r.clusterConfigFile, err)
+		}
+	}
+	if len(r.clusterAuthFile) > 0 {
+		clusterAuthFileData, err := ioutil.ReadFile(r.clusterAuthFile)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to load authentication config: %v", err)
+		}
+		if len(clusterAuthFileData) > 0 {
+			if err := discoverServiceAccountIssuer(clusterAuthFileData, &renderConfig); err != nil {
+				return fmt.Errorf("unable to parse service-account issuers from config %q: %v", r.clusterAuthFile, err)
+			}
+		}
+	}
+	if _, err := os.Stat(filepath.Join(r.generic.AssetInputDir, "bound-service-account-signing-key.key")); err == nil {
+		if _, err := os.Stat(filepath.Join(r.generic.AssetInputDir, "bound-service-account-signing-key.pub")); err == nil {
+			renderConfig.UserProvidedBoundSASigningKey = true
 		}
 	}
 	if len(renderConfig.ClusterCIDR) > 0 {
@@ -281,6 +304,27 @@ func mustReadTemplateFile(fname string) genericrenderoptions.Template {
 		panic(fmt.Sprintf("Failed to load %q: %v", fname, err))
 	}
 	return genericrenderoptions.Template{FileName: fname, Content: bs}
+}
+
+func discoverServiceAccountIssuer(clusterAuthFileData []byte, renderConfig *TemplateData) error {
+	configJson, err := yaml.YAMLToJSON(clusterAuthFileData)
+	if err != nil {
+		return err
+	}
+	clusterConfigObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, configJson)
+	if err != nil {
+		return err
+	}
+	clusterConfig, ok := clusterConfigObj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("unexpected object in %t", clusterConfigObj)
+	}
+	issuer, found, err := unstructured.NestedString(
+		clusterConfig.Object, "spec", "serviceAccountIssuer")
+	if found && err == nil {
+		renderConfig.ServiceAccountIssuer = issuer
+	}
+	return err
 }
 
 func discoverCIDRs(clusterConfigFileData []byte, renderConfig *TemplateData) error {

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -129,6 +129,43 @@ func TestDiscoverCIDRsFromClusterAPI(t *testing.T) {
 	}
 }
 
+func TestDiscoverServiceAccountIssuer(t *testing.T) {
+	tests := []struct {
+		config string
+
+		issuer string
+	}{{
+		config: `apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec: {}`,
+	}, {
+		config: `apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec:
+  serviceAccountIssuer: https://test.dummy.url`,
+		issuer: "https://test.dummy.url",
+	}}
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			renderConfig := TemplateData{
+				LockHostPath:   "",
+				EtcdServerURLs: []string{""},
+				EtcdServingCA:  "",
+			}
+			if err := discoverServiceAccountIssuer([]byte(test.config), &renderConfig); err != nil {
+				t.Fatalf("failed to discoverServiceAccountIssuer: %v", err)
+			}
+			if !reflect.DeepEqual(renderConfig.ServiceAccountIssuer, test.issuer) {
+				t.Fatalf("Got: %s, expected: %v", renderConfig.ServiceAccountIssuer, test.issuer)
+			}
+		})
+	}
+}
+
 func TestDiscoverCIDRs(t *testing.T) {
 	testCase := []struct {
 		config []byte
@@ -272,6 +309,190 @@ func TestRenderCommand(t *testing.T) {
 				}
 				if cfg.ServicesSubnet != "fd02::/112,172.30.0.0/16" {
 					return fmt.Errorf("incorrect dual-stack ServicesSubnet: %s", cfg.ServicesSubnet)
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 4 checks service account issuer when authentication no exists",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--cluster-auth-file=" + filepath.Join(assetsInputDir, "authentication.yaml"),
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 5 checks service account issuer when authentication exists but empty",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--cluster-auth-file=" + filepath.Join(assetsInputDir, "authentication.yaml"),
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := ``
+				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 6 checks service account issuer when authentication exists but empty spec",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--cluster-auth-file=" + filepath.Join(assetsInputDir, "authentication.yaml"),
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := `apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec: {}`
+				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 7 checks service account issuer when authentication spec has issuer set",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--cluster-auth-file=" + filepath.Join(assetsInputDir, "authentication.yaml"),
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := `apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec:
+  serviceAccountIssuer: https://test.dummy.url`
+				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-issuer"]) == 0 {
+					return fmt.Errorf("expected the service-account-issuer to be set, but it was empty")
+				}
+				if !reflect.DeepEqual(cfg.APIServerArguments["service-account-issuer"], kubecontrolplanev1.Arguments([]string{"https://test.dummy.url"})) {
+					return fmt.Errorf("expected the service-account-issuer to be [ https://test.dummy.url ], but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 8 no user provided bound-sa-signing-keys",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 9 user provided bound-sa-signing-key only no public part",
+			args: []string{
+				"--asset-input-dir=" + filepath.Join(assetsInputDir, "0"),
+				"--templates-input-dir=" + templateDir,
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := `DUMMY DATA`
+				if err := os.Mkdir(filepath.Join(assetsInputDir, "0"), 0700); err != nil {
+					return err
+				}
+				return ioutil.WriteFile(filepath.Join(assetsInputDir, "0", "bound-service-account-signing-key.key"), []byte(data), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 10 user provided bound-sa-signing-key only public part",
+			args: []string{
+				"--asset-input-dir=" + filepath.Join(assetsInputDir, "1"),
+				"--templates-input-dir=" + templateDir,
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := `DUMMY DATA`
+				if err := os.Mkdir(filepath.Join(assetsInputDir, "1"), 0700); err != nil {
+					return err
+				}
+				return ioutil.WriteFile(filepath.Join(assetsInputDir, "1", "bound-service-account-signing-key.pub"), []byte(data), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
+					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "scenario 11 user provided bound-sa-signing-key and public part",
+			args: []string{
+				"--asset-input-dir=" + filepath.Join(assetsInputDir, "2"),
+				"--templates-input-dir=" + templateDir,
+				"--asset-output-dir=",
+				"--config-output-file=",
+			},
+			setupFunction: func() error {
+				data := `DUMMY DATA`
+				if err := os.Mkdir(filepath.Join(assetsInputDir, "2"), 0700); err != nil {
+					return err
+				}
+				if err := ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.key"), []byte(data), 0644); err != nil {
+					return err
+				}
+				if err := ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.pub"), []byte(data), 0644); err != nil {
+					return err
+				}
+				return nil
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				if len(cfg.APIServerArguments["service-account-signing-key-file"]) == 0 {
+					return fmt.Errorf("expected the service-account-issuer to be set, but it was empty")
+				}
+				if !reflect.DeepEqual(cfg.APIServerArguments["service-account-signing-key-file"], kubecontrolplanev1.Arguments([]string{"/etc/kubernetes/secrets/bound-service-account-signing-key.key"})) {
+					return fmt.Errorf("expected the service-account-issuer to be [ /etc/kubernetes/secrets/bound-service-account-signing-key.key ], but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				}
+				if !reflect.DeepEqual(
+					cfg.APIServerArguments["service-account-key-file"],
+					kubecontrolplanev1.Arguments([]string{"/etc/kubernetes/secrets/service-account.pub", "/etc/kubernetes/secrets/bound-service-account-signing-key.pub"}),
+				) {
+					return fmt.Errorf("expected the service-account-issuer to be [ /etc/kubernetes/secrets/service-account.pub , /etc/kubernetes/secrets/bound-service-account-signing-key.pub ], but it was %s", cfg.APIServerArguments["service-account-key-file"])
 				}
 				return nil
 			},

--- a/pkg/operator/boundsatokensignercontroller/controller.go
+++ b/pkg/operator/boundsatokensignercontroller/controller.go
@@ -153,6 +153,9 @@ func (c *BoundSATokenSignerController) ensurePublicKeyConfigMap(ctx context.Cont
 	}
 
 	currPublicKey := string(operatorSecret.Data[PublicKeyKey])
+	if currPublicKey == "" {
+		return fmt.Errorf("no current %s found, one must be set in %s/%s secret", PublicKeyKey, operatorNamespace, NextSigningKeySecretName)
+	}
 	hasKey := configMapHasValue(configMap, currPublicKey)
 	if !hasKey {
 		// Increment until a unique name is found to ensure that the new public key


### PR DESCRIPTION
Revert the revert https://github.com/openshift/cluster-kube-apiserver-operator/pull/1011 therefore re-adding the changes from https://github.com/openshift/cluster-kube-apiserver-operator/pull/1006

And to fix the cause of the revert:

### boundsatokensignercontroller: enure that empty public key is not syned to bound-sa-token-signing-certs

in case the next-bound-service-account-signing-key has empty contents, for example
- when user want to rotate the keys and emptied the keys of the secret for operator to recreate them.
- when on bootstrap the render creates an empty secret as no user-provided keys exist, prompting the operator to create
  then in-cluster.

the bound-sa-token-signing-certs must wait for the public key to exist/non-empty before adding it to the ConfigMap, otherwise
there is failure starting kube-apiserver,

```
Error: error reading public key file /etc/kubernetes/static-pod-resources/configmaps/bound-sa-token-signing-certs/service-account-001.pub: data does not contain any valid RSA or ECDSA public keys
```

because the ConfigMap has a key with empty data like,
> https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/981/pull-ci-openshift-cluster-monitoring-operator-master-e2e-agnostic/1330864689164324864/artifacts/e2e-agnostic/gather-extra/configmaps.json

```
        {
            "apiVersion": "v1",
            "data": {
                "service-account-001.pub": "",
                "service-account-002.pub": "-----BEGIN RSA PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqlOait7Q4okCBEZJ1NNn\nHtNQTC/i2bL9p7cTwbfDNbUJ/5rfYGPSCpyREckIfQb5qlMQa9vc8XI0tC5LGjAK\nTwUEfC/Z3I0kxcx71sDDt/qmtmuDtsauaOtFAyuNG28lULI58Jou6MsYAtADtoia\n9h+rpyQhCBIwmsNvAQBrijwv+eIRQXPEhnCFpVbB4sh2TpH7P0LjcRIDD6ZD2HmV\nRKAuKsWqwR2tRXbLqSvdMRGgOzGmqbA1IkG2xaOQmHuYg5GUkec6lRcYErE4I8MG\nYxFbtbGI/r6eNn+mkktNPk6od4Cz83zd+Z2+tSbvxBzkpnIOxd413FwGNgAOc1WO\nIwIDAQAB\n-----END RSA PUBLIC KEY-----\n"
            },
            "kind": "ConfigMap",
            "metadata": {
                "name": "bound-sa-token-signing-certs",
                "namespace": "openshift-config-managed",
                "resourceVersion": "7023",
                "selfLink": "/api/v1/namespaces/openshift-config-managed/configmaps/bound-sa-token-signing-certs",
                "uid": "0f34f86e-3b3a-4a9c-8ed2-1eaae3dcd243"
            }
        },
```

xref: https://issues.redhat.com/browse/CO-1266