### PR TITLE
Add a nominal request to the kube-apiserver init container

### DIFF
--- a/bindata/v4.1.0/kube-apiserver/pod.yaml
+++ b/bindata/v4.1.0/kube-apiserver/pod.yaml
@@ -31,6 +31,10 @@ spec:
         done
       securityContext:
         privileged: true
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
   containers:
   - name: kube-apiserver
     image: ${IMAGE}

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -1653,6 +1653,10 @@ spec:
         done
       securityContext:
         privileged: true
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
   containers:
   - name: kube-apiserver
     image: ${IMAGE}


### PR DESCRIPTION
This pod needs a nominal request so that the workload partitioning
kubelet mutation can act upon it.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>