### PR TITLE
Bug 1907309: Add APF storage version migration manifest

### DIFF
--- a/manifests/0000_50_kube_apiserver-operator_09_flowcontrol_storage_version_migration.yaml
+++ b/manifests/0000_50_kube_apiserver-operator_09_flowcontrol_storage_version_migration.yaml
@@ -1,0 +1,19 @@
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: flowcontrol-flowschema-storage-version-migration
+spec:
+  resource:
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+    resource: flowschemas
+---
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: flowcontrol-prioritylevel-storage-version-migration
+spec:
+  resource:
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+    resource: prioritylevelconfigurations


### PR DESCRIPTION
This PR adds a new `StorageVersionMigration` manifest to auto-migrate APF
resources (`flowschemas` and `prioritylevelconfigurations`) from v1alpha1 to
v1beta1, following upstream APF promotion to beta.

The manifest is prefixed with [level 50](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/operators.md#how-do-i-get-added-as-a-special-run-level) to ensure that it is deployed only after the API 
server is ready, so that no special considerations are needed for update and 
downgrade scenarios.

Test steps:

* Create a 4.7.12 OCP cluster
* Build the `etcdhelper` CLI per instructions [here](https://github.com/openshift/origin/tree/master/tools/etcdhelper)
* Copy the `etcdhelper` binary to the etcdctl container of one of the `etcd` pods:

```sh
oc cp etcdhelper openshift-etcd/etcd-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal:/opt -c etcdctl
```

* Use `etcdhelper` to confirm the initial `v1alpha1` version of the APF resources:

```sh
$ oc -n openshift-etcd exec etcd-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal -c etcdctl \   
-- /opt/etcdhelper \
-key=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal.key \
-cert=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal.crt \
-cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt get /kubernetes.io/prioritylevelconfigurations/catch-all

flowcontrol.apiserver.k8s.io/v1alpha1, Kind=PriorityLevelConfiguration                                                                            
{                                                                                                                                                 
  "kind": "PriorityLevelConfiguration",                                                                                                           
  "apiVersion": "flowcontrol.apiserver.k8s.io/v1alpha1",                                                                                          
  "metadata": {                                                                                                                                   
    "name": "catch-all",                                                                                                                          
    "uid": "f48ae3ac-b938-4e29-bd4e-3c60322c7313",                                                                                                
    "generation": 1,                                                                                                                              
    "creationTimestamp": "2021-05-31T18:27:25Z",    
#...
```

* Upgrade to cluster to `4.8.0-fc5`
    * Repeat the same `etcdhelper` command at this point to see that resources are still at version v1alpha1
 
* Apply the new storage version migration manifest:

```sh
oc apply -f manifests/0000_50_kube_apiserver-operator_09_flowcontrol_storage_version_migration.yaml
```

* Confirm that the migration completed successfully:

```sh
$ oc -n openshift-kube-storage-version-migrator logs migrator-6f9f7d9cf-6g97l
I0531 21:31:28.767378       1 kubemigrator.go:110] flowcontrol-flowschema-storage-version-migration: migration running
I0531 21:31:28.954915       1 kubemigrator.go:127] flowcontrol-flowschema-storage-version-migration: migration succeeded
I0531 21:31:29.967353       1 kubemigrator.go:110] flowcontrol-prioritylevel-storage-version-migration: migration running
I0531 21:31:30.085521       1 kubemigrator.go:127] flowcontrol-prioritylevel-storage-version-migration: migration succeeded
```

* Confirm that the storage version is updated in etcd

```
$ oc -n openshift-etcd exec etcd-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal -c etcdctl \   
-- /opt/etcdhelper \
-key=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal.key \
-cert=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-isim-dev-ghtgw-master-0.c.openshift-gce-devel.internal.crt \
-cacert=/etc/kubernetes/static-pod-certs/configmaps/etcd-serving-ca/ca-bundle.crt get /kubernetes.io/prioritylevelconfigurations/catch-all

flowcontrol.apiserver.k8s.io/v1beta1, Kind=PriorityLevelConfiguration
{
  "kind": "PriorityLevelConfiguration",
  "apiVersion": "flowcontrol.apiserver.k8s.io/v1beta1",
  "metadata": {
    "name": "catch-all",
    "uid": "f48ae3ac-b938-4e29-bd4e-3c60322c7313",
    "generation": 1,
    "creationTimestamp": "2021-05-31T18:27:25Z",
#...
```