### PR TITLE
WIP - Add etcd object counts alert

### DIFF
--- a/bindata/v4.1.0/alerts/etcd-object-counts.yaml
+++ b/bindata/v4.1.0/alerts/etcd-object-counts.yaml
@@ -3,39 +3,40 @@ kind: PrometheusRule
 metadata:
   name: etcd-object-counts
   namespace: openshift-kube-apiserver
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: etcd-object-counts
       rules:
-        - alert: etcdHighObjectCounts
+        - alert: etcdHighCRDObjectCounts
           annotations:
-            summary: "etcd recorded more than 100000 objects. Latest count: {{ $value }}"
+            summary: etcd recorded {{ $value }} {{ $labels.resource }} objects.
             description: |
-              A high object count of more than 100000 objects may lead to stability issue in the API server and etcd storage stack. If this value continues to increase, it may degrade the responsiveness of the API server and etcd.
-              To fix this, use the following query to determine the top-5 highest resource kinds:
-                  topk(5, sum(etcd_object_counts) by (apiserver,namespace,resource))
-              Depending on the resource kinds, additional metrics can be used to help identify the actual resources. For example,
-                  count(kube_secret_info) by (namespace)
-              shows the number of secrets grouped by namespaces.
-              Additional resource metrics can be found at https://github.com/kubernetes/kube-state-metrics/tree/master/docs
+              etcd recorded {{ $value }} {{ $labels.resource }} objects. A high number of CRD objects is known to have caused stability issues in the API server and etcd storage stack. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighObjectCounts.md
           expr: |
-            sum(etcd_object_counts) > 100000
+            cluster:usage:resources:sum{resource!~".*k8s.io|^[^.]+"} > 200
           for: 10m
           labels:
             severity: warning
-        - alert: etcdIncreasingObjectCounts
+        - alert: etcdHighK8sObjectCounts
           annotations:
-            summary: "Increasing number of {{ $labels.resource }} objects in etcd."
+            summary: etcd recorded {{ $value }} {{ $labels.resource }} objects.
             description: |
-              The number of {{ $labels.resource }} objects have increased by {{ $value }} in the last 10 minutes. If this is unexpected, there are some additional metrics at https://github.com/kubernetes/kube-state-metrics/tree/master/docs that may be used to identify the actual resources. For example,
-                  count(kube_secret_info) by (namespace)
-              shows the number of secrets grouped by namespaces.
+              etcd recorded {{ $value }} {{ $labels.resource }} objects. A high number of objects is known to have caused stability issues in the API server and etcd storage stack. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighObjectCounts.md
           expr: |
-            sum(rate(etcd_object_counts[10m])) by (resource) > 100
+            cluster:usage:resources:sum{resource=~".*k8s.io|^[^.]+"} > 700
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeAPIIncreasingListResponseSize
+          annotations:
+            summary: The LIST response size among the {{ if $labels.group }}{{ $labels.group }}/{{ end }}{{ $labels.version }}/{{ $labels.resource }} objects has been increasing.
+            description: |
+              The LIST response size among the {{ if $labels.group }}{{ $labels.group }}/{{ end }}{{ $labels.version }}/{{ $labels.resource }} objects has been increasing at an average rate of {{ printf "%.2f" "$value" }} bytes/second in the past 10 minutes. If this rate continues to increase, it can caused stability issues in the API server. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/kubeAPIIncreasingListResponseSize.md
+          expr: |
+            sum by(group,version,resource)(rate(apiserver_response_sizes_sum{verb="LIST"}[10m])) > 100000
           for: 10m
           labels:
             severity: warning

--- a/bindata/v4.1.0/alerts/etcd-object-counts.yaml
+++ b/bindata/v4.1.0/alerts/etcd-object-counts.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-object-counts
+  namespace: openshift-kube-apiserver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  groups:
+    - name: etcd-object-counts
+      rules:
+        - alert: etcdHighObjectCounts
+          annotations:
+            summary: "etcd recorded more than 100000 objects. Latest count: {{ $value }}"
+            description: |
+              A high object count of more than 100000 objects may lead to stability issue in the API server and etcd storage stack. If this value continues to increase, it may degrade the responsiveness of the API server and etcd.
+              To fix this, use the following query to determine the top-5 highest resource kinds:
+                  topk(5, sum(etcd_object_counts) by (apiserver,namespace,resource))
+              Depending on the resource kinds, additional metrics can be used to help identify the actual resources. For example,
+                  count(kube_secret_info) by (namespace)
+              shows the number of secrets grouped by namespaces.
+              Additional resource metrics can be found at https://github.com/kubernetes/kube-state-metrics/tree/master/docs
+          expr: |
+            sum(etcd_object_counts) > 100000
+          for: 10m
+          labels:
+            severity: warning
+        - alert: etcdIncreasingObjectCounts
+          annotations:
+            summary: "Increasing number of {{ $labels.resource }} objects in etcd."
+            description: |
+              The number of {{ $labels.resource }} objects have increased by {{ $value }} in the last 10 minutes. If this is unexpected, there are some additional metrics at https://github.com/kubernetes/kube-state-metrics/tree/master/docs that may be used to identify the actual resources. For example,
+                  count(kube_secret_info) by (namespace)
+              shows the number of secrets grouped by namespaces.
+          expr: |
+            sum(rate(etcd_object_counts[10m])) by (resource) > 100
+          for: 10m
+          labels:
+            severity: warning

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -147,6 +147,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"v4.1.0/alerts/api-usage.yaml",
 			"v4.1.0/alerts/cpu-utilization.yaml",
 			"v4.1.0/alerts/kube-apiserver-requests.yaml",
+			"v4.1.0/alerts/etcd-object-counts.yaml",
 		},
 		(&resourceapply.ClientHolder{}).
 			WithKubernetes(kubeClient).

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -2,6 +2,7 @@
 // sources:
 // bindata/v4.1.0/alerts/api-usage.yaml
 // bindata/v4.1.0/alerts/cpu-utilization.yaml
+// bindata/v4.1.0/alerts/etcd-object-counts.yaml
 // bindata/v4.1.0/alerts/kube-apiserver-requests.yaml
 // bindata/v4.1.0/config/config-overrides.yaml
 // bindata/v4.1.0/config/defaultconfig.yaml
@@ -195,6 +196,65 @@ func v410AlertsCpuUtilizationYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v4.1.0/alerts/cpu-utilization.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _v410AlertsEtcdObjectCountsYaml = []byte(`apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-object-counts
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+    - name: etcd-object-counts
+      rules:
+        - alert: etcdHighCRDObjectCounts
+          annotations:
+            summary: etcd recorded {{ $value }} {{ $labels.resource }} objects.
+            description: |
+              etcd recorded {{ $value }} {{ $labels.resource }} objects. A high number of CRD objects is known to have caused stability issues in the API server and etcd storage stack. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighObjectCounts.md
+          expr: |
+            cluster:usage:resources:sum{resource!~".*k8s.io|^[^.]+"} > 200
+          for: 10m
+          labels:
+            severity: warning
+        - alert: etcdHighK8sObjectCounts
+          annotations:
+            summary: etcd recorded {{ $value }} {{ $labels.resource }} objects.
+            description: |
+              etcd recorded {{ $value }} {{ $labels.resource }} objects. A high number of objects is known to have caused stability issues in the API server and etcd storage stack. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/etcdHighObjectCounts.md
+          expr: |
+            cluster:usage:resources:sum{resource=~".*k8s.io|^[^.]+"} > 700
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeAPIIncreasingListResponseSize
+          annotations:
+            summary: The LIST response size among the {{ if $labels.group }}{{ $labels.group }}/{{ end }}{{ $labels.version }}/{{ $labels.resource }} objects has been increasing.
+            description: |
+              The LIST response size among the {{ if $labels.group }}{{ $labels.group }}/{{ end }}{{ $labels.version }}/{{ $labels.resource }} objects has been increasing at an average rate of {{ printf "%.2f" "$value" }} bytes/second in the past 10 minutes. If this rate continues to increase, it can caused stability issues in the API server. Information on diagnosis and mitigation steps can be found in the runbook.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/kubeAPIIncreasingListResponseSize.md
+          expr: |
+            sum by(group,version,resource)(rate(apiserver_response_sizes_sum{verb="LIST"}[10m])) > 100000
+          for: 10m
+          labels:
+            severity: warning
+`)
+
+func v410AlertsEtcdObjectCountsYamlBytes() ([]byte, error) {
+	return _v410AlertsEtcdObjectCountsYaml, nil
+}
+
+func v410AlertsEtcdObjectCountsYaml() (*asset, error) {
+	bytes, err := v410AlertsEtcdObjectCountsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/alerts/etcd-object-counts.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2109,6 +2169,7 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"v4.1.0/alerts/api-usage.yaml":                                                 v410AlertsApiUsageYaml,
 	"v4.1.0/alerts/cpu-utilization.yaml":                                           v410AlertsCpuUtilizationYaml,
+	"v4.1.0/alerts/etcd-object-counts.yaml":                                        v410AlertsEtcdObjectCountsYaml,
 	"v4.1.0/alerts/kube-apiserver-requests.yaml":                                   v410AlertsKubeApiserverRequestsYaml,
 	"v4.1.0/config/config-overrides.yaml":                                          v410ConfigConfigOverridesYaml,
 	"v4.1.0/config/defaultconfig.yaml":                                             v410ConfigDefaultconfigYaml,
@@ -2186,6 +2247,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"alerts": {nil, map[string]*bintree{
 			"api-usage.yaml":               {v410AlertsApiUsageYaml, map[string]*bintree{}},
 			"cpu-utilization.yaml":         {v410AlertsCpuUtilizationYaml, map[string]*bintree{}},
+			"etcd-object-counts.yaml":      {v410AlertsEtcdObjectCountsYaml, map[string]*bintree{}},
 			"kube-apiserver-requests.yaml": {v410AlertsKubeApiserverRequestsYaml, map[string]*bintree{}},
 		}},
 		"config": {nil, map[string]*bintree{

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -23,8 +23,8 @@ func readAllYaml(path string, t *testing.T) {
 			// the dashboard is a ConfigMap yaml but it has an embedded json in data that causes the reader to fail.
 			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml") &&
 			// there is an alert message containing $labels strings that cause the reader to fail.
-			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml")
-
+			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml") &&
+			!strings.HasSuffix(info.Name(), "etcd-object-counts.yaml")
 	})
 	if err != nil {
 		t.Errorf("Unexpected error reading manifests from %s: %v", path, err)


### PR DESCRIPTION
This PR adds some new etcd alerts to warn the users on high and increasing
object counts in etcd. The thresholds used in these alerts are derived from a
load test performed on a 4.8.0-fc.0 cluster on GCP. The test observed the
effect of creating ~120K imagestream objects on etcd peer network latency,
leader's health, disk performance, failed peer proposals, and network bytes
sent/received.

The YAML of the imagestream used for testing can be found [here](https://gist.github.com/ihcsim/a9e612a91b4757d163a1de8f3dc510f2). It was 
copied from the OOB `ruby` imagestream.

JIRA: [API-1220](https://issues.redhat.com/browse/API-1220).

Pending:

* Is it worth repeating the same tests on Azure, which is known to experience etcd disk performance latency more often?
* Alerts description usually provides links to incident runbook. Assuming we don't have one atm, are we ok with more verbose alert description?
* This PR depends on Go code changes in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1073

<details>
<summary>Here are the results of my test run:</summary>

The number of objects increased from 20k to 120k over a 12-hour period:
![image](https://user-images.githubusercontent.com/1330522/116275263-4dc9a580-a738-11eb-8803-09130647e863.png)

The rate of increase of the object counts grouped by resources, seems to be
dominated by `Event`s, follow by `ImageStream`s. I am not sure if there is a
way to increase this rate, as it seems a more aggressive increase rate will
trigger the kind of errors some users saw. FWIW, replacing `rate` with 
`increase` yields an identical trend:
![image](https://user-images.githubusercontent.com/1330522/116276767-ad748080-a739-11eb-90a3-f8b6ba6d5a4a.png)

No issues with leader election:
![image](https://user-images.githubusercontent.com/1330522/116277395-4905f100-a73a-11eb-82bc-32fe886363be.png)

![image](https://user-images.githubusercontent.com/1330522/116277542-6fc42780-a73a-11eb-967a-3342a10f182c.png)

No major degradation in disk performance with lowest value being 
6.25ms and peaked at 9.5ms:
![image](https://user-images.githubusercontent.com/1330522/116277775-a732d400-a73a-11eb-8fc7-b2329c05b0da.png)

![image](https://user-images.githubusercontent.com/1330522/116277860-be71c180-a73a-11eb-92f8-76885b31352b.png)

Other than a 20-minute blip in network round trip latency (from 0.03 to 
0.06 seconds), everything looks normal: 
![image](https://user-images.githubusercontent.com/1330522/116278006-e6f9bb80-a73a-11eb-961b-ca0bbc25d0db.png)

No network packets loss:
![image](https://user-images.githubusercontent.com/1330522/116278473-5f607c80-a73b-11eb-985b-d37dc2b3078d.png)

To get a better sense of the traffic quality between the peers, I also 
captured some `proposal_*` metrics. No prolonged failed and pending 
proposals communication in this test run:
![image](https://user-images.githubusercontent.com/1330522/116278862-bfefb980-a73b-11eb-8e32-f40b1fc78363.png)

![image](https://user-images.githubusercontent.com/1330522/116279139-0c3af980-a73c-11eb-80d3-954e6ec1e95b.png)
</details>