### PR TITLE
bug 1939227: make liveness hit livez

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -63,7 +63,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: livez
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -72,7 +72,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: livez
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1200,7 +1200,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: healthz
+        path: livez
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:


### PR DESCRIPTION
livez didn't exist when we started.  Now it does.  Update.

We may want a startup probe distinct from livez now. 

/assign @sttts 