### PR TITLE
WIP: Enable operator.openshift.io/ValidateDNS

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -60,6 +60,7 @@ apiServerArguments:
     - config.openshift.io/ValidateAPIServer
     - config.openshift.io/ValidateAuthentication
     - config.openshift.io/ValidateConsole
+    - operator.openshift.io/ValidateDNS
     - config.openshift.io/ValidateFeatureGate
     - config.openshift.io/ValidateImage
     - config.openshift.io/ValidateOAuth

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -182,6 +182,7 @@ apiServerArguments:
     - config.openshift.io/ValidateAPIServer
     - config.openshift.io/ValidateAuthentication
     - config.openshift.io/ValidateConsole
+    - operator.openshift.io/ValidateDNS
     - config.openshift.io/ValidateFeatureGate
     - config.openshift.io/ValidateImage
     - config.openshift.io/ValidateOAuth


### PR DESCRIPTION
Enable the `operator.openshift.io/ValidateDNS` admission plugin.

* `bindata/v4.1.0/config/defaultconfig.yaml`: Enable the `operator.openshift.io/ValidateDNS` plugin.
* `pkg/operator/v410_00_assets/bindata.go`: Regenerate.