### PR TITLE
Bug 1966410: alert: exclude kcm samples from removed API alerts

### DIFF
--- a/bindata/v4.1.0/alerts/api-usage.yaml
+++ b/bindata/v4.1.0/alerts/api-usage.yaml
@@ -15,7 +15,7 @@ spec:
               a successful upgrade to the next cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
             severity: info
@@ -27,7 +27,8 @@ spec:
               a successful upgrade to the next EUS cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+
           for: 1h
           labels:
             severity: info

--- a/bindata/v4.1.0/alerts/api-usage.yaml
+++ b/bindata/v4.1.0/alerts/api-usage.yaml
@@ -11,7 +11,7 @@ spec:
           annotations:
             message: >-
               Deprecated API that will be removed in the next version is being used. Removing the workload that is using
-              the {{"{{$labels.group}}"}}.{{"{{$labels.version}}"}}/{{"{{$labels.resource}}"}} API might be necessary for
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
@@ -23,7 +23,7 @@ spec:
           annotations:
             message: >-
               Deprecated API that will be removed in the next EUS version is being used. Removing the workload that is using
-              the {{"{{$labels.group}}"}}.{{"{{$labels.version}}"}}/{{"{{$labels.resource}}"}} API might be necessary for
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next EUS cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -102,7 +102,7 @@ spec:
               a successful upgrade to the next cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager"}[4h]))) > 0
           for: 1h
           labels:
             severity: info
@@ -114,7 +114,8 @@ spec:
               a successful upgrade to the next EUS cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager"}[4h]))) > 0
+
           for: 1h
           labels:
             severity: info

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -98,11 +98,11 @@ spec:
           annotations:
             message: >-
               Deprecated API that will be removed in the next version is being used. Removing the workload that is using
-              the {{"{{$labels.group}}"}}.{{"{{$labels.version}}"}}/{{"{{$labels.resource}}"}} API might be necessary for
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager"}[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
             severity: info
@@ -110,11 +110,11 @@ spec:
           annotations:
             message: >-
               Deprecated API that will be removed in the next EUS version is being used. Removing the workload that is using
-              the {{"{{$labels.group}}"}}.{{"{{$labels.version}}"}}/{{"{{$labels.resource}}"}} API might be necessary for
+              the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next EUS cluster version.
               Refer to the apirequestcount.apiserver.openshift.io resources to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager"}[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
 
           for: 1h
           labels:

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -24,6 +24,8 @@ func readAllYaml(path string, t *testing.T) {
 			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml") &&
 			// there is an alert message containing $labels strings that cause the reader to fail.
 			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml") &&
+			// there is an alert message containing $labels strings that cause the reader to fail.
+			!strings.HasSuffix(info.Name(), "api-usage.yaml") &&
 			// the kas's pod manifest contains go template values and fails compilation
 			!strings.HasSuffix(info.Name(), "pod.yaml")
 


### PR DESCRIPTION
Counter-part to https://github.com/openshift/kubernetes/pull/784