### PR TITLE
Bug 1949956: add minreadyseconds to ensure we don't have an LB outage on kas

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -186,6 +186,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		WithResources(operatorclient.TargetNamespace, "kube-apiserver", RevisionConfigMaps, RevisionSecrets).
 		WithCerts("kube-apiserver-certs", CertConfigMaps, CertSecrets).
 		WithVersioning("kube-apiserver", versionRecorder).
+		WithMinReadyDuration(30 * time.Second).
 		ToControllers()
 	if err != nil {
 		return err


### PR DESCRIPTION
proof of openshift/library-go#1018

// minReadySeconds is the time to wait between the completion of an operand becoming ready (all containers ready)
// and starting the rollout onto the next node. This avoids a problem with an external load balancer that looks like
// 1. for some reason we have two instances, maybe a liveness check blipped on one node. it doesn't matter why
// 2. we bring down an instance on m0 to start a new revision
// 3. at this point we have one instance running on m1
// 4. m0 starts up and goes ready, but the LB ready check just timed out and is waiting for X seconds
// 5. we bring down an instance on m1 to start the new revision.
// 6. the LB thinks all backends are down and routes randomly
// 7. no profit.
// setting this field to 30s can prevent the kube-apiserver from triggering the above flow on AWS.