### PR TITLE
 kube-apiserver failed to load SNI cert and key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909
+	github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909 h1:jxSIKPkt6RuD8zXWIAJHrmes4bwHNXx7e0Y+P71x8Qc=
-github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909/go.mod h1:D0QEmUeYyWP9ORJ92EprPOMkiFg72yX8GM9KxajnMAI=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255 h1:4lXXCXSNmAD56T+lL0CRQfm4aImnb1I6Va9QVtN/d+Q=
+github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/bindata/bindata.go
@@ -74,139 +74,6 @@ data:
       resources:
       - group: ""
         resources: ["events"]
-    # Don't log oauth tokens as metadata.name is the secret
-    - level: None
-      resources:
-      - group: "oauth.openshift.io"
-        resources: ["oauthaccesstokens", "oauthauthorizetokens"]
-    # Don't log authenticated requests to certain non-resource URL paths.
-    - level: None
-      userGroups: ["system:authenticated", "system:unauthenticated"]
-      nonResourceURLs:
-      - "/api*" # Wildcard matching.
-      - "/version"
-      - "/healthz"
-      - "/readyz"
-    # Log the full Identity API resource object so that the audit trail
-    # allows us to match the username with the IDP identity.
-    - level: RequestResponse
-      verbs: ["create", "update", "patch"]
-      resources:
-        - group: "user.openshift.io"
-          resources: ["identities"]
-    # A catch-all rule to log all other requests at the Metadata level.
-    - level: Metadata
-      # Long-running requests like watches that fall under this rule will not
-      # generate an audit event in RequestReceived.
-      omitStages:
-      - "RequestReceived"
-
-  writerequestbodies.yaml: |
-    apiVersion: audit.k8s.io/v1beta1
-    kind: Policy
-    metadata:
-      name: WriteRequestBodies
-    # Don't generate audit events for all requests in RequestReceived stage.
-    omitStages:
-    - "RequestReceived"
-    rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
-    # Don't log oauth tokens as metadata.name is the secret
-    - level: None
-      resources:
-      - group: "oauth.openshift.io"
-        resources: ["oauthaccesstokens", "oauthauthorizetokens"]
-    # Don't log authenticated requests to certain non-resource URL paths.
-    - level: None
-      userGroups: ["system:authenticated", "system:unauthenticated"]
-      nonResourceURLs:
-      - "/api*" # Wildcard matching.
-      - "/version"
-      - "/healthz"
-      - "/readyz"
-    # exclude resources where the body is security-sensitive
-    - level: Metadata
-      resources:
-      - group: "route.openshift.io"
-        resources: ["routes"]
-      - resources: ["secrets"]
-    - level: Metadata
-      resources:
-      - group: "oauth.openshift.io"
-        resources: ["oauthclients"]
-    # log request and response payloads for all write requests
-    - level: RequestResponse
-      verbs:
-      - update
-      - patch
-      - create
-      - delete
-      - deletecollection
-    # catch-all rule to log all other requests at the Metadata level.
-    - level: Metadata
-      # Long-running requests like watches that fall under this rule will not
-      # generate an audit event in RequestReceived.
-      omitStages:
-      - RequestReceived
-
-  allrequestbodies.yaml: |
-    apiVersion: audit.k8s.io/v1beta1
-    kind: Policy
-    metadata:
-      name: AllRequestBodies
-    # Don't generate audit events for all requests in RequestReceived stage.
-    omitStages:
-    - "RequestReceived"
-    rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
-    # Don't log oauth tokens as metadata.name is the secret
-    - level: None
-      resources:
-      - group: "oauth.openshift.io"
-        resources: ["oauthaccesstokens", "oauthauthorizetokens"]
-    # Don't log authenticated requests to certain non-resource URL paths.
-    - level: None
-      userGroups: ["system:authenticated", "system:unauthenticated"]
-      nonResourceURLs:
-      - "/api*" # Wildcard matching.
-      - "/version"
-      - "/healthz"
-      - "/readyz"
-    # exclude resources where the body is security-sensitive
-    - level: Metadata
-      resources:
-      - group: "route.openshift.io"
-        resources: ["routes"]
-      - resources: ["secrets"]
-    - level: Metadata
-      resources:
-      - group: "oauth.openshift.io"
-        resources: ["oauthclients"]
-    # catch-all rule to log all other requests with request and response payloads
-    - level: RequestResponse
-
-  secure-oauth-storage-default.yaml: |
-    apiVersion: audit.k8s.io/v1beta1
-    kind: Policy
-    metadata:
-      name: Default
-    # Don't generate audit events for all requests in RequestReceived stage.
-    omitStages:
-    - "RequestReceived"
-    rules:
-    # Don't log requests for events
-    - level: None
-      resources:
-      - group: ""
-        resources: ["events"]
     # Don't log authenticated requests to certain non-resource URL paths.
     - level: None
       userGroups: ["system:authenticated", "system:unauthenticated"]
@@ -230,8 +97,7 @@ data:
       # generate an audit event in RequestReceived.
       omitStages:
       - "RequestReceived"
-
-  secure-oauth-storage-writerequestbodies.yaml: |
+  writerequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:
@@ -277,8 +143,7 @@ data:
       # generate an audit event in RequestReceived.
       omitStages:
       - RequestReceived
-
-  secure-oauth-storage-allrequestbodies.yaml: |
+  allrequestbodies.yaml: |
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy
     metadata:
@@ -311,7 +176,8 @@ data:
       - group: "oauth.openshift.io"
         resources: ["oauthclients"]
     # catch-all rule to log all other requests with request and response payloads
-    - level: RequestResponse`)
+    - level: RequestResponse
+`)
 
 func pkgOperatorApiserverAuditManifestsAuditPoliciesCmYamlBytes() ([]byte, error) {
 	return _pkgOperatorApiserverAuditManifestsAuditPoliciesCmYaml, nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
@@ -42,7 +42,7 @@ func NewControllers(
 	// TODO: update the eventHandlers used by the controllers to ignore components that do not match their own
 	encryptionSecretSelector := metav1.ListOptions{LabelSelector: secrets.EncryptionKeySecretsLabel + "=" + component}
 
-	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer, kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector)
+	encryptionEnabledChecker, err := newEncryptionEnabledPrecondition(apiServerInformer.Lister(), kubeInformersForNamespaces, encryptionSecretSelector.LabelSelector, component)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +69,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -79,6 +80,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -91,6 +93,7 @@ func NewControllers(
 				encryptionEnabledChecker.PreconditionFulfilled,
 				migrator,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,
@@ -101,6 +104,7 @@ func NewControllers(
 				deployer,
 				encryptionEnabledChecker.PreconditionFulfilled,
 				operatorClient,
+				apiServerInformer,
 				kubeInformersForNamespaces,
 				secretsClient,
 				encryptionSecretSelector,

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -38,6 +39,7 @@ func NewConditionController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -56,6 +58,7 @@ func NewConditionController(
 	return factory.New().WithInformers(
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
 		operatorClient.Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ResyncEvery(time.Minute).WithSync(c.sync).ToController("EncryptionConditionController", eventRecorder.WithComponentSuffix("encryption-condition-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -19,6 +19,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
@@ -75,6 +76,7 @@ func NewMigrationController(
 	preconditionsFulfilledFn preconditionsFulfilled,
 	migrator migrators.Migrator,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -97,6 +99,7 @@ func NewMigrationController(
 		migrator,
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-migration-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
@@ -16,6 +16,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -51,6 +52,7 @@ func NewPruneController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -69,6 +71,7 @@ func NewPruneController(
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-prune-controller"))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
@@ -13,6 +13,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
@@ -53,6 +54,7 @@ func NewStateController(
 	deployer statemachine.Deployer,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	operatorClient operatorv1helpers.OperatorClient,
+	apiServerConfigInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
@@ -74,6 +76,7 @@ func NewStateController(
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithInformers(
 		operatorClient.Informer(),
 		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
 		deployer,
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-state-controller"))
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/preconditions.go
@@ -3,17 +3,13 @@ package encryption
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
-
-	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type preconditionChecker struct {
@@ -22,37 +18,26 @@ type preconditionChecker struct {
 
 	secretLister          corev1listers.SecretNamespaceLister
 	apiServerConfigLister configv1listers.APIServerLister
-
-	cacheSynced []cache.InformerSynced
 }
 
 // newEncryptionEnabledPrecondition determines if encryption controllers should synchronise.
 // It uses the cache for gathering data to avoid sending requests to the API servers.
-func newEncryptionEnabledPrecondition(apiServerConfigInformer configv1informers.APIServerInformer, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString string) (*preconditionChecker, error) {
+func newEncryptionEnabledPrecondition(apiServerConfigLister configv1listers.APIServerLister, kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces, encryptionSecretSelectorString, component string) (*preconditionChecker, error) {
 	encryptionSecretSelector, err := labels.Parse(encryptionSecretSelectorString)
 	if err != nil {
 		return nil, err
 	}
 	return &preconditionChecker{
+		component:                component,
 		encryptionSecretSelector: encryptionSecretSelector,
 		secretLister:             kubeInformersForNamespaces.SecretLister().Secrets("openshift-config-managed"),
-		apiServerConfigLister:    apiServerConfigInformer.Lister(),
-		cacheSynced: []cache.InformerSynced{
-			apiServerConfigInformer.Informer().HasSynced,
-			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer().HasSynced,
-		},
+		apiServerConfigLister:    apiServerConfigLister,
 	}, nil
 }
 
 // PreconditionFulfilled a method that indicates whether all prerequisites are met and we can Sync.
+// This method MUST be call after the informers synced
 func (pc *preconditionChecker) PreconditionFulfilled() (bool, error) {
-	if !pc.hasCachesSynced() {
-		// at this point we are unable to perform our checks
-		// report there is work to do so that controllers run their sync loops
-		klog.V(4).Info("unable to check preconditions. The caches haven't been synchronized. Forcing the encryption controllers to run their sync loops.")
-		return true, nil
-	}
-
 	encryptionWasEnabled, err := pc.encryptionWasEnabled()
 	if err != nil {
 		return false, err // got an error, report it and run the sync loops
@@ -103,13 +88,4 @@ func (pc *preconditionChecker) encryptionWasEnabled() (bool, error) {
 		return false, err // unknown error
 	}
 	return len(encryptionSecrets) > 0, nil
-}
-
-func (pc *preconditionChecker) hasCachesSynced() bool {
-	for i := range pc.cacheSynced {
-		if !pc.cacheSynced[i]() {
-			return false
-		}
-	}
-	return true
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/controller/installer"
 )
 
@@ -157,7 +158,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing configmap manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, []byte(content), 0644); err != nil {
+			if err := staticpod.WriteFileAtomic([]byte(content), 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for configmap: %s/%s: %v", configMap.Namespace, configMap.Name, err)
 				errors = append(errors, err)
 				continue
@@ -263,7 +264,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := ioutil.WriteFile(fullFilename, content, 0644); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0644, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -28,7 +28,7 @@ import (
 // PruneController is a controller that watches static installer pod revision statuses and spawns
 // a pruner pod to delete old revision resources from disk
 type PruneController struct {
-	targetNamespace, podResourcePrefix string
+	targetNamespace, podResourcePrefix, certDir string
 	// command is the string to use for the pruning pod command
 	command []string
 
@@ -57,6 +57,7 @@ const (
 func NewPruneController(
 	targetNamespace string,
 	podResourcePrefix string,
+	certDir string,
 	command []string,
 	configMapGetter corev1client.ConfigMapsGetter,
 	secretGetter corev1client.SecretsGetter,
@@ -67,6 +68,7 @@ func NewPruneController(
 	c := &PruneController{
 		targetNamespace:   targetNamespace,
 		podResourcePrefix: podResourcePrefix,
+		certDir:           certDir,
 		command:           command,
 
 		operatorClient:  operatorClient,
@@ -225,6 +227,7 @@ func (c *PruneController) ensurePrunePod(recorder events.Recorder, nodeName stri
 		fmt.Sprintf("--max-eligible-revision=%d", maxEligibleRevision),
 		fmt.Sprintf("--protected-revisions=%s", revisionsToString(protectedRevisions)),
 		fmt.Sprintf("--resource-dir=%s", "/etc/kubernetes/static-pod-resources"),
+		fmt.Sprintf("--cert-dir=%s", c.certDir),
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -230,6 +230,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 		manager.WithController(prune.NewPruneController(
 			b.operandNamespace,
 			b.staticPodPrefix,
+			b.certDir,
 			b.pruneCommand,
 			configMapClient,
 			secretClient,

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/file_utils.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/file_utils.go
@@ -1,0 +1,35 @@
+package staticpod
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"io/ioutil"
+)
+
+func WriteFileAtomic(content []byte, filePerms os.FileMode, fullFilename string) error {
+	tmpFile, err := writeTemporaryFile(content, filePerms, fullFilename)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(tmpFile, fullFilename)
+}
+
+func writeTemporaryFile(content []byte, filePerms os.FileMode, fullFilename string) (string, error) {
+	contentDir := filepath.Dir(fullFilename)
+	filename := filepath.Base(fullFilename)
+	tmpfile, err := ioutil.TempFile(contentDir, fmt.Sprintf("%s.tmp", filename))
+	if err != nil {
+		return "", err
+	}
+	defer tmpfile.Close()
+	if err := tmpfile.Chmod(filePerms); err != nil {
+		return "", err
+	}
+	if _, err := tmpfile.Write(content); err != nil {
+		return "", err
+	}
+	return tmpfile.Name(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/copy.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/copy.go
@@ -1,12 +1,12 @@
 package installerpod
 
 import (
-	"golang.org/x/net/context"
-	"k8s.io/klog/v2"
+	"context"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/resource/retry"
 )

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
@@ -21,6 +23,7 @@ type PruneOptions struct {
 	ProtectedRevisions  []int
 
 	ResourceDir   string
+	CertDir       string
 	StaticPodName string
 }
 
@@ -57,6 +60,7 @@ func (o *PruneOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntSliceVar(&o.ProtectedRevisions, "protected-revisions", o.ProtectedRevisions, "list of revision IDs to preserve (not delete)")
 	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory for all files supporting the static pod manifest")
 	fs.StringVar(&o.StaticPodName, "static-pod-name", o.StaticPodName, "name of the static pod")
+	fs.StringVar(&o.CertDir, "cert-dir", o.CertDir, "directory for all certs")
 }
 
 func (o *PruneOptions) Validate() error {
@@ -112,5 +116,37 @@ func (o *PruneOptions) Run() error {
 			return err
 		}
 	}
-	return nil
+
+	// prune any temporary certificate files
+	// we do create temporary files to atomically "write" various certificates to disk
+	// usually, these files are short-lived because they are immediately renamed, the following loop removes old/unused/dangling files
+	//
+	// the temporary files have the following form:
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/control-plane-node-kubeconfig/kubeconfig.tmp753375784
+	//  /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/service-network-serving-certkey/tls.key.tmp643092404
+	if len(o.CertDir) == 0 {
+		return nil
+	}
+
+	return filepath.Walk(path.Join(o.ResourceDir, o.CertDir),
+		func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			// info.Name() gives just a filename like tls.key or tls.key.tmp643092404
+			if !strings.Contains(info.Name(), ".tmp") {
+				return nil
+			}
+			if time.Now().Sub(info.ModTime()) > 30*time.Minute {
+				klog.Infof("Removing %s, the last time it was modified was %v", filePath, info.ModTime())
+				if err := os.RemoveAll(filePath); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909
+# github.com/openshift/library-go v0.0.0-20210611094144-35c8a075e255
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
As of today, the dynamic certificates i.e. `kube-apiserver-certs` are accessed by at least two processes, namely the installer pod and the cert-syncer.
Up until now, there was no coordination between these processes that might have lead to many unexpected errors, like https://bugzilla.redhat.com/show_bug.cgi?id=1963730

This PR writes all certificates in an atomic way by first creating a temporary file, writing the content to it, and then renaming it to the original file. 

`os.Rename` calls `syscall.Rename` which in turn uses the rename syscall (Linux) which provides atomicity (https://man7.org/linux/man-pages/man2/rename.2.html)


The previous attempt didn't work as it would break the DR scripts - https://github.com/openshift/library-go/pull/1098