### PR TITLE
config api-audiences along with SA issuer

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -89,13 +89,17 @@ func observedConfig(
 				"service-account-issuer": []interface{}{
 					newIssuer,
 				},
+				"api-audiences": []interface{}{
+					newIssuer,
+				},
 			},
 		}, errs
 	}
 
-	// if the issuer is not set, rely on the config-overrides.yaml to set it
-	// but configure the jwks-uri to point to the LB so that it does not default to
-	// KAS IP which is not included in the serving certs
+	// if the issuer is not set, rely on the config-overrides.yaml to set both
+	// the issuer and the api-audiences but configure the jwks-uri to point to
+	// the LB so that it does not default to KAS IP which is not included
+	// in the serving certs
 	infrastructureConfig, err := getInfrastructureConfig("cluster")
 	if err != nil {
 		return existingConfig, append(errs, err)

--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer_test.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer_test.go
@@ -143,9 +143,13 @@ func apiConfigForIssuer(issuer string) *kubecontrolplanev1.KubeAPIServerConfig {
 		"service-account-issuer": {
 			issuer,
 		},
+		"api-audiences": {
+			issuer,
+		},
 	}
 	if len(issuer) == 0 {
 		delete(args, "service-account-issuer")
+		delete(args, "api-audiences")
 		args["service-account-jwks-uri"] = kubecontrolplanev1.Arguments{testLBURI}
 	}
 


### PR DESCRIPTION
I noticed that the API audiences were only being configured in the bootstrap phase to match the SA issuer, but during normal runtime, they would be rolled back to the default value.

Make the audiences always match the SA issuer.

/assign @marun 