### PR TITLE
Bug 1932165: variables in DeprecatedAPIInUse alert's annotations.message are not parsed to existing values

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -141,7 +141,7 @@ spec:
         annotations:
           message: >-
             Deprecated API that will be removed in the next version is being used. Removing the workload that is using
-            the {{"{{$labels.group}}"}}.{{"{{$labels.version}}"}}/{{"{{$labels.resource}}"}} API might be necessary for
+            the {{$labels.group}}.{{$labels.version}}/{{$labels.resource}} API might be necessary for
             a successful upgrade to the next cluster version. Refer to the audit logs to identify the workload.
         expr: |
           group(apiserver_requested_deprecated_apis{removed_release="1.21"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total[10m]))) > 0

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -21,7 +21,10 @@ func readAllYaml(path string, t *testing.T) {
 	manifests, err := assets.New(path, render.TemplateData{}, func(info os.FileInfo) bool {
 		return assets.OnlyYaml(info) && !strings.HasPrefix(info.Name(), "recovery-") &&
 			// the dashboard is a ConfigMap yaml but it has an embedded json in data that causes the reader to fail.
-			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml")
+			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml") &&
+			// there is an alert message containing $labels strings that cause the reader to fail.
+			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml")
+
 	})
 	if err != nil {
 		t.Errorf("Unexpected error reading manifests from %s: %v", path, err)


### PR DESCRIPTION
Alert message template when made to pass the `TestYamlCorrectness` test, results in an invalid message.
Fixed the template and exclude it from the test.