### PR TITLE
Rename workload annotations

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     openshift.io/run-level: "0"
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   restartPolicy: Always
   hostNetwork: true

--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kube-apiserver
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"

--- a/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/recovery-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     revision: "recovery"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-apiserver-recovery

--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: kube-apiserver-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-apiserver-operator
     spec:

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1132,7 +1132,7 @@ metadata:
   name: kube-apiserver
   annotations:
     kubectl.kubernetes.io/default-logs-container: kube-apiserver
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app: openshift-kube-apiserver
     apiserver: "true"
@@ -1458,7 +1458,7 @@ metadata:
   labels:
     revision: "recovery"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   containers:
   - name: kube-apiserver-recovery

--- a/pkg/recovery/apiserver_test.go
+++ b/pkg/recovery/apiserver_test.go
@@ -60,7 +60,7 @@ func TestApiserverRecoveryPod(t *testing.T) {
 						"revision": "recovery",
 					},
 					Annotations: map[string]string{
-						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please