### PR TITLE
Set proper root image in .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.16
+  tag: rhel-8-release-golang-1.16-openshift-4.8


### PR DESCRIPTION
We should be always using `rhel-8-release-golang-1.16-openshift-4.8` not `golang-1.16` since the other is deprecated and is missing a lot of tooling needed for build process. 

/assign @mfojtik 