### PR TITLE
Bug 1943804: increases termination timeouts for AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-e2e-encryption-rotation: test-unit
 
 test-e2e-encryption-perf: GO_TEST_PACKAGES :=./test/e2e-encryption-perf/...
 test-e2e-encryption-perf: GO_TEST_FLAGS += -v
-test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 1h
+test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 2h
 test-e2e-encryption-perf: GO_TEST_FLAGS += -p 1
 test-e2e-encryption-perf: test-unit
 .PHONY: test-e2e-encryption-perf

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -14,7 +14,7 @@ spec:
   initContainers:
     - name: setup
       terminationMessagePolicy: FallbackToLogsOnError
-      image: ${IMAGE}
+      image: {{.Image}}
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
@@ -37,7 +37,7 @@ spec:
           cpu: 5m
   containers:
   - name: kube-apiserver
-    image: ${IMAGE}
+    image: {{.Image}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["/bin/bash", "-ec"]
@@ -68,7 +68,7 @@ spec:
             fi
           done
           echo
-          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration=135s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY} --permit-address-sharing
+          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration={{.GracefulTerminationDuration}}s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} {{.Verbosity}} --permit-address-sharing
     resources:
       requests:
         memory: 1Gi
@@ -123,7 +123,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "cert-syncer"]
@@ -146,7 +146,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "cert-regeneration-controller"]
@@ -162,7 +162,7 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
   - name: kube-apiserver-insecure-readyz
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "insecure-readyz"]
@@ -176,7 +176,7 @@ spec:
         memory: 50Mi
         cpu: 5m
   - name: kube-apiserver-check-endpoints
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command:
@@ -228,7 +228,7 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: {{.GracefulTerminationDuration}}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20210503193030-25175d9d392d
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535
-	github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230
+	github.com/openshift/library-go v0.0.0-20210517095020-4f4c86ddf1a7
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535 h1:JGSJhDJiQxq
 github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535/go.mod h1:v5/AYttPCjfqMGC1Ed/vutuDpuXmgWc5O+W9nwQ7EtE=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230 h1:Mr0ac4Z0VO8QQ5uFSVXz2x5egyf+UEP3UkcfaM1wwsI=
-github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210517095020-4f4c86ddf1a7 h1:vp/1PjaCj+b5SUUA/43Gjuww9U4/FvEgFecVjygsrcU=
+github.com/openshift/library-go v0.0.0-20210517095020-4f4c86ddf1a7/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -1,0 +1,114 @@
+package apiserver
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+var shutdownDelayDurationPath = []string{"apiServerArguments", "shutdown-delay-duration"}
+
+var gracefulTerminationDurationPath = []string{"gracefulTerminationDuration"}
+
+// ObserveShutdownDelayDuration allows for overwriting shutdown-delay-duration value.
+// It exists because the time needed for an LB to notice and remove unhealthy instances might vary by platform.
+func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	defer func() {
+		// Prune the observed config so that it only contains shutdown-delay-duration field.
+		ret = configobserver.Pruned(ret, shutdownDelayDurationPath)
+	}()
+
+	// read the observed value
+	var observedShutdownDelayDuration string
+	listers := genericListers.(configobservation.Listers)
+	infra, err := listers.InfrastructureLister().Get("cluster")
+	if err != nil && !apierrors.IsNotFound(err) {
+		// without the infrastructure object we are not able to determine the type of platform we are running on
+		return existingConfig, append(errs, err)
+	}
+	switch infra.Spec.PlatformSpec.Type {
+	case configv1.AWSPlatformType:
+		// AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804
+		// We need to extend the shutdown-delay-duration so that an NLB has a chance to notice and remove unhealthy instance.
+		// Once the mentioned issue is resolved this code must be removed and default values applied
+		observedShutdownDelayDuration = "210s"
+	default:
+		// just return the existing configuration since we don't have an opinion anyway
+		return existingConfig, errs
+	}
+
+	// read the current value
+	var currentShutdownDelayDuration string
+	currentShutdownDelaySlice, _, err := unstructured.NestedStringSlice(existingConfig, shutdownDelayDurationPath...)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to extract shutdown delay duration from the existing config: %v", err))
+		// keep going, we are only interested in the observed value which will overwrite the current configuration anyway
+	}
+	if len(currentShutdownDelaySlice) > 0 {
+		currentShutdownDelayDuration = currentShutdownDelaySlice[0]
+	}
+
+	// see if the current and the observed value differ
+	observedConfig := map[string]interface{}{}
+	if currentShutdownDelayDuration != observedShutdownDelayDuration {
+		if err = unstructured.SetNestedStringSlice(observedConfig, []string{observedShutdownDelayDuration}, shutdownDelayDurationPath...); err != nil {
+			return existingConfig, append(errs, err)
+		}
+		return observedConfig, errs
+	}
+
+	// nothing has changed return the original configuration
+	return existingConfig, errs
+}
+
+// ObserveShutdownDelayDuration sets the graceful termination duration according to the current platform.
+func ObserveWatchTerminationDuration(genericListers configobserver.Listers, _ events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	defer func() {
+		// Prune the observed config so that it only contains gracefulTerminationDuration field.
+		ret = configobserver.Pruned(ret, gracefulTerminationDurationPath)
+	}()
+
+	// read the observed value
+	var observedGracefulTerminationDuration string
+	listers := genericListers.(configobservation.Listers)
+	infra, err := listers.InfrastructureLister().Get("cluster")
+	if err != nil && !apierrors.IsNotFound(err) {
+		// without the infrastructure object we are not able to determine the type of platform we are running on
+		return existingConfig, append(errs, err)
+	}
+	switch infra.Spec.PlatformSpec.Type {
+	case configv1.AWSPlatformType:
+		// AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804
+		// We need to extend the shutdown-delay-duration so that an NLB has a chance to notice and remove unhealthy instance.
+		// Once the mentioned issue is resolved this code must be removed and default values applied
+		observedGracefulTerminationDuration = "275"
+	default:
+		// just return the existing configuration since we don't have an opinion anyway
+		return existingConfig, errs
+	}
+
+	// read the current value
+	currentGracefulTerminationDuration, _, err := unstructured.NestedString(existingConfig, gracefulTerminationDurationPath...)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to extract gracefulTerminationDuration from the existing config: %v, path = %v", err, gracefulTerminationDurationPath))
+		// keep going, we are only interested in the observed value which will overwrite the current configuration anyway
+	}
+
+	// see if the current and the observed value differ
+	observedConfig := map[string]interface{}{}
+	if currentGracefulTerminationDuration != observedGracefulTerminationDuration {
+		if err = unstructured.SetNestedField(observedConfig, observedGracefulTerminationDuration, gracefulTerminationDurationPath...); err != nil {
+			return existingConfig, append(errs, err)
+		}
+		return observedConfig, errs
+	}
+
+	// nothing has changed return the original configuration
+	return existingConfig, errs
+}

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -29,7 +29,7 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 	listers := genericListers.(configobservation.Listers)
 	infra, err := listers.InfrastructureLister().Get("cluster")
 	if err != nil && !apierrors.IsNotFound(err) {
-		// without the infrastructure object we are not able to determine the type of platform we are running on
+		// we got an error so without the infrastructure object we are not able to determine the type of platform we are running on
 		return existingConfig, append(errs, err)
 	}
 	switch infra.Spec.PlatformSpec.Type {
@@ -39,8 +39,8 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 		// Once the mentioned issue is resolved this code must be removed and default values applied
 		observedShutdownDelayDuration = "210s"
 	default:
-		// just return the existing configuration since we don't have an opinion anyway
-		return existingConfig, errs
+		// don't override default value
+		return map[string]interface{}{}, errs
 	}
 
 	// read the current value
@@ -79,7 +79,7 @@ func ObserveWatchTerminationDuration(genericListers configobserver.Listers, _ ev
 	listers := genericListers.(configobservation.Listers)
 	infra, err := listers.InfrastructureLister().Get("cluster")
 	if err != nil && !apierrors.IsNotFound(err) {
-		// without the infrastructure object we are not able to determine the type of platform we are running on
+		// we got an error so without the infrastructure object we are not able to determine the type of platform we are running on
 		return existingConfig, append(errs, err)
 	}
 	switch infra.Spec.PlatformSpec.Type {
@@ -89,8 +89,8 @@ func ObserveWatchTerminationDuration(genericListers configobserver.Listers, _ ev
 		// Once the mentioned issue is resolved this code must be removed and default values applied
 		observedGracefulTerminationDuration = "275"
 	default:
-		// just return the existing configuration since we don't have an opinion anyway
-		return existingConfig, errs
+		// don't override default value
+		return map[string]interface{}{}, errs
 	}
 
 	// read the current value

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -1,0 +1,180 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestObserveWatchTerminationDuration(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		validateKubeAPIConfigFn func(kubecontrolplanev1.KubeAPIServerConfig) error
+		existingKubeAPIConfig   map[string]interface{}
+		expectedKubeAPIConfig   map[string]interface{}
+		platformType            configv1.PlatformType
+	}{
+
+		// scenario 1
+		{
+			name: "default value is not applied",
+		},
+
+		// scenario 2
+		{
+			name:                  "happy path: a config with some watchTerminationDuration value already exists",
+			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+		},
+
+		// scenario 3
+		{
+			name:                  "the shutdown-delay-duration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
+			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "275"},
+			platformType:          configv1.AWSPlatformType,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewInMemoryRecorder("")
+			infrastructureIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			infrastructureIndexer.Add(&configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: scenario.platformType}}})
+			listers := configobservation.Listers{
+				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infrastructureIndexer),
+			}
+
+			// act
+			observedKubeAPIConfig, err := ObserveWatchTerminationDuration(listers, eventRecorder, scenario.existingKubeAPIConfig)
+
+			// validate
+			if len(err) > 0 {
+				t.Fatal(err)
+			}
+			if !cmp.Equal(scenario.expectedKubeAPIConfig, observedKubeAPIConfig) {
+				t.Fatalf("unexpected configuraiton, diff = %v", cmp.Diff(scenario.expectedKubeAPIConfig, observedKubeAPIConfig))
+			}
+		})
+	}
+}
+
+func TestObserveShutdownDelayDuration(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		validateKubeAPIConfigFn func(kubecontrolplanev1.KubeAPIServerConfig) error
+		existingConfig          kubecontrolplanev1.KubeAPIServerConfig
+		platformType            configv1.PlatformType
+	}{
+
+		// scenario 1
+		{
+			name: "a config with a shutdown-delay-duration value is respected",
+			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
+				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
+				if len(shutdownDurationArgs) != 1 {
+					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
+				}
+				if shutdownDurationArgs[0] != "70s" {
+					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 70s, got %v", shutdownDurationArgs[0])
+				}
+				return nil
+			},
+			existingConfig: kubecontrolplanev1.KubeAPIServerConfig{APIServerArguments: map[string]kubecontrolplanev1.Arguments{"shutdown-delay-duration": {"70s"}}},
+		},
+
+		// scenario 2
+		{
+			name: "the shutdown-delay-duration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
+			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
+				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
+				if len(shutdownDurationArgs) != 1 {
+					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
+				}
+				if shutdownDurationArgs[0] != "210s" {
+					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 210s, got %v", shutdownDurationArgs[0])
+				}
+				return nil
+			},
+			existingConfig: kubecontrolplanev1.KubeAPIServerConfig{APIServerArguments: map[string]kubecontrolplanev1.Arguments{"shutdown-delay-duration": {"70s"}}},
+			platformType:   configv1.AWSPlatformType,
+		},
+
+		// scenario 3
+		{
+			name: "happy path: a config without shutdown-delay-duration value is respected",
+			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
+				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
+				if len(shutdownDurationArgs) > 0 {
+					return fmt.Errorf("didn't expect to find a value for shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewInMemoryRecorder("")
+			infrastructureIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			infrastructureIndexer.Add(&configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: scenario.platformType}}})
+			listers := configobservation.Listers{
+				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infrastructureIndexer),
+			}
+
+			// act
+			observedKubeAPIConfig, err := ObserveShutdownDelayDuration(listers, eventRecorder, unstructuredAPIConfig(t, scenario.existingConfig))
+
+			// validate
+			if len(err) > 0 {
+				t.Fatal(err)
+			}
+
+			actualKubeAPIServerConfig := kubeAPIServerConfig(t, observedKubeAPIConfig)
+			if err := scenario.validateKubeAPIConfigFn(actualKubeAPIServerConfig); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func unstructuredAPIConfig(t *testing.T, existingCfg kubecontrolplanev1.KubeAPIServerConfig) map[string]interface{} {
+	existingCfg.TypeMeta = metav1.TypeMeta{
+		Kind: "KubeAPIServerConfig",
+	}
+	marshalledConfig, err := json.Marshal(existingCfg)
+	require.NoError(t, err)
+	unstructuredObj := &unstructured.Unstructured{}
+	require.NoError(t, json.Unmarshal(marshalledConfig, unstructuredObj))
+	return unstructuredObj.Object
+}
+
+func kubeAPIServerConfig(t *testing.T, observedConfig map[string]interface{}) kubecontrolplanev1.KubeAPIServerConfig {
+	unstructuredConfig := unstructured.Unstructured{
+		Object: observedConfig,
+	}
+	jsonConfig, err := unstructuredConfig.MarshalJSON()
+	require.NoError(t, err)
+	unmarshalledConfig := &kubecontrolplanev1.KubeAPIServerConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "KubeAPIServerConfig",
+		},
+	}
+	require.NoError(t, json.Unmarshal(jsonConfig, unmarshalledConfig))
+	return *unmarshalledConfig
+}

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -30,14 +30,15 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 
 		// scenario 1
 		{
-			name: "default value is not applied",
+			name:                  "default value is not applied",
+			expectedKubeAPIConfig: map[string]interface{}{},
 		},
 
 		// scenario 2
 		{
 			name:                  "happy path: a config with some watchTerminationDuration value already exists",
 			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
-			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+			expectedKubeAPIConfig: map[string]interface{}{}, // this is okay, the desired state in that case is no data, eventually all the configurations will be merged
 		},
 
 		// scenario 3
@@ -85,13 +86,10 @@ func TestObserveShutdownDelayDuration(t *testing.T) {
 		{
 			name: "a config with a shutdown-delay-duration value is respected",
 			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
-				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
-				if len(shutdownDurationArgs) != 1 {
-					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
+				if actualKasConfig.APIServerArguments != nil {
+					return fmt.Errorf("expected to receive an empty APIServerArguments list, saw %d items in the list", len(actualKasConfig.APIServerArguments))
 				}
-				if shutdownDurationArgs[0] != "70s" {
-					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 70s, got %v", shutdownDurationArgs[0])
-				}
+				// this is okay, the desired state in that case is no data, eventually all the configurations will be merged
 				return nil
 			},
 			existingConfig: kubecontrolplanev1.KubeAPIServerConfig{APIServerArguments: map[string]kubecontrolplanev1.Arguments{"shutdown-delay-duration": {"70s"}}},

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -119,6 +119,8 @@ func NewConfigObserver(
 			apiserver.ObserveNamedCertificates,
 			apiserver.ObserveUserClientCABundle,
 			apiserver.ObserveAdditionalCORSAllowedOrigins,
+			apiserver.ObserveShutdownDelayDuration,
+			apiserver.ObserveWatchTerminationDuration,
 			libgoapiserver.ObserveTLSSecurityProfile,
 			libgoapiserver.NewAuditObserver(auditPolicypathGetter),
 			auth.ObserveAuthMetadata,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -162,6 +162,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces,
+		configInformers.Config().V1().Infrastructures(),
 		kubeClient,
 		controllerContext.EventRecorder,
 	)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -162,7 +162,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces,
-		configInformers.Config().V1().Infrastructures(),
 		kubeClient,
 		controllerContext.EventRecorder,
 	)

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -3,7 +3,17 @@ package targetconfigcontroller
 import (
 	"strings"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 )
+
+var codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 
 func TestIsRequiredConfigPresent(t *testing.T) {
 	tests := []struct {
@@ -112,6 +122,60 @@ func TestIsRequiredConfigPresent(t *testing.T) {
 				t.Fatal(actual)
 			case actual != nil && len(test.expectedError) != 0 && !strings.Contains(actual.Error(), test.expectedError):
 				t.Fatal(actual)
+			}
+		})
+	}
+}
+
+func TestManageTemplate(t *testing.T) {
+	scenarios := []struct {
+		name         string
+		template     string
+		golden       string
+		operatorSpec *operatorv1.StaticPodOperatorSpec
+		platformType configv1.PlatformType
+	}{
+
+		// scenario 1
+		{
+			name:         "happy path: default values are applied",
+			template:     "{{.Image}}, {{.OperatorImage}}, {{.Verbosity}}, {{.GracefulTerminationDuration}}",
+			golden:       "CaptainAmerica, Piper,  -v=2, 135",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{}},
+		},
+
+		// scenario 2
+		{
+			name:         "the GracefulTerminationDuration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
+			template:     "{{.Image}}, {{.OperatorImage}}, {{.Verbosity}}, {{.GracefulTerminationDuration}}",
+			golden:       "CaptainAmerica, Piper,  -v=2, 275",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{}},
+			platformType: configv1.AWSPlatformType,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			infrastructureIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			infrastructureIndexer.Add(&configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: scenario.platformType}}})
+			infrastructureLister := configlistersv1.NewInfrastructureLister(infrastructureIndexer)
+
+			// act
+			appliedTemplate, err := manageTemplate(
+				scenario.template,
+				"CaptainAmerica",
+				"Piper",
+				infrastructureLister,
+				scenario.operatorSpec)
+
+			// validate
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if appliedTemplate != scenario.golden {
+				t.Fatalf("returned data is different thatn expected. wanted = %v, got %v, the templates was %v", scenario.golden, appliedTemplate, scenario.template)
 			}
 		})
 	}

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1487,7 +1487,7 @@ spec:
   initContainers:
     - name: setup
       terminationMessagePolicy: FallbackToLogsOnError
-      image: ${IMAGE}
+      image: {{.Image}}
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
@@ -1510,7 +1510,7 @@ spec:
           cpu: 5m
   containers:
   - name: kube-apiserver
-    image: ${IMAGE}
+    image: {{.Image}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["/bin/bash", "-ec"]
@@ -1541,7 +1541,7 @@ spec:
             fi
           done
           echo
-          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration=135s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY} --permit-address-sharing
+          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration={{.GracefulTerminationDuration}}s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} {{.Verbosity}} --permit-address-sharing
     resources:
       requests:
         memory: 1Gi
@@ -1596,7 +1596,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "cert-syncer"]
@@ -1619,7 +1619,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "cert-regeneration-controller"]
@@ -1635,7 +1635,7 @@ spec:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
   - name: kube-apiserver-insecure-readyz
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "insecure-readyz"]
@@ -1649,7 +1649,7 @@ spec:
         memory: 50Mi
         cpu: 5m
   - name: kube-apiserver-check-endpoints
-    image: ${OPERATOR_IMAGE}
+    image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent
     terminationMessagePolicy: FallbackToLogsOnError
     command:
@@ -1701,7 +1701,7 @@ spec:
       requests:
         memory: 50Mi
         cpu: 10m
-  terminationGracePeriodSeconds: 135 # bit more than 70s (minimal termination period) + 60s (apiserver graceful termination)
+  terminationGracePeriodSeconds: {{.GracefulTerminationDuration}}
   hostNetwork: true
   priorityClassName: system-node-critical
   tolerations:

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -23,7 +23,9 @@ func readAllYaml(path string, t *testing.T) {
 			// the dashboard is a ConfigMap yaml but it has an embedded json in data that causes the reader to fail.
 			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml") &&
 			// there is an alert message containing $labels strings that cause the reader to fail.
-			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml")
+			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml") &&
+			// the kas's pod manifest contains go template values and fails compilation
+			!strings.HasSuffix(info.Name(), "pod.yaml")
 
 	})
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -27,8 +27,12 @@ import (
 )
 
 var (
-	waitPollInterval      = 15 * time.Second
-	waitPollTimeout       = 60 * time.Minute // a happy path scenario needs to roll out 3 revisions each taking ~10 min
+	waitPollInterval = 15 * time.Second
+	// rolling out a single instance on AWS: 3m 30s (max delay aws) + 60s (in-flight req) + 3m 10s (starting new instance - observation) = 7m 40s
+	// rolling out all instances: 7m 40s * 3 = 23m
+	// a happy path scenario needs to roll out 3 revisions each taking 23m
+	// plus 10 additional minutes for actual migration
+	waitPollTimeout       = 69*time.Minute + 10*time.Minute
 	defaultEncryptionMode = string(configv1.EncryptionTypeIdentity)
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210513103829-aa02c23cb230
+# github.com/openshift/library-go v0.0.0-20210517095020-4f4c86ddf1a7
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804
the time needed for an LB to notice and remove unhealthy instances must be extended.

`shutdown-delay-duration` flag has been changed from `70s` to `210s` and `terminationGracePeriodSeconds` field from `135s` to` 275s`.

For `terminationGracePeriodSeconds` the initial `210s` is reserved for the minimal termination period.
Additional `60s` for finishing all in-flight requests and an extra `5s` to make sure a potential SIGTERM will be sent after a server terminates itself.
