### PR TITLE
[debug] clientv3 retry

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -97,6 +97,8 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
+      - name: ETCD_CLIENT_DEBUG
+        value: "1"
     securityContext:
       privileged: true
   - name: kube-apiserver-cert-syncer

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1225,6 +1225,8 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
+      - name: ETCD_CLIENT_DEBUG
+        value: "1"
     securityContext:
       privileged: true
   - name: kube-apiserver-cert-syncer


### PR DESCRIPTION
In some circumstances (max retry)[1] we will see retriable errors returned to the caller "etcdserver: leader change".  I am using this PR to ensure kas prints all retry attempts to understand why this happens during upgrade. In the future we should consider this ENV at perhaps an explicit loglevel and or output these logs to `/var/log/` alongside audit when appropriate.

[1] https://github.com/etcd-io/etcd/blob/release-3.4/clientv3/retry_interceptor.go#L92
/hold