### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_00_cr-anyuid.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-anyuid.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:anyuid
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-hostaccess.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-hostaccess.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:hostaccess
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-hostmount-anyuid.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-hostmount-anyuid.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:hostmount
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-hostnetwork.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-hostnetwork.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:hostnetwork
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-nonroot.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-nonroot.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:nonroot
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-privileged.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-privileged.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:privileged
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_cr-restricted.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_cr-restricted.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: system:openshift:scc:restricted
 rules:
 - apiGroups:

--- a/manifests/0000_20_kube-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
@@ -19,8 +19,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: anyuid provides all features of the restricted SCC
-      but allows users to run with any UID and any GID.
+    kubernetes.io/description: anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID.
+    include.release.openshift.io/single-node-production-edge: "true"
   name: anyuid
 priority: 10
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
@@ -18,10 +18,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: 'hostaccess allows access to all host namespaces but
-      still requires pods to be run with a UID and SELinux context that are allocated
-      to the namespace. WARNING: this SCC allows host access to namespaces, file systems,
-      and PIDS.  It should only be used by trusted pods.  Grant with caution.'
+    kubernetes.io/description: 'hostaccess allows access to all host namespaces but still requires pods to be run with a UID and SELinux context that are allocated to the namespace. WARNING: this SCC allows host access to namespaces, file systems, and PIDS.  It should only be used by trusted pods.  Grant with caution.'
+    include.release.openshift.io/single-node-production-edge: "true"
   name: hostaccess
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
@@ -23,6 +23,7 @@ metadata:
       restricted SCC but allows host mounts and any UID by a pod.  This is primarily
       used by the persistent volume recycler. WARNING: this SCC allows host file
       system access as any UID, including UID 0.  Grant with caution.
+    include.release.openshift.io/single-node-production-edge: "true"
   name: hostmount-anyuid
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
@@ -18,9 +18,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: hostnetwork allows using host networking and host ports
-      but still requires pods to be run with a UID and SELinux context that are allocated
-      to the namespace.
+    kubernetes.io/description: hostnetwork allows using host networking and host ports but still requires pods to be run with a UID and SELinux context that are allocated to the namespace.
+    include.release.openshift.io/single-node-production-edge: "true"
   name: hostnetwork
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
@@ -18,9 +18,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: nonroot provides all features of the restricted SCC
-      but allows users to run with any non-root UID.  The user must specify the UID
-      or it must be specified on the by the manifest of the container runtime.
+    kubernetes.io/description: nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.  The user must specify the UID or it must be specified on the by the manifest of the container runtime.
+    include.release.openshift.io/single-node-production-edge: "true"
   name: nonroot
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-privileged.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-privileged.yaml
@@ -24,10 +24,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: 'privileged allows access to all privileged and host
-      features and the ability to run as any user, any group, any fsGroup, and with
-      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
-      only for cluster administration. Grant with caution.'
+    kubernetes.io/description: 'privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context.  WARNING: this is the most relaxed SCC and should be used only for cluster administration. Grant with caution.'
+    include.release.openshift.io/single-node-production-edge: "true"
   name: privileged
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
@@ -19,9 +19,8 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    kubernetes.io/description: restricted denies access to all host features and requires
-      pods to be run with a UID, and SELinux context that are allocated to the namespace.  This
-      is the most restrictive SCC and it is used by default for authenticated users.
+    kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
+    include.release.openshift.io/single-node-production-edge: "true"
   name: restricted
 priority:
 readOnlyRootFilesystem: false

--- a/manifests/0000_20_kube-apiserver-operator_01_operator.cr.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_01_operator.cr.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_20_kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_02_service.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: kube-apiserver-operator
   name: metrics

--- a/manifests/0000_20_kube-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_03_configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/0000_20_kube-apiserver-operator_04_clusterrolebinding.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_04_clusterrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_20_kube-apiserver-operator_05_serviceaccount.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_05_serviceaccount.yaml
@@ -9,4 +9,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_07_clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:

--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   limited:
     assuredConcurrencyShares: 10
@@ -25,6 +26,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser
@@ -51,6 +53,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser

--- a/manifests/0000_90_kube-apiserver-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_01_prometheusrole.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_kube-apiserver-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_02_prometheusrolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -38,6 +39,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
   - name: cluster-version

--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -26,6 +27,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -46,6 +48,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -123,6 +126,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
   - name: apiserver-requests-in-flight


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.