### PR TITLE
WIP Enable graceful rollout for single replica control plane

### DIFF
--- a/Dockerfile-origin-release
+++ b/Dockerfile-origin-release
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/origin-release:v4.0 as origin-release
+FROM registry.ci.openshift.org/openshift/origin-release:v4.0 as origin-release
 
 FROM centos:7 as jq
 ARG IMAGES

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,6 +10,8 @@ COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/scc-manifests /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/iptables-scripts/iptables /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/iptables-scripts/ip6tables /usr/bin/
 COPY manifests /manifests
 COPY bindata/bootkube/scc-manifests /manifests
 COPY vendor/github.com/openshift/api/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml /manifests

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CRD_APIS :=./vendor/github.com/openshift/api/operator/v1
 # Exclude e2e tests from unit testing
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
-IMAGE_REGISTRY :=registry.svc.ci.openshift.org
+IMAGE_REGISTRY :=registry.ci.openshift.org
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ IMAGE_ORG=sttts make images
 $ docker push sttts/origin-cluster-kube-apiserver-operator
 
 $ cd ../cluster-kube-apiserver-operator
-$ oc adm release new --from-release=registry.svc.ci.openshift.org/openshift/origin-release:v4.0 cluster-kube-apiserver-operator=docker.io/sttts/origin-cluster-kube-apiserver-operator:latest --to-image=sttts/origin-release:latest
+$ oc adm release new --from-release=registry.ci.openshift.org/openshift/origin-release:v4.0 cluster-kube-apiserver-operator=docker.io/sttts/origin-cluster-kube-apiserver-operator:latest --to-image=sttts/origin-release:latest
 
 $ cd ../installer
 $ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/sttts/origin-release:latest bin/openshift-install cluster ...

--- a/bindata/v4.1.0/kube-apiserver/graceful-pod-cm.yaml
+++ b/bindata/v4.1.0/kube-apiserver/graceful-pod-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-apiserver
+  name: graceful-monitor-pod
+data:
+  pod.yaml:

--- a/bindata/v4.1.0/kube-apiserver/graceful-pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/graceful-pod.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: graceful-monitor
+  labels:
+    revision: "REVISION"
+spec:
+  containers:
+  - name: graceful-monitor
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    command: ["cluster-kube-apiserver-operator", "graceful-monitor"]
+    args:
+      - -v=3
+    volumeMounts:
+    - mountPath: /host
+      name: host-slash
+      readOnly: true
+      mountPropagation: HostToContainer
+    - mountPath: /etc/kubernetes/manifests
+      name: manifests
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    securityContext:
+      privileged: true
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: "Exists"
+  volumes:
+  - name: host-slash
+    hostPath:
+      path: /
+  - name: manifests
+    hostPath:
+      path: /etc/kubernetes/manifests

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/certregenerationcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/checkendpoints"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/gracefulmonitor"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/insecurereadyz"
 	operatorcmd "github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/render"
@@ -23,7 +24,6 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod"
-	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/prune"
 )
 
@@ -61,7 +61,8 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 
 	cmd.AddCommand(operatorcmd.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand())
-	cmd.AddCommand(installerpod.NewInstaller())
+	cmd.AddCommand(gracefulmonitor.NewInstallerCommand())
+	cmd.AddCommand(gracefulmonitor.NewGracefulMonitorCommand())
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/apparentlymart/go-cidr v1.0.1
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/coreos/go-iptables v0.6.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -35,3 +36,5 @@ require (
 )
 
 replace k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 // points to temporary-watch-reduction-patch-1.21 to pick up k/k/pull/100959
+
+replace github.com/openshift/library-go => github.com/marun/library-go v0.0.0-20210420192337-3a0db88f982f

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
+github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
@@ -368,6 +370,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/marun/library-go v0.0.0-20210420192337-3a0db88f982f h1:ny6vPEuKIql+qhAl4UQq28ideHFpc5r21StnxRPPDzM=
+github.com/marun/library-go v0.0.0-20210420192337-3a0db88f982f/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -424,8 +428,6 @@ github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f h1:MAFVN4yW6pP
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc h1:tywho0nChchtAD4E2YmlX9MWQ3CBoWT49GrTHfM2+ss=
-github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/iptables-scripts/ip6tables
+++ b/iptables-scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/iptables-scripts/iptables
+++ b/iptables-scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/pkg/cmd/gracefulmonitor/cmd.go
+++ b/pkg/cmd/gracefulmonitor/cmd.go
@@ -1,0 +1,267 @@
+package gracefulmonitor
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+const (
+	defaultSecurePort         = 6443
+	defaultInsecurePort       = 6080
+	defaultCheckEndpointsPort = 17697
+)
+
+type GracefulMonitorOptions struct {
+	PodManifestDir string
+}
+
+func NewGracefulMonitorCommand() *cobra.Command {
+	o := GracefulMonitorOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "graceful-monitor",
+		Short: "Monitors static pod state and ensures a graceful transition between old and new pods.",
+		Run: func(cmd *cobra.Command, args []string) {
+			klog.V(1).Info(cmd.Flags())
+			klog.V(1).Info(spew.Sdump(o))
+
+			if err := o.Validate(); err != nil {
+				klog.Exit(err)
+			}
+
+			if err := o.Run(); err != nil {
+				klog.Exit(err)
+			}
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *GracefulMonitorOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.PodManifestDir, "pod-manifest-dir", "/etc/kubernetes/manifests", "directory for the static pod manifests")
+}
+
+func (o *GracefulMonitorOptions) Validate() error {
+	if len(o.PodManifestDir) == 0 {
+		return fmt.Errorf("--pod-manifest-dir is required")
+	}
+
+	return nil
+}
+
+func (o *GracefulMonitorOptions) Run() error {
+	currentRevision := 0
+
+	podPrefix := "kube-apiserver-pod"
+	containerName := "kube-apiserver"
+	return wait.PollImmediateInfinite(10, func() (bool, error) {
+		manifests, err := ReadStaticPodManifests(o.PodManifestDir, podPrefix, containerName)
+		if err != nil {
+			klog.Errorf("Error reading static pod manifests: %v", err)
+			return false, nil
+		}
+
+		activeManifest := StaticPodManifest{}
+		nextManifest := StaticPodManifest{}
+		nextRevision := 0
+		switch len(manifests) {
+		case 0:
+			// TODO(marun) Cleanup chain
+			klog.V(2).Infof("No static pod manifests found in path %q with prefix %q",
+				o.PodManifestDir, podPrefix)
+			return false, nil
+		case 1:
+			activeManifest = manifests[0]
+			nextRevision = activeManifest.Revision
+		case 2:
+			if manifests[0].Revision < manifests[1].Revision {
+				activeManifest = manifests[0]
+				nextManifest = manifests[1]
+			} else {
+				activeManifest = manifests[1]
+				nextManifest = manifests[0]
+			}
+			nextRevision = nextManifest.Revision
+		default:
+			klog.Errorf("Graceful transition only possible for 2 pods, but found %d.", len(manifests))
+			return false, nil
+		}
+
+		if currentRevision == nextRevision {
+			klog.V(7).Infof("Forwarding already configured for kube-apiserver %s.", activeManifest)
+			return false, nil
+		}
+
+		err = gracefulRollout(activeManifest, nextManifest)
+		if err != nil {
+			klog.Errorf("Error attempting graceful rollout: %v", err)
+		}
+
+		currentRevision = nextRevision
+
+		return false, nil
+	})
+}
+
+func gracefulRollout(activeManifest, nextManifest StaticPodManifest) error {
+	// TODO(marun) How to ensure support for ipv6?
+
+	ipt, err := iptables.New()
+	if err != nil {
+		return err
+	}
+
+	activeMap := activePortMap(activeManifest.Port)
+
+	// A pod on port 6443 does not need forwarding. This can occur if
+	// enabling graceful rollout on an existing cluster.
+	if activeManifest.Port == defaultSecurePort {
+		klog.V(2).Infof("Ensuring no port forwarding for kube-apiserver %s", activeManifest)
+		if err := removeChain(ipt); err != nil {
+			return err
+		}
+	} else {
+		klog.V(2).Infof("Ensuring port forwarding for kube-apiserver %s", activeManifest)
+		if err := ensureActiveRules(ipt, activeMap); err != nil {
+			return err
+		}
+	}
+	if nextManifest.Invalid() {
+		// No next pod to transition to.
+		return nil
+	}
+
+	nextMap := NextPortMap(activeManifest.Port)
+
+	if nextManifest.Port == defaultSecurePort {
+		// If transitioning to the default port (i.e. due to disabling
+		// graceful rollout), health checking the next apiserver won't
+		// be possible since that port is currently forwarded to the
+		// active apiserver.
+		klog.V(2).Infof("Transitioning to kube-apiserver %s non-gracefully", nextManifest)
+	} else {
+		// Wait for the next pod to become ready by health checking
+		// its insecure port.
+		nextInsecurePort := nextMap[defaultInsecurePort]
+		klog.V(2).Infof("Waiting for kube-apiserver %s to become ready", nextManifest)
+		if err := waitForReadiness(nextManifest, nextInsecurePort); err != nil {
+			return err
+		}
+		klog.V(2).Infof("kube-apiserver %s is ready", nextManifest)
+	}
+
+	// Remove the old pod's manifest
+	klog.V(2).Infof("Initiating termination of kube-apiserver r%d by deleting manifest %s",
+		activeManifest.Revision, activeManifest.Filename)
+	if err := os.Remove(activeManifest.Filename); err != nil {
+		if nestedErr := ensureActiveRules(ipt, activeMap); err != nil {
+			klog.Errorf("Error attempting to cleanup forwarding rules: %v", nestedErr)
+		}
+		return err
+	}
+
+	// Ensure new connections are forwarded to the new pod
+	if nextManifest.Port == defaultSecurePort {
+		klog.V(2).Infof("Ensuring no port forwarding for kube-apiserver %s", nextManifest)
+		return removeChain(ipt)
+	} else {
+		klog.V(2).Infof("Ensuring port forwarding for kube-apiserver %s", nextManifest)
+		return ensureActiveRules(ipt, nextMap)
+	}
+}
+
+// TODO(marun) Check pod readiness via the API in the installer instead?
+func waitForReadiness(manifest StaticPodManifest, port int) error {
+	url := fmt.Sprintf("http://localhost:%d/readyz", port)
+	return wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
+		_, err := checkURL(url)
+		if err != nil {
+			// TODO(marun) Differentiate between error and timeout
+			klog.Errorf("apiserver %s is not yet ready: %v", manifest, err)
+		}
+		return err == nil, nil
+	})
+}
+
+// checkReadiness returns no error if a readyz request returns
+// successfully.
+func checkURL(url string) (string, error) {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	headers := http.Header{}
+	headers.Set("User-Agent", fmt.Sprintf("graceful-monitor"))
+	headers.Set("Accept", "*/*")
+	req.Header = headers
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	// Closing idle connections ensures that golang will use a
+	// different source port for subsequent requests which ensures
+	// that the current iptables forwarding rule will be used instead
+	// of the previously tracked connection to a different port.
+	client.CloseIdleConnections()
+
+	if res == nil {
+		return "", errors.New("nil response")
+	}
+
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("expected 200 for %s, got %d: %s", url, res.StatusCode, body)
+	}
+
+	return string(body), nil
+}
+
+func activePortMap(activePort int) map[int]int {
+	offset := activePort % defaultSecurePort
+	return portMapForOffset(offset)
+}
+
+func NextPortMap(activePort int) map[int]int {
+	// Next active port is 6444
+	offset := 1
+	if activePort == 6444 {
+		// Next active port is 6445
+		offset = 2
+	}
+	return portMapForOffset(offset)
+}
+
+func portMapForOffset(offset int) map[int]int {
+	return map[int]int{
+		defaultSecurePort:         defaultSecurePort + offset,
+		defaultInsecurePort:       defaultInsecurePort + offset,
+		defaultCheckEndpointsPort: defaultCheckEndpointsPort + offset,
+	}
+}

--- a/pkg/cmd/gracefulmonitor/installer.go
+++ b/pkg/cmd/gracefulmonitor/installer.go
@@ -1,0 +1,200 @@
+package gracefulmonitor
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/operator/staticpod/installerpod"
+)
+
+func NewInstallerCommand() *cobra.Command {
+	installerOptions := installerpod.NewInstallOptions().WithInitializeFn(
+		func(ctx context.Context, o *installerpod.InstallOptions) error {
+			isSingleReplica, err := isSingleReplicaControlPlane(ctx, o.ProtoConfig)
+			if err != nil {
+				return err
+			}
+			if isSingleReplica {
+				// Only configure graceful rollout for a single replica control plane
+				return configureGracefulRollout(o)
+			}
+			return nil
+		})
+	return installerpod.NewInstallerWithOptions(installerOptions)
+}
+
+// configureGracefulRollout configures the installer for graceful rollout by:
+//
+// - ensuring only the oldest static pod manifest will be present in the manifest path
+// - ensuring that the new static pod will have unique names and ports
+// - ensuring a static pod will be created for the graceful monitor
+//
+// These changes allow for a new apiserver to be started and for the active one only
+// be replaced once the new apiserver passes a readyz check.
+func configureGracefulRollout(o *installerpod.InstallOptions) error {
+	klog.V(1).Info("Configuring graceful rollout for a single replica control plane")
+
+	manifests, err := ReadAPIServerManifests(o.PodManifestDir)
+	if err != nil {
+		return err
+	}
+	activeManifest := manifests.ActiveManifest()
+
+	// Ensure only the active pod manifest exists in the manifest path before
+	// creating a new pod manifest.
+	if err := pruneInactiveManifests(manifests, activeManifest); err != nil {
+		return err
+	}
+
+	// Enable inclusion of the pod revision in the pod name and manifest
+	// filename to ensure uniqueness. This allows concurrent execution of
+	// multiple pods during a graceful transition.
+	o.WithManifestFilenameFn(setRevisionInManifestFilename)
+	o.WithPodMutationFn(setRevisionInPodName)
+
+	// Enable customization of the pod yaml by substituting the log filenames
+	// and ports in the revision's configmaps. This works because the pod yaml
+	// is delivered to the node as a configmap.
+	// TODO(marun) Limit substitution to the pod
+	o.WithSubstitutePodFn(func(input string) string {
+		// Determine the port map to use for substituting configmap content.
+		activePort := 0
+		if activeManifest != nil {
+			activePort = activeManifest.Port
+		}
+		portMap := NextPortMap(activePort)
+
+		// Prevent concurrent writes to the same log file by including the pod's
+		// secure port in log filenames. Only a single pod for a given secure port
+		// can run at a time due to the init container check.
+		//
+		// TODO(marun) Ensure uniquely-named logs are rotated/culled
+		result := substituteLogFilenames(input, portMap[6443])
+
+		// Replace the default ports with the ports that will be forwarded to
+		return substitutePorts(result, portMap)
+	})
+
+	// Enable copying the graceful monitor manifest to manage port forwarding to
+	// the active static pod
+	o.WithCopyContentFn(copyGracefulMonitorManifest)
+
+	return nil
+}
+
+// isSingleReplicaControlPlane indicates whether the cluster is using a single node
+// control plane topology.
+func isSingleReplicaControlPlane(ctx context.Context, c *rest.Config) (bool, error) {
+	configClient, err := configv1client.NewForConfig(c)
+	if err != nil {
+		return false, err
+	}
+	infra, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, nil
+}
+
+// copyGracefulMonitorManifest copies the monitor manifest from the given resource
+// dir to the manifest path.
+func copyGracefulMonitorManifest(resourceDir, podManifestDir string) error {
+	sourceFilename := path.Join(
+		resourceDir,
+		"configmaps",
+		"graceful-monitor-pod",
+		"pod.yaml",
+	)
+	podBytes, err := ioutil.ReadFile(sourceFilename)
+	if err != nil {
+		return err
+	}
+
+	destFilename := path.Join(podManifestDir, "graceful-monitor-pod.yaml")
+	klog.Infof("Writing graceful-monitor static pod manifest %q ...\n%s", destFilename, podBytes)
+	if err := ioutil.WriteFile(destFilename, podBytes, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setRevisionInPodName ensures the pod name includes its revision so that the
+// static pods for a node are differentiated in the API.
+func setRevisionInPodName(pod *corev1.Pod) error {
+	revision := pod.Labels["revision"]
+	revSuffix := fmt.Sprintf("-%s", revision)
+	pod.Name = pod.Name + revSuffix
+	return nil
+}
+
+// setRevisionInManifestFilename ensures the manifest filename is unique by
+// including the pod revision so that multiple apiserver manifests can exist in the
+// manifests path.
+func setRevisionInManifestFilename(baseFilename string, pod *corev1.Pod) string {
+	// Ensure
+	revision := pod.Labels["revision"]
+	return fmt.Sprintf("%s-%s.yaml", baseFilename, revision)
+}
+
+// pruneInactiveManifests deletes all but the active manifest to ensure that the
+// new revision of the apiserver static pod can bind to its configured ports.
+func pruneInactiveManifests(manifests StaticPodManifests, activeManifest *StaticPodManifest) error {
+	for _, manifest := range manifests {
+		if activeManifest != nil && activeManifest.Filename == manifest.Filename {
+			continue
+		}
+		if err := os.Remove(manifest.Filename); err != nil {
+			return err
+		}
+
+		// Not necessary to wait for terminatation since the pod
+		// init container waits for the ports to be freed.
+	}
+	return nil
+}
+
+// substituteLogFilenames suffixes known log filenames in the input with the
+// provided port.
+func substituteLogFilenames(input string, port int) string {
+	logSuffix := fmt.Sprintf("-%d", port)
+	result := strings.ReplaceAll(
+		input,
+		"/var/log/kube-apiserver/audit.log",
+		fmt.Sprintf("/var/log/kube-apiserver/audit%s.log", logSuffix),
+	)
+	result = strings.ReplaceAll(
+		result,
+		"/var/log/kube-apiserver/.terminating",
+		fmt.Sprintf("/var/log/kube-apiserver/.terminating%s", logSuffix),
+	)
+	result = strings.ReplaceAll(
+		result,
+		"/var/log/kube-apiserver/termination.log",
+		fmt.Sprintf("/var/log/kube-apiserver/termination%s.log", logSuffix),
+	)
+	return result
+}
+
+// substitutePorts replaces the default ports in the input with the ports that will
+// be forwarded to
+func substitutePorts(input string, portMap map[int]int) string {
+	result := input
+	for port, substitutePort := range portMap {
+		result = strings.ReplaceAll(result, fmt.Sprintf("%d", port), fmt.Sprintf("%d", substitutePort))
+	}
+	return result
+}

--- a/pkg/cmd/gracefulmonitor/iptables.go
+++ b/pkg/cmd/gracefulmonitor/iptables.go
@@ -1,0 +1,189 @@
+package gracefulmonitor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"k8s.io/klog/v2"
+)
+
+const apiChain = "OPENSHIFT-APISERVER-REWRITE"
+
+func commonRule(targetPort, destinationPort int) []string {
+	return []string{
+		"-m",
+		"addrtype",
+		"--dst-type",
+		"LOCAL",
+		"-m",
+		"tcp",
+		"--dport",
+		fmt.Sprintf("%d", targetPort),
+		"-j",
+		"DNAT",
+		"--to-destination",
+		fmt.Sprintf(":%d", destinationPort),
+	}
+}
+
+func dnatRule(targetPort, destinationPort int) []string {
+	rule := []string{
+		"-p",
+		"tcp",
+	}
+	return append(rule, commonRule(targetPort, destinationPort)...)
+}
+
+func establishedDNATRule(targetPort, destinationPort int) []string {
+	rule := []string{
+		"-p",
+		"tcp",
+		"-m",
+		"state",
+		"--state",
+		"RELATED,ESTABLISHED",
+	}
+	return append(rule, commonRule(targetPort, destinationPort)...)
+}
+
+func ensureActiveRules(ipt *iptables.IPTables, portMap map[int]int) error {
+	// Ensure chain
+	exists, err := ipt.ChainExists("nat", apiChain)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := ipt.NewChain("nat", apiChain); err != nil {
+			return err
+		}
+	}
+
+	// Ensure jump for traffic originating externally (PREROUTING) and
+	// internally (OUTPUT).
+	jumpRule := []string{"-j", apiChain}
+	exists, err = ipt.Exists("nat", "PREROUTING", jumpRule...)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := ipt.Insert("nat", "PREROUTING", 1, jumpRule...); err != nil {
+			return err
+		}
+	}
+	if err := ipt.AppendUnique("nat", "OUTPUT", jumpRule...); err != nil {
+		return err
+	}
+
+	// Ensure the chain contains the desired dnat rules
+	dnatRules := map[string][]string{}
+	for target, destination := range portMap {
+		rule := dnatRule(target, destination)
+		// Index by concatinated rule to simplify lookup
+		key := strings.Join(rule, " ")
+		dnatRules[key] = rule
+		klog.V(7).Infof("Ensuring nat rule: %s", key)
+		if err := ipt.AppendUnique("nat", apiChain, rule...); err != nil {
+			return err
+		}
+	}
+
+	// TODO(marun) Discover transition rules
+	// Search nat table
+	// Find KUBE-SEP-* chains containing -j DNAT --to-destination <node ip>:6443
+	// For each chain
+	//   Find KUBE-SVC chain containing jump to chain -j KUBE-SEP-
+	//   Find KUBE-SERVICES rule jumping to KUBE-SVC
+	//     The -d address indicates service ips that need to be redirected
+	nodeAddress := "192.168.126.11"
+	serviceIPs := []string{
+		"172.30.226.27/32", // This one - the openshift-kube-apiserver service - differs by cluster
+		"172.30.0.1/32",    // This one appears to be consistently the first address
+	}
+
+	destinationPort := portMap[6443]
+	for _, serviceIP := range serviceIPs {
+		rule := []string{
+			"-d",
+			serviceIP,
+			"-p",
+			"tcp",
+			"-m",
+			"tcp",
+			"--dport",
+			"443",
+			"-j",
+			"DNAT",
+			"--to-destination",
+			fmt.Sprintf("%s:%d", nodeAddress, destinationPort),
+		}
+		key := strings.Join(rule, " ")
+		dnatRules[key] = rule
+		if err := ipt.AppendUnique("nat", apiChain, rule...); err != nil {
+			return err
+		}
+	}
+
+	return deleteUnknownRules(ipt, apiChain, dnatRules)
+}
+
+func deleteUnknownRules(ipt *iptables.IPTables, apiChain string, dnatRules map[string][]string) error {
+	// Ensure the chain contains no other rules
+	chainRules, err := ipt.List("nat", apiChain)
+	if err != nil {
+		return err
+	}
+	for _, rawRule := range chainRules {
+		// Each rule will be prefixed with the <flag> <chain name>
+		// (e.g. -A OPENSHIFT_APISERVER_REWRITE) that have to be stripped to be able to compare the rule content.
+		rawRuleParts := strings.Split(rawRule, " ")
+
+		// Rule defining the chain (-N <chain name>)
+		if rawRuleParts[0] == "-N" {
+			continue
+		}
+
+		// Strip the prefix
+		rule := rawRuleParts[2:]
+
+		joinedRule := strings.Join(rule, " ")
+		if _, ok := dnatRules[joinedRule]; ok {
+			// Known rule, do not delete
+			continue
+		}
+
+		klog.V(7).Infof("Deleting nat rule: %s", joinedRule)
+		if err := ipt.Delete("nat", apiChain, rule...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func removeChain(ipt *iptables.IPTables) error {
+	exists, err := ipt.ChainExists("nat", apiChain)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		// Chain and jump rules not present
+		return nil
+	}
+
+	// Only attempt removal of jump rules if the api chain exists. If
+	// the api chain does not exist, DeleteIfExists will return an
+	// error complaining that the api chain is missing even if the
+	// rule does not exist.
+	for _, chain := range []string{"OUTPUT", "PREROUTING"} {
+		err := ipt.DeleteIfExists("nat", chain, "-j", apiChain)
+		if err != nil {
+			return err
+		}
+	}
+	err = ipt.ClearAndDeleteChain("nat", apiChain)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/gracefulmonitor/iptables_test.go
+++ b/pkg/cmd/gracefulmonitor/iptables_test.go
@@ -1,0 +1,135 @@
+package gracefulmonitor
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-iptables/iptables"
+)
+
+type testServer struct {
+	name    string
+	address string
+	port    int
+}
+
+func (s *testServer) readyMsg() string {
+	return fmt.Sprintf("%s-ok", s.name)
+}
+
+func (s *testServer) serve(t *testing.T) func() {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.address = listener.Addr().String()
+	rawPort := s.address[strings.LastIndex(s.address, ":")+1:]
+	s.port, err = strconv.Atoi(rawPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s listening on port %d", s.name, s.port)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(s.readyMsg()))
+	})
+	srv := http.Server{
+		Handler: mux,
+	}
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			t.Errorf("Serve failed: %v", err)
+		}
+	}()
+	return func() {
+		err := srv.Close()
+		if err != nil {
+			t.Errorf("server close failed: %v", err)
+		}
+	}
+}
+
+// Valid simple forwarding semantics (requires sudo and iptables)
+func TestForwardToActive(t *testing.T) {
+	if os.Getenv("TEST_IPTABLES") == "" {
+		t.Skip("Skipping iptables testing due to TEST_IPTABLES not being set")
+	}
+	// Start first server
+	server1 := testServer{name: "one"}
+	cleanup1 := server1.serve(t)
+	defer cleanup1()
+
+	// Pick a random port to forward
+	forwardListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	forwardingAddress := forwardListener.Addr().String()
+	rawForwardingPort := forwardingAddress[strings.LastIndex(forwardingAddress, ":")+1:]
+	forwardingPort, err := strconv.Atoi(rawForwardingPort)
+	t.Logf("forwarding port is %d", forwardingPort)
+	defer func() {
+		// Keep port open to minimize the potential for interacting
+		// with a non-test process.
+		err = forwardListener.Close()
+		if err != nil {
+			t.Errorf("error closing forwarding listener: %v", err)
+		}
+	}()
+
+	ipt, err := iptables.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable port forwarding for server
+	portMap := map[int]int{
+		forwardingPort: server1.port,
+	}
+	err = ensureActiveRules(ipt, portMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := removeChain(ipt)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Check that forwarding works
+	readyzURL := fmt.Sprintf("http://%s/readyz", forwardingAddress)
+	_, err = checkURL(readyzURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a second server
+	server2 := testServer{name: "two"}
+	cleanup2 := server2.serve(t)
+	defer cleanup2()
+
+	// Switch the
+	nextMap := map[int]int{
+		forwardingPort: server2.port,
+	}
+	err = ensureActiveRules(ipt, nextMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the port is now forwarding to the second server.
+	forwardedMsg, err := checkURL(readyzURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forwardedMsg != server2.readyMsg() {
+		t.Fatalf("expected %s, got %s", server2.readyMsg(), forwardedMsg)
+	}
+}

--- a/pkg/cmd/gracefulmonitor/manifests.go
+++ b/pkg/cmd/gracefulmonitor/manifests.go
@@ -1,0 +1,112 @@
+package gracefulmonitor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+)
+
+type StaticPodManifest struct {
+	Filename string
+	Revision int
+	Port     int
+}
+
+type StaticPodManifests []StaticPodManifest
+
+func (m StaticPodManifest) Invalid() bool {
+	return len(m.Filename) == 0
+}
+
+func (m StaticPodManifest) String() string {
+	return fmt.Sprintf("r%d on port %d", m.Revision, m.Port)
+}
+
+// ActiveManifest returns the active manifest - the one with the
+// smallest revision.
+func (m StaticPodManifests) ActiveManifest() *StaticPodManifest {
+	var active *StaticPodManifest
+	for _, manifest := range m {
+		if active == nil || manifest.Revision < active.Revision {
+			active = &manifest
+		}
+	}
+	return active
+}
+
+// ReadStaticPodManifest reads a static pod manifest from a file and
+// returns its metadata - filename, revision and port.
+func ReadStaticPodManifest(filename, containerName string) (*StaticPodManifest, error) {
+	// Unmarshal the pod
+	rawPodBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	pod, err := resourceread.ReadPodV1([]byte(rawPodBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the revision
+	rawRevision := pod.Labels["revision"]
+	revision, err := strconv.Atoi(rawRevision)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the port declared by the indicated container
+	port := 0
+	for _, container := range pod.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		if len(container.Ports) != 1 {
+			template := "container %q should define only a single port"
+			return nil, fmt.Errorf(template, containerName)
+		}
+		port = int(container.Ports[0].ContainerPort)
+	}
+	if port == 0 {
+		return nil, fmt.Errorf("port for container %q not found", containerName)
+	}
+
+	return &StaticPodManifest{
+		Filename: filename,
+		Revision: revision,
+		Port:     port,
+	}, nil
+}
+
+func ReadAPIServerManifests(manifestDir string) (StaticPodManifests, error) {
+	return ReadStaticPodManifests(manifestDir, "kube-apiserver-pod", "kube-apiserver")
+}
+
+// ReadStaticPodManifests reads the prefixed static pod manifests from
+// disk and returns metadata about each one - filename, revision and
+// port.
+func ReadStaticPodManifests(manifestDir, podNamePrefix, containerName string) (StaticPodManifests, error) {
+	files, err := ioutil.ReadDir(manifestDir)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests := []StaticPodManifest{}
+	for _, file := range files {
+		// Look only for manifests of the form prefix.yaml
+		if !strings.HasPrefix(file.Name(), podNamePrefix) {
+			continue
+		}
+
+		filename := path.Join(manifestDir, file.Name())
+		manifest, err := ReadStaticPodManifest(filename, containerName)
+		if err != nil {
+			return nil, err
+		}
+		manifests = append(manifests, *manifest)
+	}
+	return manifests, nil
+}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -44,6 +44,8 @@ type TargetConfigController struct {
 
 	kubeClient      kubernetes.Interface
 	configMapLister corev1listers.ConfigMapLister
+
+	enableGracefulRollout bool
 }
 
 func NewTargetConfigController(
@@ -53,6 +55,7 @@ func NewTargetConfigController(
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	kubeClient kubernetes.Interface,
 	eventRecorder events.Recorder,
+	enableGracefulRollout bool,
 ) factory.Controller {
 	c := &TargetConfigController{
 		targetImagePullSpec:   targetImagePullSpec,
@@ -60,6 +63,7 @@ func NewTargetConfigController(
 		operatorClient:        operatorClient,
 		kubeClient:            kubeClient,
 		configMapLister:       kubeInformersForNamespaces.ConfigMapLister(),
+		enableGracefulRollout: enableGracefulRollout,
 	}
 
 	return factory.New().WithInformers(
@@ -177,6 +181,14 @@ func createTargetConfig(ctx context.Context, c TargetConfigController, recorder 
 		errors = append(errors, fmt.Errorf("%q: %v", "serviceaccount/localhost-recovery-client", err))
 	}
 
+	// Avoid adding the graceful monitor pod configmap if graceful rollout is not configured
+	if c.enableGracefulRollout {
+		_, _, err = manageGracefulMonitorPod(c.kubeClient.CoreV1(), recorder, c.operatorImagePullSpec)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("%q: %v", "configmap/graceful-monitor-pod", err))
+		}
+	}
+
 	if len(errors) > 0 {
 		condition := operatorv1.OperatorCondition{
 			Type:    "TargetConfigControllerDegraded",
@@ -290,6 +302,16 @@ func managePod(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, o
 	configMap.Data["pod.yaml"] = resourceread.WritePodV1OrDie(required)
 	configMap.Data["forceRedeploymentReason"] = operatorSpec.ForceRedeploymentReason
 	configMap.Data["version"] = version.Get().String()
+	return resourceapply.ApplyConfigMap(client, recorder, configMap)
+}
+
+func manageGracefulMonitorPod(client coreclientv1.ConfigMapsGetter, recorder events.Recorder, operatorImagePullSpec string) (*corev1.ConfigMap, bool, error) {
+	required := resourceread.ReadPodV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-apiserver/graceful-pod.yaml"))
+	required.Spec.Containers[0].Image = operatorImagePullSpec
+	required.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+
+	configMap := resourceread.ReadConfigMapV1OrDie(v410_00_assets.MustAsset("v4.1.0/kube-apiserver/graceful-pod-cm.yaml"))
+	configMap.Data["pod.yaml"] = resourceread.WritePodV1OrDie(required)
 	return resourceapply.ApplyConfigMap(client, recorder, configMap)
 }
 

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -17,6 +17,8 @@
 // bindata/v4.1.0/kube-apiserver/cm.yaml
 // bindata/v4.1.0/kube-apiserver/control-plane-node-kubeconfig-cm.yaml
 // bindata/v4.1.0/kube-apiserver/delegated-incluster-authentication-rolebinding.yaml
+// bindata/v4.1.0/kube-apiserver/graceful-pod-cm.yaml
+// bindata/v4.1.0/kube-apiserver/graceful-pod.yaml
 // bindata/v4.1.0/kube-apiserver/kubeconfig-cm.yaml
 // bindata/v4.1.0/kube-apiserver/localhost-recovery-client-crb.yaml
 // bindata/v4.1.0/kube-apiserver/localhost-recovery-sa.yaml
@@ -1462,6 +1464,86 @@ func v410KubeApiserverDelegatedInclusterAuthenticationRolebindingYaml() (*asset,
 	return a, nil
 }
 
+var _v410KubeApiserverGracefulPodCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-kube-apiserver
+  name: graceful-monitor-pod
+data:
+  pod.yaml:
+`)
+
+func v410KubeApiserverGracefulPodCmYamlBytes() ([]byte, error) {
+	return _v410KubeApiserverGracefulPodCmYaml, nil
+}
+
+func v410KubeApiserverGracefulPodCmYaml() (*asset, error) {
+	bytes, err := v410KubeApiserverGracefulPodCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-apiserver/graceful-pod-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410KubeApiserverGracefulPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  namespace: openshift-kube-apiserver
+  name: graceful-monitor
+  labels:
+    revision: "REVISION"
+spec:
+  containers:
+  - name: graceful-monitor
+    image: ${OPERATOR_IMAGE}
+    imagePullPolicy: IfNotPresent
+    command: ["cluster-kube-apiserver-operator", "graceful-monitor"]
+    args:
+      - -v=3
+    volumeMounts:
+    - mountPath: /host
+      name: host-slash
+      readOnly: true
+      mountPropagation: HostToContainer
+    - mountPath: /etc/kubernetes/manifests
+      name: manifests
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    securityContext:
+      privileged: true
+  hostNetwork: true
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: "Exists"
+  volumes:
+  - name: host-slash
+    hostPath:
+      path: /
+  - name: manifests
+    hostPath:
+      path: /etc/kubernetes/manifests
+`)
+
+func v410KubeApiserverGracefulPodYamlBytes() ([]byte, error) {
+	return _v410KubeApiserverGracefulPodYaml, nil
+}
+
+func v410KubeApiserverGracefulPodYaml() (*asset, error) {
+	bytes, err := v410KubeApiserverGracefulPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/kube-apiserver/graceful-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410KubeApiserverKubeconfigCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -2237,6 +2319,8 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/kube-apiserver/cm.yaml":                                                v410KubeApiserverCmYaml,
 	"v4.1.0/kube-apiserver/control-plane-node-kubeconfig-cm.yaml":                  v410KubeApiserverControlPlaneNodeKubeconfigCmYaml,
 	"v4.1.0/kube-apiserver/delegated-incluster-authentication-rolebinding.yaml":    v410KubeApiserverDelegatedInclusterAuthenticationRolebindingYaml,
+	"v4.1.0/kube-apiserver/graceful-pod-cm.yaml":                                   v410KubeApiserverGracefulPodCmYaml,
+	"v4.1.0/kube-apiserver/graceful-pod.yaml":                                      v410KubeApiserverGracefulPodYaml,
 	"v4.1.0/kube-apiserver/kubeconfig-cm.yaml":                                     v410KubeApiserverKubeconfigCmYaml,
 	"v4.1.0/kube-apiserver/localhost-recovery-client-crb.yaml":                     v410KubeApiserverLocalhostRecoveryClientCrbYaml,
 	"v4.1.0/kube-apiserver/localhost-recovery-sa.yaml":                             v410KubeApiserverLocalhostRecoverySaYaml,
@@ -2314,6 +2398,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"cm.yaml":                                                {v410KubeApiserverCmYaml, map[string]*bintree{}},
 			"control-plane-node-kubeconfig-cm.yaml":                  {v410KubeApiserverControlPlaneNodeKubeconfigCmYaml, map[string]*bintree{}},
 			"delegated-incluster-authentication-rolebinding.yaml":    {v410KubeApiserverDelegatedInclusterAuthenticationRolebindingYaml, map[string]*bintree{}},
+			"graceful-pod-cm.yaml":                                   {v410KubeApiserverGracefulPodCmYaml, map[string]*bintree{}},
+			"graceful-pod.yaml":                                      {v410KubeApiserverGracefulPodYaml, map[string]*bintree{}},
 			"kubeconfig-cm.yaml":                                     {v410KubeApiserverKubeconfigCmYaml, map[string]*bintree{}},
 			"localhost-recovery-client-crb.yaml":                     {v410KubeApiserverLocalhostRecoveryClientCrbYaml, map[string]*bintree{}},
 			"localhost-recovery-sa.yaml":                             {v410KubeApiserverLocalhostRecoverySaYaml, map[string]*bintree{}},

--- a/vendor/github.com/coreos/go-iptables/LICENSE
+++ b/vendor/github.com/coreos/go-iptables/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-iptables/NOTICE
+++ b/vendor/github.com/coreos/go-iptables/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-iptables/iptables/iptables.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/iptables.go
@@ -1,0 +1,680 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Adds the output of stderr to exec.ExitError
+type Error struct {
+	exec.ExitError
+	cmd        exec.Cmd
+	msg        string
+	exitStatus *int //for overriding
+}
+
+func (e *Error) ExitStatus() int {
+	if e.exitStatus != nil {
+		return *e.exitStatus
+	}
+	return e.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("running %v: exit status %v: %v", e.cmd.Args, e.ExitStatus(), e.msg)
+}
+
+// IsNotExist returns true if the error is due to the chain or rule not existing
+func (e *Error) IsNotExist() bool {
+	if e.ExitStatus() != 1 {
+		return false
+	}
+	msgNoRuleExist := "Bad rule (does a matching rule exist in that chain?).\n"
+	msgNoChainExist := "No chain/target/match by that name.\n"
+	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist)
+}
+
+// Protocol to differentiate between IPv4 and IPv6
+type Protocol byte
+
+const (
+	ProtocolIPv4 Protocol = iota
+	ProtocolIPv6
+)
+
+type IPTables struct {
+	path              string
+	proto             Protocol
+	hasCheck          bool
+	hasWait           bool
+	waitSupportSecond bool
+	hasRandomFully    bool
+	v1                int
+	v2                int
+	v3                int
+	mode              string // the underlying iptables operating mode, e.g. nf_tables
+	timeout           int    // time to wait for the iptables lock, default waits forever
+}
+
+// Stat represents a structured statistic entry.
+type Stat struct {
+	Packets     uint64     `json:"pkts"`
+	Bytes       uint64     `json:"bytes"`
+	Target      string     `json:"target"`
+	Protocol    string     `json:"prot"`
+	Opt         string     `json:"opt"`
+	Input       string     `json:"in"`
+	Output      string     `json:"out"`
+	Source      *net.IPNet `json:"source"`
+	Destination *net.IPNet `json:"destination"`
+	Options     string     `json:"options"`
+}
+
+type option func(*IPTables)
+
+func IPFamily(proto Protocol) option {
+	return func(ipt *IPTables) {
+		ipt.proto = proto
+	}
+}
+
+func Timeout(timeout int) option {
+	return func(ipt *IPTables) {
+		ipt.timeout = timeout
+	}
+}
+
+// New creates a new IPTables configured with the options passed as parameter.
+// For backwards compatibility, by default always uses IPv4 and timeout 0.
+// i.e. you can create an IPv6 IPTables using a timeout of 5 seconds passing
+// the IPFamily and Timeout options as follow:
+//	ip6t := New(IPFamily(ProtocolIPv6), Timeout(5))
+func New(opts ...option) (*IPTables, error) {
+
+	ipt := &IPTables{
+		proto:   ProtocolIPv4,
+		timeout: 0,
+	}
+
+	for _, opt := range opts {
+		opt(ipt)
+	}
+
+	path, err := exec.LookPath(getIptablesCommand(ipt.proto))
+	if err != nil {
+		return nil, err
+	}
+	ipt.path = path
+
+	vstring, err := getIptablesVersionString(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not get iptables version: %v", err)
+	}
+	v1, v2, v3, mode, err := extractIptablesVersion(vstring)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract iptables version from [%s]: %v", vstring, err)
+	}
+	ipt.v1 = v1
+	ipt.v2 = v2
+	ipt.v3 = v3
+	ipt.mode = mode
+
+	checkPresent, waitPresent, waitSupportSecond, randomFullyPresent := getIptablesCommandSupport(v1, v2, v3)
+	ipt.hasCheck = checkPresent
+	ipt.hasWait = waitPresent
+	ipt.waitSupportSecond = waitSupportSecond
+	ipt.hasRandomFully = randomFullyPresent
+
+	return ipt, nil
+}
+
+// New creates a new IPTables for the given proto.
+// The proto will determine which command is used, either "iptables" or "ip6tables".
+func NewWithProtocol(proto Protocol) (*IPTables, error) {
+	return New(IPFamily(proto), Timeout(0))
+}
+
+// Proto returns the protocol used by this IPTables.
+func (ipt *IPTables) Proto() Protocol {
+	return ipt.proto
+}
+
+// Exists checks if given rulespec in specified table/chain exists
+func (ipt *IPTables) Exists(table, chain string, rulespec ...string) (bool, error) {
+	if !ipt.hasCheck {
+		return ipt.existsForOldIptables(table, chain, rulespec)
+
+	}
+	cmd := append([]string{"-t", table, "-C", chain}, rulespec...)
+	err := ipt.run(cmd...)
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return true, nil
+	case eok && eerr.ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// Insert inserts rulespec to specified table/chain (in specified pos)
+func (ipt *IPTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-I", chain, strconv.Itoa(pos)}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+// Append appends rulespec to specified table/chain
+func (ipt *IPTables) Append(table, chain string, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-A", chain}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+// AppendUnique acts like Append except that it won't add a duplicate
+func (ipt *IPTables) AppendUnique(table, chain string, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return ipt.Append(table, chain, rulespec...)
+	}
+
+	return nil
+}
+
+// Delete removes rulespec in specified table/chain
+func (ipt *IPTables) Delete(table, chain string, rulespec ...string) error {
+	cmd := append([]string{"-t", table, "-D", chain}, rulespec...)
+	return ipt.run(cmd...)
+}
+
+func (ipt *IPTables) DeleteIfExists(table, chain string, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err == nil && exists {
+		err = ipt.Delete(table, chain, rulespec...)
+	}
+	return err
+}
+
+// List rules in specified table/chain
+func (ipt *IPTables) List(table, chain string) ([]string, error) {
+	args := []string{"-t", table, "-S", chain}
+	return ipt.executeList(args)
+}
+
+// List rules (with counters) in specified table/chain
+func (ipt *IPTables) ListWithCounters(table, chain string) ([]string, error) {
+	args := []string{"-t", table, "-v", "-S", chain}
+	return ipt.executeList(args)
+}
+
+// ListChains returns a slice containing the name of each chain in the specified table.
+func (ipt *IPTables) ListChains(table string) ([]string, error) {
+	args := []string{"-t", table, "-S"}
+
+	result, err := ipt.executeList(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over rules to find all default (-P) and user-specified (-N) chains.
+	// Chains definition always come before rules.
+	// Format is the following:
+	// -P OUTPUT ACCEPT
+	// -N Custom
+	var chains []string
+	for _, val := range result {
+		if strings.HasPrefix(val, "-P") || strings.HasPrefix(val, "-N") {
+			chains = append(chains, strings.Fields(val)[1])
+		} else {
+			break
+		}
+	}
+	return chains, nil
+}
+
+// '-S' is fine with non existing rule index as long as the chain exists
+// therefore pass index 1 to reduce overhead for large chains
+func (ipt *IPTables) ChainExists(table, chain string) (bool, error) {
+	err := ipt.run("-t", table, "-S", chain, "1")
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return true, nil
+	case eok && eerr.ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// Stats lists rules including the byte and packet counts
+func (ipt *IPTables) Stats(table, chain string) ([][]string, error) {
+	args := []string{"-t", table, "-L", chain, "-n", "-v", "-x"}
+	lines, err := ipt.executeList(args)
+	if err != nil {
+		return nil, err
+	}
+
+	appendSubnet := func(addr string) string {
+		if strings.IndexByte(addr, byte('/')) < 0 {
+			if strings.IndexByte(addr, '.') < 0 {
+				return addr + "/128"
+			}
+			return addr + "/32"
+		}
+		return addr
+	}
+
+	ipv6 := ipt.proto == ProtocolIPv6
+
+	rows := [][]string{}
+	for i, line := range lines {
+		// Skip over chain name and field header
+		if i < 2 {
+			continue
+		}
+
+		// Fields:
+		// 0=pkts 1=bytes 2=target 3=prot 4=opt 5=in 6=out 7=source 8=destination 9=options
+		line = strings.TrimSpace(line)
+		fields := strings.Fields(line)
+
+		// The ip6tables verbose output cannot be naively split due to the default "opt"
+		// field containing 2 single spaces.
+		if ipv6 {
+			// Check if field 6 is "opt" or "source" address
+			dest := fields[6]
+			ip, _, _ := net.ParseCIDR(dest)
+			if ip == nil {
+				ip = net.ParseIP(dest)
+			}
+
+			// If we detected a CIDR or IP, the "opt" field is empty.. insert it.
+			if ip != nil {
+				f := []string{}
+				f = append(f, fields[:4]...)
+				f = append(f, "  ") // Empty "opt" field for ip6tables
+				f = append(f, fields[4:]...)
+				fields = f
+			}
+		}
+
+		// Adjust "source" and "destination" to include netmask, to match regular
+		// List output
+		fields[7] = appendSubnet(fields[7])
+		fields[8] = appendSubnet(fields[8])
+
+		// Combine "options" fields 9... into a single space-delimited field.
+		options := fields[9:]
+		fields = fields[:9]
+		fields = append(fields, strings.Join(options, " "))
+		rows = append(rows, fields)
+	}
+	return rows, nil
+}
+
+// ParseStat parses a single statistic row into a Stat struct. The input should
+// be a string slice that is returned from calling the Stat method.
+func (ipt *IPTables) ParseStat(stat []string) (parsed Stat, err error) {
+	// For forward-compatibility, expect at least 10 fields in the stat
+	if len(stat) < 10 {
+		return parsed, fmt.Errorf("stat contained fewer fields than expected")
+	}
+
+	// Convert the fields that are not plain strings
+	parsed.Packets, err = strconv.ParseUint(stat[0], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse packets")
+	}
+	parsed.Bytes, err = strconv.ParseUint(stat[1], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse bytes")
+	}
+	_, parsed.Source, err = net.ParseCIDR(stat[7])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse source")
+	}
+	_, parsed.Destination, err = net.ParseCIDR(stat[8])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse destination")
+	}
+
+	// Put the fields that are strings
+	parsed.Target = stat[2]
+	parsed.Protocol = stat[3]
+	parsed.Opt = stat[4]
+	parsed.Input = stat[5]
+	parsed.Output = stat[6]
+	parsed.Options = stat[9]
+
+	return parsed, nil
+}
+
+// StructuredStats returns statistics as structured data which may be further
+// parsed and marshaled.
+func (ipt *IPTables) StructuredStats(table, chain string) ([]Stat, error) {
+	rawStats, err := ipt.Stats(table, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	structStats := []Stat{}
+	for _, rawStat := range rawStats {
+		stat, err := ipt.ParseStat(rawStat)
+		if err != nil {
+			return nil, err
+		}
+		structStats = append(structStats, stat)
+	}
+
+	return structStats, nil
+}
+
+func (ipt *IPTables) executeList(args []string) ([]string, error) {
+	var stdout bytes.Buffer
+	if err := ipt.runWithOutput(args, &stdout); err != nil {
+		return nil, err
+	}
+
+	rules := strings.Split(stdout.String(), "\n")
+
+	// strip trailing newline
+	if len(rules) > 0 && rules[len(rules)-1] == "" {
+		rules = rules[:len(rules)-1]
+	}
+
+	for i, rule := range rules {
+		rules[i] = filterRuleOutput(rule)
+	}
+
+	return rules, nil
+}
+
+// NewChain creates a new chain in the specified table.
+// If the chain already exists, it will result in an error.
+func (ipt *IPTables) NewChain(table, chain string) error {
+	return ipt.run("-t", table, "-N", chain)
+}
+
+const existsErr = 1
+
+// ClearChain flushed (deletes all rules) in the specified table/chain.
+// If the chain does not exist, a new one will be created
+func (ipt *IPTables) ClearChain(table, chain string) error {
+	err := ipt.NewChain(table, chain)
+
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return nil
+	case eok && eerr.ExitStatus() == existsErr:
+		// chain already exists. Flush (clear) it.
+		return ipt.run("-t", table, "-F", chain)
+	default:
+		return err
+	}
+}
+
+// RenameChain renames the old chain to the new one.
+func (ipt *IPTables) RenameChain(table, oldChain, newChain string) error {
+	return ipt.run("-t", table, "-E", oldChain, newChain)
+}
+
+// DeleteChain deletes the chain in the specified table.
+// The chain must be empty
+func (ipt *IPTables) DeleteChain(table, chain string) error {
+	return ipt.run("-t", table, "-X", chain)
+}
+
+func (ipt *IPTables) ClearAndDeleteChain(table, chain string) error {
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil || !exists {
+		return err
+	}
+	err = ipt.run("-t", table, "-F", chain)
+	if err == nil {
+		err = ipt.run("-t", table, "-X", chain)
+	}
+	return err
+}
+
+func (ipt *IPTables) ClearAll() error {
+	return ipt.run("-F")
+}
+
+func (ipt *IPTables) DeleteAll() error {
+	return ipt.run("-X")
+}
+
+// ChangePolicy changes policy on chain to target
+func (ipt *IPTables) ChangePolicy(table, chain, target string) error {
+	return ipt.run("-t", table, "-P", chain, target)
+}
+
+// Check if the underlying iptables command supports the --random-fully flag
+func (ipt *IPTables) HasRandomFully() bool {
+	return ipt.hasRandomFully
+}
+
+// Return version components of the underlying iptables command
+func (ipt *IPTables) GetIptablesVersion() (int, int, int) {
+	return ipt.v1, ipt.v2, ipt.v3
+}
+
+// run runs an iptables command with the given arguments, ignoring
+// any stdout output
+func (ipt *IPTables) run(args ...string) error {
+	return ipt.runWithOutput(args, nil)
+}
+
+// runWithOutput runs an iptables command with the given arguments,
+// writing any stdout output to the given writer
+func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
+	args = append([]string{ipt.path}, args...)
+	if ipt.hasWait {
+		args = append(args, "--wait")
+		if ipt.timeout != 0 && ipt.waitSupportSecond {
+			args = append(args, strconv.Itoa(ipt.timeout))
+		}
+	} else {
+		fmu, err := newXtablesFileLock()
+		if err != nil {
+			return err
+		}
+		ul, err := fmu.tryLock()
+		if err != nil {
+			syscall.Close(fmu.fd)
+			return err
+		}
+		defer ul.Unlock()
+	}
+
+	var stderr bytes.Buffer
+	cmd := exec.Cmd{
+		Path:   ipt.path,
+		Args:   args,
+		Stdout: stdout,
+		Stderr: &stderr,
+	}
+
+	if err := cmd.Run(); err != nil {
+		switch e := err.(type) {
+		case *exec.ExitError:
+			return &Error{*e, cmd, stderr.String(), nil}
+		default:
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getIptablesCommand returns the correct command for the given protocol, either "iptables" or "ip6tables".
+func getIptablesCommand(proto Protocol) string {
+	if proto == ProtocolIPv6 {
+		return "ip6tables"
+	} else {
+		return "iptables"
+	}
+}
+
+// Checks if iptables has the "-C" and "--wait" flag
+func getIptablesCommandSupport(v1 int, v2 int, v3 int) (bool, bool, bool, bool) {
+	return iptablesHasCheckCommand(v1, v2, v3), iptablesHasWaitCommand(v1, v2, v3), iptablesWaitSupportSecond(v1, v2, v3), iptablesHasRandomFully(v1, v2, v3)
+}
+
+// getIptablesVersion returns the first three components of the iptables version
+// and the operating mode (e.g. nf_tables or legacy)
+// e.g. "iptables v1.3.66" would return (1, 3, 66, legacy, nil)
+func extractIptablesVersion(str string) (int, int, int, string, error) {
+	versionMatcher := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)(?:\s+\((\w+))?`)
+	result := versionMatcher.FindStringSubmatch(str)
+	if result == nil {
+		return 0, 0, 0, "", fmt.Errorf("no iptables version found in string: %s", str)
+	}
+
+	v1, err := strconv.Atoi(result[1])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	v2, err := strconv.Atoi(result[2])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	v3, err := strconv.Atoi(result[3])
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+
+	mode := "legacy"
+	if result[4] != "" {
+		mode = result[4]
+	}
+	return v1, v2, v3, mode, nil
+}
+
+// Runs "iptables --version" to get the version string
+func getIptablesVersionString(path string) (string, error) {
+	cmd := exec.Command(path, "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// Checks if an iptables version is after 1.4.11, when --check was added
+func iptablesHasCheckCommand(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 4 {
+		return true
+	}
+	if v1 == 1 && v2 == 4 && v3 >= 11 {
+		return true
+	}
+	return false
+}
+
+// Checks if an iptables version is after 1.4.20, when --wait was added
+func iptablesHasWaitCommand(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 4 {
+		return true
+	}
+	if v1 == 1 && v2 == 4 && v3 >= 20 {
+		return true
+	}
+	return false
+}
+
+//Checks if an iptablse version is after 1.6.0, when --wait support second
+func iptablesWaitSupportSecond(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 >= 6 {
+		return true
+	}
+	return false
+}
+
+// Checks if an iptables version is after 1.6.2, when --random-fully was added
+func iptablesHasRandomFully(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 6 {
+		return true
+	}
+	if v1 == 1 && v2 == 6 && v3 >= 2 {
+		return true
+	}
+	return false
+}
+
+// Checks if a rule specification exists for a table
+func (ipt *IPTables) existsForOldIptables(table, chain string, rulespec []string) (bool, error) {
+	rs := strings.Join(append([]string{"-A", chain}, rulespec...), " ")
+	args := []string{"-t", table, "-S"}
+	var stdout bytes.Buffer
+	err := ipt.runWithOutput(args, &stdout)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(stdout.String(), rs), nil
+}
+
+// counterRegex is the regex used to detect nftables counter format
+var counterRegex = regexp.MustCompile(`^\[([0-9]+):([0-9]+)\] `)
+
+// filterRuleOutput works around some inconsistencies in output.
+// For example, when iptables is in legacy vs. nftables mode, it produces
+// different results.
+func filterRuleOutput(rule string) string {
+	out := rule
+
+	// work around an output difference in nftables mode where counters
+	// are output in iptables-save format, rather than iptables -S format
+	// The string begins with "[0:0]"
+	//
+	// Fixes #49
+	if groups := counterRegex.FindStringSubmatch(out); groups != nil {
+		// drop the brackets
+		out = out[len(groups[0]):]
+		out = fmt.Sprintf("%s -c %s %s", out, groups[1], groups[2])
+	}
+
+	return out
+}

--- a/vendor/github.com/coreos/go-iptables/iptables/lock.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/lock.go
@@ -1,0 +1,84 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"os"
+	"sync"
+	"syscall"
+)
+
+const (
+	// In earlier versions of iptables, the xtables lock was implemented
+	// via a Unix socket, but now flock is used via this lockfile:
+	// http://git.netfilter.org/iptables/commit/?id=aa562a660d1555b13cffbac1e744033e91f82707
+	// Note the LSB-conforming "/run" directory does not exist on old
+	// distributions, so assume "/var" is symlinked
+	xtablesLockFilePath = "/var/run/xtables.lock"
+
+	defaultFilePerm = 0600
+)
+
+type Unlocker interface {
+	Unlock() error
+}
+
+type nopUnlocker struct{}
+
+func (_ nopUnlocker) Unlock() error { return nil }
+
+type fileLock struct {
+	// mu is used to protect against concurrent invocations from within this process
+	mu sync.Mutex
+	fd int
+}
+
+// tryLock takes an exclusive lock on the xtables lock file without blocking.
+// This is best-effort only: if the exclusive lock would block (i.e. because
+// another process already holds it), no error is returned. Otherwise, any
+// error encountered during the locking operation is returned.
+// The returned Unlocker should be used to release the lock when the caller is
+// done invoking iptables commands.
+func (l *fileLock) tryLock() (Unlocker, error) {
+	l.mu.Lock()
+	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	switch err {
+	case syscall.EWOULDBLOCK:
+		l.mu.Unlock()
+		return nopUnlocker{}, nil
+	case nil:
+		return l, nil
+	default:
+		l.mu.Unlock()
+		return nil, err
+	}
+}
+
+// Unlock closes the underlying file, which implicitly unlocks it as well. It
+// also unlocks the associated mutex.
+func (l *fileLock) Unlock() error {
+	defer l.mu.Unlock()
+	return syscall.Close(l.fd)
+}
+
+// newXtablesFileLock opens a new lock on the xtables lockfile without
+// acquiring the lock
+func newXtablesFileLock() (*fileLock, error) {
+	fd, err := syscall.Open(xtablesLockFilePath, os.O_CREATE, defaultFilePerm)
+	if err != nil {
+		return nil, err
+	}
+	return &fileLock{fd: fd}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/README.md
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/README.md
@@ -1,0 +1,161 @@
+# Static Pod Controllers
+
+OpenShift 4.x deploys the following foundational components as [static
+pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/):
+
+- etcd
+- kube-apiserver
+- kube-controller-manager
+- kube-scheduler
+
+These components comprise the minimum control plane on which all other
+OpenShift components are hosted.
+
+The operators that manage these foundational components rely on the
+set of controllers found in the `pkg/operator/staticpod` package and
+its children. These controllers are collectively responsible for
+generating static pod manifests and related configuration and writing
+them to the static pod manifests (`/etc/kubernetes/manifests`) and
+static pod resources (`/etcd/kubernetes/static-pod-resources`) paths,
+respectively, on each control plane node.
+
+The controllers take as input resources read from the OpenShift
+API. That means these controllers won't work without an
+apiserver. Installation of a new cluster involves creating bootstrap
+versions of the foundational components before these controllers can
+take over.
+
+## High-level flow
+
+A given operator (e.g. `cluster-kube-apiserver-operator`) configures a
+set of static pod controllers via the `staticpod` package's
+`NewBuilder` function and associated `With*` methods. Configuration includes:
+
+ - the set of configmaps and secrets containing configuration data for
+   the static pod
+   - the first configmap is expected to contain the static pod
+ - the set of configmaps and secrets containing ca bundles and tls certs
+   - resources containing tls data are supplied separately from other
+     resources to allow reload without restart/redeploy of the static pod
+ - the operator namespace
+
+A static pod rollout occurs as follows:
+
+ - the revision controller determines that a new revision is
+   required. Triggers include:
+   - no revision is present
+   - the watched resources have changed since the current revision
+   - rollout has been manually triggered by setting
+     forceRedeploymentReason in the operator config
+ - the installer controller creates an installer pod for the new
+   revision for each control plane node
+   - the image of the installer pod is typically the operator image
+     and the command defined by the operator
+ - each installer pod copies the resources and static pod manifest for
+   the current revision to the host filesystem
+ - the installer state controller watches the installer pods for
+   indications of failure and records any problem in operator status
+ - the static pod state controller watches static pods for indications
+   of failure and records any problem in operator status
+
+## Status
+
+The static pod controllers record status in the following resources:
+
+ - Operator config
+   - e.g. operator.openshift.io/v1:KubeAPIServer/cluster
+   - used by the operator to track its state
+     - operator-specific conditions
+     - static pod accounting e.g.
+       - latestAvailableRevision
+       - nodeStatuses
+
+ - Cluster operator status
+   - e.g. config.openshift.io/v1:ClusterOperator/kube-apiserver
+   - used by the operator to convey its state to the cluster
+     - degraded/progressing/available conditions
+     - relatedObjects
+       - used by must-gather to know what to collect
+     - records component versions
+
+### Revision
+
+[Controller Definition](../revisioncontroller/revision_controller.go)
+
+ - copies tracked secrets and configmaps when they change
+   - the name of the copied resources is suffixed with the new revision
+   - ensures that installer pods can copy the resources for a revision
+     without fear of them changing during the rollout
+ - maintains 'revision' configmaps indicating status of a given revision
+   - allows determining what the current revision is
+   - provides status to the prune controller
+
+### Installer
+
+[Controller Definition](controller/installer/installer_controller.go)
+
+ - creates installer pod per control plane node for a given revision
+ - watches statis pod controllers for evidence that a new revision is required
+
+### Installer State
+
+[Controller Definition](controller/installerstate/installer_state_controller.go)
+
+ - watches installer pods in the operand namespace
+ - records in operator status if pod are pending for more than a max duration
+   - pod pending
+   - pod container waiting
+   - failed to create pod network
+
+### Static Pod State
+
+[Controller Definition](controller/staticpodstate/staticpodstate_controller.go)
+
+ - watches static pods in the operand namespace
+ - sets 'StaticPodsDegraded' condition
+
+### Prune
+
+[Controller Definition](controller/prune/prune_controller.go)
+
+ - ensures a maximum number of revisioned resources by removing old
+   revisioned resources
+
+### Node
+
+[Controller Definition](controller/node/node_controller.go)
+
+ - updates MasterNodesReady operator status condition
+ - sets StaticPodOperatorStatus in operator status e.g.
+   - latestAvailableRevision
+   - latestAvailableRevisionReason
+   - nodeStatuses
+     - nodeName
+     - currentRevision
+     - targetRevision
+     - lastFailedRevision
+     - lastFailedRevisionErrors
+
+### Static Resource
+
+[Controller Definition](../staticresourcecontroller/static_resource_controller.go)
+
+ - applies static manifests required by installer pods
+   - service account
+   - cluster role binding
+
+### Unsupported Config Overrides
+
+[Controller Definition](../unsupportedconfigoverridescontroller/unsupportedconfigoverrides_controller.go)
+
+ - sets `UnsupportedConfigOverridesSet` condition in operator status
+   if `spec.unsupportedConfigOverrides` is not empty
+ - has nothing to do with deployment of static pods.
+
+### Cluster Operator Logging
+
+[Controller Definition](../loglevel/logging_controller.go)
+
+ - supports changing the klog logging level for the operator via a
+   value specified in the operator config
+ - has nothing to do with deployment of static pods.

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/util.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/util.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func MirrorPodNameForNode(staticPodName, nodeName string) string {
+	return staticPodName + "-" + nodeName
+}
+
+// GetStaticPod assumes a single mirror pod for each node.
+func GetStaticPod(ctx context.Context, podsGetter corev1client.PodsGetter, namespace, staticPodName, nodeName string) (*corev1.Pod, error) {
+	return podsGetter.Pods(namespace).Get(ctx, MirrorPodNameForNode(staticPodName, nodeName), metav1.GetOptions{})
+}
+
+// StaticPodFunc retrieves the active static pod for a node
+type StaticPodFunc func(ctx context.Context, podsGetter corev1client.PodsGetter, namespace, staticPodName, nodeName string) (*corev1.Pod, error)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,6 +14,9 @@ github.com/beorn7/perks/quantile
 github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
+# github.com/coreos/go-iptables v0.6.0
+## explicit
+github.com/coreos/go-iptables/iptables
 # github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
@@ -218,7 +221,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc
+# github.com/openshift/library-go v0.0.0-20210414082648-6e767630a0dc => github.com/marun/library-go v0.0.0-20210420192337-3a0db88f982f
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
@@ -274,6 +277,7 @@ github.com/openshift/library-go/pkg/operator/revisioncontroller
 github.com/openshift/library-go/pkg/operator/staleconditions
 github.com/openshift/library-go/pkg/operator/staticpod
 github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod
+github.com/openshift/library-go/pkg/operator/staticpod/controller
 github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource
 github.com/openshift/library-go/pkg/operator/staticpod/controller/backingresource/bindata
 github.com/openshift/library-go/pkg/operator/staticpod/controller/installer
@@ -1074,3 +1078,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
 # k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99
+# github.com/openshift/library-go => github.com/marun/library-go v0.0.0-20210420192337-3a0db88f982f


### PR DESCRIPTION
**NOTE** This PR depends on https://github.com/openshift/library-go/pull/1054

Preliminary work to enable graceful rollout for single replica control plane.

TODO
 - [ ] Enable log rotation
 - [ ] Ensure internal traffic is directed to the api server. Currently hardcoded. Possible solutions: 
        -  Have installer pod configure the graceful monitor with the node ip and cluster ips for `default/kubernetes` and `openshift-kube-apiserver/apiserver`
        - Fix kube-apiserver endpoint controller to properly set the endpoint port
        - Use a reverse proxy e.g. [caddy](https://caddyserver.com/docs/quick-starts/reverse-proxy)
 - [ ] Switch to checking pod health via the installer pod so that the monitor pod's only responsibility is ensuring a static configuration
 - [ ] e2e testing

/cc @sttts 