### PR TITLE
bug 1939226: make kube-apiserver readiness checks, check readyz

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -70,7 +70,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: readyz
       initialDelaySeconds: 10
       timeoutSeconds: 10
     env:

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -79,7 +79,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: readyz
       initialDelaySeconds: 10
       timeoutSeconds: 10
     env:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1207,7 +1207,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: readyz
       initialDelaySeconds: 10
       timeoutSeconds: 10
     env:


### PR DESCRIPTION
readyz has different semantics than healthz

/assign @sttts 