### PR TITLE
switch to v1beta1 for the p&f APIs

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
 kind: PriorityLevelConfiguration
 metadata:
   name: openshift-control-plane-operators
@@ -17,7 +17,7 @@ spec:
       type: Queue
   type: Limited
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
 kind: FlowSchema
 metadata:
   name: openshift-monitoring-metrics
@@ -43,7 +43,7 @@ spec:
         name: prometheus-k8s
         namespace: openshift-monitoring
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1alpha1
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
 kind: FlowSchema
 metadata:
   name: openshift-kube-apiserver-operator


### PR DESCRIPTION
Important Note: We support upgrade and downgrade - 4.7 to 4.6 downgrade would behave very badly (in a skew case). So we should NOT back port to 4.7
