### PR TITLE
bug 1955226: update library-go to avoid CRD update loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.8
-	github.com/openshift/api v0.0.0-20210428112725-f951947e8995
+	github.com/openshift/api v0.0.0-20210429235223-e5fb810477d3
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535
-	github.com/openshift/library-go v0.0.0-20210429163314-32304c314a2e
+	github.com/openshift/library-go v0.0.0-20210430084706-e555322cb708
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/openshift/api v0.0.0-20210331162552-3e31249e6a55/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
 github.com/openshift/api v0.0.0-20210331193751-3acddb19d360/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
 github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
-github.com/openshift/api v0.0.0-20210428112725-f951947e8995 h1:r2uFeTj8263g52GA6wwq6+NbT6r42RqVps8Uze4YM+c=
-github.com/openshift/api v0.0.0-20210428112725-f951947e8995/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
+github.com/openshift/api v0.0.0-20210429235223-e5fb810477d3 h1:7PZf6SH0EqK6X6sdlLXPw/rnx1bpLCDW+xLbvi2zYcE=
+github.com/openshift/api v0.0.0-20210429235223-e5fb810477d3/go.mod h1:dZ4kytOo3svxJHNYd0J55hwe/6IQG5gAUHUE0F3Jkio=
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e h1:F7rBobgSjtYL3/zsgDUjlTVx3Z06hdgpoldpDcn7jzc=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
@@ -428,8 +428,8 @@ github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535 h1:JGSJhDJiQxq
 github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535/go.mod h1:v5/AYttPCjfqMGC1Ed/vutuDpuXmgWc5O+W9nwQ7EtE=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210429163314-32304c314a2e h1:BxMVC+xYW646Xgq6qQcDIi9AoXFxSBD3F+09NoUtbGo=
-github.com/openshift/library-go v0.0.0-20210429163314-32304c314a2e/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
+github.com/openshift/library-go v0.0.0-20210430084706-e555322cb708 h1:Xnx252xAZag9fk8IhWdgqkfVkF2c1jMIM5cq4/y8mmM=
+github.com/openshift/library-go v0.0.0-20210430084706-e555322cb708/go.mod h1:pnz961veImKsbn7pQcuFbcVpCQosYiC1fUOjzEDeOLU=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_operator.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_operator.go
@@ -142,6 +142,8 @@ type ClusterStatusConditionType string
 const (
 	// Available indicates that the operand (eg: openshift-apiserver for the
 	// openshift-apiserver-operator), is functional and available in the cluster.
+	// Available=False means at least part of the component is non-functional,
+	// and that the condition requires immediate administrator intervention.
 	OperatorAvailable ClusterStatusConditionType = "Available"
 
 	// Progressing indicates that the operator is actively rolling out new code,
@@ -162,10 +164,10 @@ const (
 	// persist over a long enough period to report Degraded.  A service should not
 	// report Degraded during the course of a normal upgrade.  A service may report
 	// Degraded in response to a persistent infrastructure failure that requires
-	// administrator intervention.  For example, if a control plane host is unhealthy
-	// and must be replaced.  An operator should report Degraded if unexpected
-	// errors occur over a period, but the expectation is that all unexpected errors
-	// are handled as operators mature.
+	// eventual administrator intervention.  For example, if a control plane host
+	// is unhealthy and must be replaced.  An operator should report Degraded if
+	// unexpected errors occur over a period, but the expectation is that all
+	// unexpected errors are handled as operators mature.
 	OperatorDegraded ClusterStatusConditionType = "Degraded"
 
 	// Upgradeable indicates whether the operator is in a state that is safe to upgrade. When status is `False`

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -1,9 +1,12 @@
 package resourcemerge
 
 import (
+	"strings"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
@@ -23,9 +26,43 @@ func EnsureCustomResourceDefinitionV1Beta1(modified *bool, existing *apiextensio
 func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextensionsv1.CustomResourceDefinition, required apiextensionsv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
+	// we need to match defaults
+	mimicCRDV1Defaulting(&required)
 	// we stomp everything
 	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
 		*modified = true
 		existing.Spec = required.Spec
+	}
+}
+
+func mimicCRDV1Defaulting(required *apiextensionsv1.CustomResourceDefinition) {
+	crd_SetDefaults_CustomResourceDefinitionSpec(&required.Spec)
+
+	if required.Spec.Conversion != nil &&
+		required.Spec.Conversion.Webhook != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig.Service != nil {
+		crd_SetDefaults_ServiceReference(required.Spec.Conversion.Webhook.ClientConfig.Service)
+	}
+}
+
+// lifted from https://github.com/kubernetes/kubernetes/blob/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go#L42-L61
+func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomResourceDefinitionSpec) {
+	if len(obj.Names.Singular) == 0 {
+		obj.Names.Singular = strings.ToLower(obj.Names.Kind)
+	}
+	if len(obj.Names.ListKind) == 0 && len(obj.Names.Kind) > 0 {
+		obj.Names.ListKind = obj.Names.Kind + "List"
+	}
+	if obj.Conversion == nil {
+		obj.Conversion = &apiextensionsv1.CustomResourceConversion{
+			Strategy: apiextensionsv1.NoneConverter,
+		}
+	}
+}
+
+func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
+	if obj.Port == nil {
+		obj.Port = utilpointer.Int32Ptr(443)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20210428112725-f951947e8995
+# github.com/openshift/api v0.0.0-20210429235223-e5fb810477d3
 ## explicit
 github.com/openshift/api
 github.com/openshift/api/apiserver
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210429163314-32304c314a2e
+# github.com/openshift/library-go v0.0.0-20210430084706-e555322cb708
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
proof of https://github.com/openshift/library-go/pull/1065