### PR TITLE
Bug 1943804: split encryption tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,14 @@ test-e2e-encryption: GO_TEST_FLAGS += -p 1
 test-e2e-encryption: test-unit
 .PHONY: test-e2e-encryption
 
+# these are extremely slow serial e2e encryption rotation tests that modify the cluster's global state
+test-e2e-encryption-rotation: GO_TEST_PACKAGES :=./test/e2e-encryption-rotation/...
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -v
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption-rotation: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-rotation: test-unit
+.PHONY: test-e2e-encryption-rotation
+
 test-e2e-encryption-perf: GO_TEST_PACKAGES :=./test/e2e-encryption-perf/...
 test-e2e-encryption-perf: GO_TEST_FLAGS += -v
 test-e2e-encryption-perf: GO_TEST_FLAGS += -timeout 1h

--- a/test/e2e-encryption-rotation/encryption_rotation_test.go
+++ b/test/e2e-encryption-rotation/encryption_rotation_test.go
@@ -1,0 +1,40 @@
+package e2e_encryption_rotation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestEncryptionRotation first encrypts data with aescbc key
+// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
+func TestEncryptionRotation(t *testing.T) {
+	library.TestEncryptionRotation(t, library.RotationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
+		},
+		CreateResourceFunc: operatorencryption.CreateAndStoreSecretOfLife,
+		GetRawResourceFunc: operatorencryption.GetRawSecretOfLife,
+		UnsupportedConfigFunc: func(raw []byte) error {
+			operatorClient := operatorencryption.GetOperator(t)
+			apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			apiServerOperator.Spec.UnsupportedConfigOverrides.Raw = raw
+			_, err = operatorClient.Update(context.TODO(), apiServerOperator, metav1.UpdateOptions{})
+			return err
+		},
+	})
+}

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -1,11 +1,8 @@
 package e2e_encryption
 
 import (
-	"context"
 	"fmt"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
@@ -52,33 +49,5 @@ func TestEncryptionTurnOnAndOff(t *testing.T) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
-	})
-}
-
-// TestEncryptionRotation first encrypts data with aescbc key
-// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
-func TestEncryptionRotation(t *testing.T) {
-	library.TestEncryptionRotation(t, library.RotationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
-		},
-		CreateResourceFunc: operatorencryption.CreateAndStoreSecretOfLife,
-		GetRawResourceFunc: operatorencryption.GetRawSecretOfLife,
-		UnsupportedConfigFunc: func(raw []byte) error {
-			operatorClient := operatorencryption.GetOperator(t)
-			apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			apiServerOperator.Spec.UnsupportedConfigOverrides.Raw = raw
-			_, err = operatorClient.Update(context.TODO(), apiServerOperator, metav1.UpdateOptions{})
-			return err
-		},
 	})
 }


### PR DESCRIPTION
The current timeout for all encryption tests is 4 hours.
Previously the time needed to roll out a new KAS was 15 minutes, due to a known issue on AWS with the NLB it can take now 22 minutes.
It means that the tests need ~25 min to make sure that all servers are on the same revision and it is safe to start the test.

Since the rotation scenario needs to enable the encryption first, then wait and check if all resources were migrated, then change the encryption key and check the migration again.
It means that only these tests will need ~1 hour just for installing the servers.

Thus this PR moves the rotation tests to a separate CI job.
It will shorten the overall time needed to test encryption but also increase the pass rate of the tests as we have seen them frequently failing to due to a timeout.

xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1079