### PR TITLE
Bug 1949593: rename DeprecatedAPIInUse alert to APIRemovedInNextReleaseInUse

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -137,7 +137,7 @@ spec:
         max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,requestKind)[2m:])
   - name: pre-release-lifecycle
     rules:
-      - alert: DeprecatedAPIInUse
+      - alert: APIRemovedInNextReleaseInUse
         annotations:
           message: >-
             Deprecated API that will be removed in the next version is being used. Removing the workload that is using

--- a/test/e2e/deprecated_api_test.go
+++ b/test/e2e/deprecated_api_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/discovery"
 )
 
-func TestDeprecatedAPIInUse(t *testing.T) {
+func TestAPIRemovedInNextReleaseInUse(t *testing.T) {
 	t.Run("RemovedRelease", func(t *testing.T) {
 		kubeConfig, err := test.NewClientConfigForTest()
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestDeprecatedAPIInUse(t *testing.T) {
 		expr := func() string {
 			for _, group := range rule.Spec.Groups {
 				for _, rule := range group.Rules {
-					if rule.Alert == "DeprecatedAPIInUse" {
+					if rule.Alert == "APIRemovedInNextReleaseInUse" {
 						return strings.TrimSpace(rule.Expr.StrVal)
 					}
 				}


### PR DESCRIPTION
We don't care about the use of a deprecated API, unless it is being removed in the next release.
Rename the `DeprecatedAPIInUse` alert to `APIRemovedInNextReleaseInUse` to better reflect the intent of the alert.