### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     openshift.io/run-level: "0"
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-apiserver-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-kube-apiserver
   labels:
     openshift.io/run-level: "0"

--- a/bindata/bootkube/manifests/00_openshift-kube-apiserver-operator-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-kube-apiserver-operator-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/bindata/v4.1.0/kube-apiserver/ns.yaml
+++ b/bindata/v4.1.0/kube-apiserver/ns.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-kube-apiserver
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kube-apiserver
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"

--- a/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
@@ -5,6 +5,8 @@ metadata:
   name: kube-apiserver-recovery
   labels:
     revision: "recovery"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-apiserver-recovery

--- a/manifests/0000_20_kube-apiserver-operator_00_namespace.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: kube-apiserver-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-apiserver-operator
     spec:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1078,6 +1078,7 @@ metadata:
   name: openshift-kube-apiserver
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
@@ -1131,6 +1132,7 @@ metadata:
   name: kube-apiserver
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"
@@ -1455,6 +1457,8 @@ metadata:
   name: kube-apiserver-recovery
   labels:
     revision: "recovery"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-apiserver-recovery

--- a/pkg/recovery/apiserver_test.go
+++ b/pkg/recovery/apiserver_test.go
@@ -59,6 +59,9 @@ func TestApiserverRecoveryPod(t *testing.T) {
 					Labels: map[string]string{
 						"revision": "recovery",
 					},
+					Annotations: map[string]string{
+						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.