### PR TITLE
Always set service-account-issuer flag

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -37,6 +37,8 @@ admission:
         - {{.}}{{end}}
     {{end}}
 apiServerArguments:
+  api-audiences:
+  - {{ or .ServiceAccountIssuer "https://kubernetes.default.svc" }}
   client-ca-file:
     - /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
   etcd-cafile:
@@ -75,10 +77,14 @@ apiServerArguments:
   {{- if .UserProvidedBoundSASigningKey}}
     - /etc/kubernetes/secrets/bound-service-account-signing-key.pub
   {{- end}}
-  service-account-issuer: {{if .ServiceAccountIssuer}}
-    - {{.ServiceAccountIssuer}}{{end}}
-  service-account-signing-key-file: {{if .UserProvidedBoundSASigningKey}}
-    - /etc/kubernetes/secrets/bound-service-account-signing-key.key{{end}}
+  service-account-issuer:
+    - {{ or .ServiceAccountIssuer "https://kubernetes.default.svc" }}
+  service-account-signing-key-file:
+  {{- if .UserProvidedBoundSASigningKey }}
+    - /etc/kubernetes/secrets/bound-service-account-signing-key.key
+  {{- else }}
+    - /etc/kubernetes/secrets/service-account.key # FIXME: wire a real default key
+  {{ end }}
   tls-cert-file:
     - /etc/kubernetes/secrets/kube-apiserver-service-network-server.crt
   tls-private-key-file:

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -323,8 +323,10 @@ func TestRenderCommand(t *testing.T) {
 				"--config-output-file=",
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				issuer := cfg.APIServerArguments["service-account-issuer"]
+				expectedIssuer := kubecontrolplanev1.Arguments{"https://kubernetes.default.svc"}
+				if !reflect.DeepEqual(issuer, expectedIssuer) {
+					return fmt.Errorf("expected the service-account-issuer to be %q, but it was %q", expectedIssuer, issuer)
 				}
 				return nil
 			},
@@ -343,8 +345,10 @@ func TestRenderCommand(t *testing.T) {
 				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				issuer := cfg.APIServerArguments["service-account-issuer"]
+				expectedIssuer := kubecontrolplanev1.Arguments{"https://kubernetes.default.svc"}
+				if !reflect.DeepEqual(issuer, expectedIssuer) {
+					return fmt.Errorf("expected the service-account-issuer to be %q, but it was %q", expectedIssuer, issuer)
 				}
 				return nil
 			},
@@ -367,8 +371,10 @@ spec: {}`
 				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-issuer"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				issuer := cfg.APIServerArguments["service-account-issuer"]
+				expectedIssuer := kubecontrolplanev1.Arguments{"https://kubernetes.default.svc"}
+				if !reflect.DeepEqual(issuer, expectedIssuer) {
+					return fmt.Errorf("expected the service-account-issuer to be %q, but it was %q", expectedIssuer, issuer)
 				}
 				return nil
 			},
@@ -410,8 +416,11 @@ spec:
 				"--config-output-file=",
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				issuerKeyFile := cfg.APIServerArguments["service-account-signing-key-file"]
+				// FIXME: Update when we wire a real default key
+				expectedIssuerKeyFile := kubecontrolplanev1.Arguments{"/etc/kubernetes/secrets/service-account.key"}
+				if !reflect.DeepEqual(issuerKeyFile, expectedIssuerKeyFile) {
+					return fmt.Errorf("expected the service-account-signing-key-file to be %q, but it was %q", expectedIssuerKeyFile, issuerKeyFile)
 				}
 				return nil
 			},
@@ -432,8 +441,11 @@ spec:
 				return ioutil.WriteFile(filepath.Join(assetsInputDir, "0", "bound-service-account-signing-key.key"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				issuerKeyFile := cfg.APIServerArguments["service-account-signing-key-file"]
+				// FIXME: Update when we wire a real default key
+				expectedIssuerKeyFile := kubecontrolplanev1.Arguments{"/etc/kubernetes/secrets/service-account.key"}
+				if !reflect.DeepEqual(issuerKeyFile, expectedIssuerKeyFile) {
+					return fmt.Errorf("expected the service-account-signing-key-file to be %q, but it was %q", expectedIssuerKeyFile, issuerKeyFile)
 				}
 				return nil
 			},
@@ -454,8 +466,11 @@ spec:
 				return ioutil.WriteFile(filepath.Join(assetsInputDir, "1", "bound-service-account-signing-key.pub"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
-				if len(cfg.APIServerArguments["service-account-signing-key-file"]) > 0 {
-					return fmt.Errorf("expected the service-account-issuer to be empty, but it was %s", cfg.APIServerArguments["service-account-signing-key-file"])
+				issuerKeyFile := cfg.APIServerArguments["service-account-signing-key-file"]
+				// FIXME: Update when we wire a real default key
+				expectedIssuerKeyFile := kubecontrolplanev1.Arguments{"/etc/kubernetes/secrets/service-account.key"}
+				if !reflect.DeepEqual(issuerKeyFile, expectedIssuerKeyFile) {
+					return fmt.Errorf("expected the service-account-signing-key-file to be %q, but it was %q", expectedIssuerKeyFile, issuerKeyFile)
 				}
 				return nil
 			},


### PR DESCRIPTION
The flag is required since kube 1.20

To be follower by a BZ to wire the proper key to the installer but we need to unblock the rebase.

/cc @sttts @marun 