### PR TITLE
Bug 1956081: Update bootstrap manifest namespace for SNO compatibility

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -2,7 +2,9 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: bootstrap-kube-apiserver
-  namespace: kube-system
+  # Use the same namespace for the bootstrap apiserver as the post-bootstrap
+  # apiserver for compatibility with a single-node (SNO) cluster.
+  namespace: openshift-kube-apiserver
   labels:
     openshift.io/control-plane: "true"
     openshift.io/component: "api"


### PR DESCRIPTION
Previously, the bootstrap manifest defined a pod in the `kube-system` namespace. After bootstrap of an SNO cluster, the CKAO updated the same same file (/etc/kubernetes/manifests/kube-apiserver-pod.yaml) to define a pod in the `openshift-kube-apiserver` namespace. The kubelet did not appear to consistently tear down the containers of the old pod. If the previous apiserver or insecure readyz containers continued to run, the new pod failed to start due to 6443 and/or 6080 remaining bound by the old pod's containers.

/cc @sttts 