### PR TITLE
bug 1957645: avoid warm loop for writing prometheus rules

### DIFF
--- a/bindata/v4.1.0/alerts/cpu-utilization.yaml
+++ b/bindata/v4.1.0/alerts/cpu-utilization.yaml
@@ -8,15 +8,16 @@ spec:
     - name: control-plane-cpu-utilization
       rules:
         - alert: HighOverallControlPlaneCPU
-          summary: >
-            CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
-            cause a cascading failure; increase available CPU.
-          message: >
-            Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
-            This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be HA.
-            If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
-            fail when they take the load.
-            To fix this, increase the CPU and memory on your control plane nodes.
+          annotations:
+            summary: >-
+              CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
+              cause a cascading failure; increase available CPU.
+            message: >-
+              Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
+              This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be HA.
+              If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
+              fail when they take the load.
+              To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
             sum(
               100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
@@ -30,16 +31,16 @@ spec:
             severity: warning
         - alert: ExtremelyHighIndividualControlPlaneCPU
           annotations:
-          summary: >
-            CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
-          message: >
-            Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
-            When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
-            causing even more CPU pressure.
-            It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
-            If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
-            kube-apiservers are also under-provisioned.
-            To fix this, increase the CPU and memory on your control plane nodes.
+            summary: >-
+              CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
+            message: >-
+              Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
+              When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
+              causing even more CPU pressure.
+              It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
+              If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
+              kube-apiservers are also under-provisioned.
+              To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
             100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
           for: 5m

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -144,15 +144,16 @@ spec:
     - name: control-plane-cpu-utilization
       rules:
         - alert: HighOverallControlPlaneCPU
-          summary: >
-            CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
-            cause a cascading failure; increase available CPU.
-          message: >
-            Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
-            This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be HA.
-            If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
-            fail when they take the load.
-            To fix this, increase the CPU and memory on your control plane nodes.
+          annotations:
+            summary: >-
+              CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
+              cause a cascading failure; increase available CPU.
+            message: >-
+              Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
+              This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be HA.
+              If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
+              fail when they take the load.
+              To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
             sum(
               100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
@@ -166,16 +167,16 @@ spec:
             severity: warning
         - alert: ExtremelyHighIndividualControlPlaneCPU
           annotations:
-          summary: >
-            CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
-          message: >
-            Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
-            When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
-            causing even more CPU pressure.
-            It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
-            If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
-            kube-apiservers are also under-provisioned.
-            To fix this, increase the CPU and memory on your control plane nodes.
+            summary: >-
+              CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
+            message: >-
+              Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
+              When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
+              causing even more CPU pressure.
+              It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
+              If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
+              kube-apiservers are also under-provisioned.
+              To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
             100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
           for: 5m


### PR DESCRIPTION
1. brings in the lib-go fixes https://github.com/openshift/library-go/pull/1070
2. fixes the formatting for one naughty rule
3. writes up a dockerfile I used for testing.