### PR TITLE
avoid creating revisions for oauth token timeouts we don't use

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -1,30 +1,28 @@
 package configobservercontroller
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/cache"
-
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/configobserver"
-	libgoapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
-	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	configobserveroauth "github.com/openshift/library-go/pkg/operator/configobserver/oauth"
-	"github.com/openshift/library-go/pkg/operator/configobserver/proxy"
-	encryption "github.com/openshift/library-go/pkg/operator/encryption/observer"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/apiserver"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/etcdendpoints"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/images"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/network"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/oauth"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/scheduler"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	libgoapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
+	"github.com/openshift/library-go/pkg/operator/configobserver/cloudprovider"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/configobserver/proxy"
+	encryption "github.com/openshift/library-go/pkg/operator/encryption/observer"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 )
 
 var FeatureBlacklist sets.String
@@ -144,7 +142,7 @@ func NewConfigObserver(
 			network.ObserveExternalIPPolicy,
 			network.ObserveServicesNodePortRange,
 			// TODO: remove token inactivity observation in 4.9 when the authenticator no longer exists in KAS
-			configobserveroauth.ObserveAccessTokenInactivityTimeout,
+			oauth.ObserveAccessTokenInactivityTimeout,
 			proxy.NewProxyObserveFunc([]string{"targetconfigcontroller", "proxy"}),
 			images.ObserveInternalRegistryHostname,
 			images.ObserveExternalRegistryHostnames,

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -21,6 +21,8 @@ type Listers struct {
 	OAuthLister_          configlistersv1.OAuthLister
 	ProxyLister_          configlistersv1.ProxyLister
 	SchedulerLister       configlistersv1.SchedulerLister
+	ClusterOperatorLister configlistersv1.ClusterOperatorLister
+	ClusterVersionLister  configlistersv1.ClusterVersionLister
 
 	OpenshiftEtcdEndpointsLister corelistersv1.EndpointsLister
 	ConfigmapLister              corelistersv1.ConfigMapLister

--- a/pkg/operator/configobservation/oauth/doc.go
+++ b/pkg/operator/configobservation/oauth/doc.go
@@ -1,0 +1,5 @@
+// this package should be removed in 4.9.
+// for 4.8 it is necessary to watch for oauthconfig until we are ready to use the webhook authenticator.
+// after the webhook authenticator configuration is ready for use, then these settings should be cleared and never set again.
+// This is because when webhook configuration is set, the webhook is ready to be used as authoritative.
+package oauth

--- a/pkg/operator/configobservation/oauth/observe_tokenconfig.go
+++ b/pkg/operator/configobservation/oauth/observe_tokenconfig.go
@@ -1,0 +1,141 @@
+package oauth
+
+import (
+	"fmt"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// OAuthLister lists OAuth information
+type OAuthLister interface {
+	OAuthLister() configlistersv1.OAuthLister
+}
+
+const (
+	defaultAccessTokenMaxAgeSeconds   = float64(86400) // a day
+	fieldAccessTokenMaxAgeSeconds     = "accessTokenMaxAgeSeconds"
+	fieldAccessTokenInactivityTimeout = "accessTokenInactivityTimeout"
+)
+
+// Standa: why does nothing call this?
+// ObserveAccessTokenMaxAgeSeconds returns an unstructured fragment of KubeAPIServerConfig that changes the default value for access token max age,
+// if there is a valid value for it in OAuth cluster config.
+func ObserveAccessTokenMaxAgeSeconds(genericlisters configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	errs = []error{}
+	tokenConfigPath := []string{"oauthConfig", "tokenConfig"}
+	tokenMaxAgePath := append(tokenConfigPath, fieldAccessTokenMaxAgeSeconds)
+	defer func() {
+		// Prune the observed config so that it only contains access token max age field.
+		ret = configobserver.Pruned(ret, tokenMaxAgePath)
+	}()
+
+	listers, ok := genericlisters.(OAuthLister)
+	if !ok {
+		return existingConfig, append(errs, fmt.Errorf("failed to assert: given lister does not implement an OAuth lister"))
+	}
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if err != nil {
+		// Failed to read OAuth cluster config.
+		if errors.IsNotFound(err) {
+			klog.Warning("oauth.config.openshift.io/cluster: not found")
+		}
+		// return whatever is present in existing config.
+		return existingConfig, append(errs, err)
+	}
+
+	observedAccessTokenMaxAgeSeconds := float64(oauthConfig.Spec.TokenConfig.AccessTokenMaxAgeSeconds)
+	if observedAccessTokenMaxAgeSeconds == 0 {
+		// As the value 0 indicates that this field is not set or missing in OAuth cluster config, use the default value.
+		observedAccessTokenMaxAgeSeconds = defaultAccessTokenMaxAgeSeconds
+	}
+
+	existingAccessTokenMaxAgeSeconds, _, err := unstructured.NestedFloat64(existingConfig, tokenMaxAgePath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if existingAccessTokenMaxAgeSeconds != observedAccessTokenMaxAgeSeconds {
+		recorder.Eventf("ObserveAccessTokenMaxAgeSeconds", "%s changed from %d to %d", fieldAccessTokenMaxAgeSeconds,
+			existingAccessTokenMaxAgeSeconds,
+			observedAccessTokenMaxAgeSeconds)
+	}
+
+	return buildUnstructuredTokenConfig(observedAccessTokenMaxAgeSeconds, tokenMaxAgePath), errs
+}
+
+// ObserveAccessTokenInactivityTimeout returns an unstructured fragment of KubeAPIServerConfig that has access token inactivity timeout,
+// if there is a valid value for it in OAuth cluster config.
+func ObserveAccessTokenInactivityTimeout(genericlisters configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	errs = []error{}
+	tokenConfigPath := []string{"oauthConfig", "tokenConfig"}
+	tokenInactivityTimeoutPath := append(tokenConfigPath, fieldAccessTokenInactivityTimeout)
+	defer func() {
+		// Prune the observed config so that it only contains access token inactivity timeout field.
+		ret = configobserver.Pruned(ret, tokenInactivityTimeoutPath)
+	}()
+
+	listers, ok := genericlisters.(configobservation.Listers)
+	if !ok {
+		return existingConfig, append(errs, fmt.Errorf("failed to assert: given lister does not implement OAuth lister"))
+	}
+
+	if isReady, err := auth.IsWebhookAuthenticatorReady(listers, existingConfig); err != nil {
+		// if we had an error determining, just show the error and keep the existing config.
+		return existingConfig, append(errs, err)
+	} else if isReady {
+		// if the webhook is ready, then we should no longer have any configuration for kube-apiserver
+		return map[string]interface{}{}, nil
+	}
+
+	oauthConfig, err := listers.OAuthLister().Get("cluster")
+	if err != nil {
+		// Failed to read OAuth cluster config.
+		if errors.IsNotFound(err) {
+			klog.Warning("oauth.config.openshift.io/cluster: not found")
+		}
+		// Return whatever is present in existing config
+		return existingConfig, append(errs, err)
+	}
+
+	existingAccessTokenInactivityTimeout, _, err := unstructured.NestedString(existingConfig, tokenInactivityTimeoutPath...)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	observedConfig := map[string]interface{}{}
+	observedAccessTokenInactivityTimeout := ""
+	if oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout != nil {
+		observedAccessTokenInactivityTimeout = oauthConfig.Spec.TokenConfig.AccessTokenInactivityTimeout.Duration.String()
+		observedConfig = buildUnstructuredTokenConfig(observedAccessTokenInactivityTimeout, tokenInactivityTimeoutPath)
+	}
+
+	if existingAccessTokenInactivityTimeout != observedAccessTokenInactivityTimeout {
+		recorder.Eventf("ObserveAccessTokenInactivityTimeout", "%s changed from %v to %v", fieldAccessTokenInactivityTimeout,
+			existingAccessTokenInactivityTimeout,
+			observedAccessTokenInactivityTimeout)
+	}
+
+	return observedConfig, errs
+}
+
+func buildUnstructuredTokenConfig(val interface{}, fields []string) map[string]interface{} {
+	unstructuredConfig := map[string]interface{}{}
+
+	if err := unstructured.SetNestedField(unstructuredConfig, val, fields...); err != nil {
+		// SetNestedField can return an error if one of the nesting level is not map[string]interface{}.
+		// As unstructuredConfig is empty, this error must never happen.
+		klog.Warningf("failed to write unstructured config for fields %v: %v", fields, err)
+	}
+
+	return unstructuredConfig
+}


### PR DESCRIPTION
// TODO in 4.9, this is removed because the webhook is always available
// We determine readiness by...
// 1. if the webhook is not set, it is not ready.
// 2. if webhook is set and does not point to secret/openshift-oauth-apiserver, the webhook authenticator configuration is ready
// 3. if webhook is set and points to secret/openshift-oauth-apiserver and the existing observedConfig shows a webhook configuration
//    the webhook authenticator configuration is ready.  This allows stickiness after being set once.
// 4. if webhook is set and points to secret/openshift-oauth-apiserver and the authentication operator is at the same level as the
//    kube-apiserver, the webhook authenticator configuration is ready.  This ensures, the oauth-apiserver is ready to
//    answer webhook requests
// 5. if webhook is set and points to secret/openshift-oauth-apiserver and the clusterversion indicates this is an initial
//    install, the webhook authenticator is ready.  This avoids a late stage revision during install because some people care.
// overall, it is better to return true than false if the choice is ambiguous

In reading the kube-apiserver code, it appears that as soon as we specific a webhook configuration, we no longer honor the oauth token inactivity timeout.  I'm interested in whether a gap exists.

1. install 4.7
2. start upgrade to 4.8
3. kube-apiserver finishes upgrade, but doesn't use webhook auth because auth operator has not set auth.spec.webhookconfig
4. auth operator sets the auth.spec.webhookconfig *before* the oauth-apiserver has been updated
5. kube-apiserver rolls out the configuration change for webhook configuration, but the webhook consistently fails on that master until the oauth-apiserver is updated.
