### PR TITLE
Bug 1920159: kube-apiservers overstate steady-state CPU needs slightly

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -58,7 +58,7 @@ spec:
     resources:
       requests:
         memory: 1Gi
-        cpu: 300m
+        cpu: 265m
     ports:
     - containerPort: 6443
     volumeMounts:
@@ -120,7 +120,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
@@ -143,7 +143,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
@@ -160,7 +160,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
   - name: kube-apiserver-check-endpoints
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1152,7 +1152,7 @@ spec:
     resources:
       requests:
         memory: 1Gi
-        cpu: 300m
+        cpu: 265m
     ports:
     - containerPort: 6443
     volumeMounts:
@@ -1214,7 +1214,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
@@ -1237,7 +1237,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
@@ -1254,7 +1254,7 @@ spec:
     resources:
       requests:
         memory: 50Mi
-        cpu: 10m
+        cpu: 5m
   - name: kube-apiserver-check-endpoints
     image: ${OPERATOR_IMAGE}
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
The kube-apiserver is one of our most dynamic scaling components,
but the majority of clusters have a base load that is fairly
predictable of around 300 millicore. In order to get more headroom
for smaller clusters, adjust the out of the box request to a more
accurate default. All of the sidecars were measured in heavily
loaded production clusters as taking less than 5 millicore each,
and the core kube-apiserver is tweaked slightly.  CPU is burstable
so the apiserver will grow as necessary into slack capacity, while
still yielding to etcd on saturated masters.

/hold

Testing multiple changes together