### PR TITLE
audit: keep 3 days and avoid write conflict

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -21,10 +21,10 @@ apiServerArguments:
     - Node
   audit-log-format:
     - json
-  audit-log-maxbackup:
-    - "10"
   audit-log-maxsize:
     - "100"
+  audit-log-maxage:
+    - 3
   audit-log-path:
     - /var/log/kube-apiserver/audit.log
   audit-policy-file:

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -54,6 +54,9 @@ spec:
             fi
           done
           echo
+          echo -b "Rotating audit logs in /var/log/kube-apiserver"
+          test -f /var/log/kube-apiserver/audit.log && mv /var/log/kube-apiserver/audit{,-$(date '+%Y-%m-%dT%H-%M-%S.%3N')}.log
+          echo
           exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration=135s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY} --permit-address-sharing
     resources:
       requests:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -141,10 +141,10 @@ apiServerArguments:
     - Node
   audit-log-format:
     - json
-  audit-log-maxbackup:
-    - "10"
   audit-log-maxsize:
     - "100"
+  audit-log-maxage:
+    - 3
   audit-log-path:
     - /var/log/kube-apiserver/audit.log
   audit-policy-file:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1182,6 +1182,9 @@ spec:
             fi
           done
           echo
+          echo -b "Rotating audit logs in /var/log/kube-apiserver"
+          test -f /var/log/kube-apiserver/audit.log && mv /var/log/kube-apiserver/audit{,-$(date '+%Y-%m-%dT%H-%M-%S.%3N')}.log
+          echo
           exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration=135s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} ${VERBOSITY} --permit-address-sharing
     resources:
       requests:


### PR DESCRIPTION
- don't limit rotated files to 10, but keep 3 days. This is deterministic.
- rotate old audit.log on (re)start of container.