### PR TITLE
WIP Revert "bump lib-go to get prune and installer pods projected volumes…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909
+	github.com/openshift/library-go v0.0.0-20210607154825-abe9feaede8b
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909 h1:jxSIKPkt6RuD8zXWIAJHrmes4bwHNXx7e0Y+P71x8Qc=
-github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909/go.mod h1:D0QEmUeYyWP9ORJ92EprPOMkiFg72yX8GM9KxajnMAI=
+github.com/openshift/library-go v0.0.0-20210607154825-abe9feaede8b h1:6u/AoFa2KASLED5c84lN7+En+crqxK4t9jAkzbWET2Q=
+github.com/openshift/library-go v0.0.0-20210607154825-abe9feaede8b/go.mod h1:D0QEmUeYyWP9ORJ92EprPOMkiFg72yX8GM9KxajnMAI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/bindata/bindata.go
@@ -62,7 +62,6 @@ metadata:
   labels:
     app: installer
 spec:
-  automountServiceAccountToken: false
   serviceAccountName: installer-sa
   nodeName: # Value set by operator
   containers:
@@ -87,9 +86,6 @@ spec:
       volumeMounts:
         - mountPath: /etc/kubernetes/
           name: kubelet-dir
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
-          readOnly: true
       resources:
         requests:
           memory: 200M
@@ -107,24 +103,6 @@ spec:
     - hostPath:
         path: /etc/kubernetes/
       name: kubelet-dir
-    - name: kube-api-access
-      projected:
-        defaultMode: 420
-        sources:
-        - serviceAccountToken:
-            expirationSeconds: 3600
-            path: token
-        - configMap:
-            items:
-            - key: ca.crt
-              path: ca.crt
-            name: kube-root-ca.crt
-        - downwardAPI:
-            items:
-            - fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-              path: namespace
 `)
 
 func pkgOperatorStaticpodControllerInstallerManifestsInstallerPodYamlBytes() ([]byte, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/bindata/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/bindata/bindata.go
@@ -62,7 +62,6 @@ metadata:
   labels:
     app: pruner
 spec:
-  automountServiceAccountToken: false
   serviceAccountName: installer-sa
   nodeName: # Value set by operator
   containers:
@@ -85,9 +84,6 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/
       name: kubelet-dir
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: kube-api-access
-      readOnly: true
   restartPolicy: Never
   priorityClassName: system-node-critical
   tolerations:
@@ -98,24 +94,6 @@ spec:
   - hostPath:
       path: /etc/kubernetes/
     name: kubelet-dir
-  - name: kube-api-access
-    projected:
-      defaultMode: 420
-      sources:
-      - serviceAccountToken:
-          expirationSeconds: 3600
-          path: token
-      - configMap:
-          items:
-          - key: ca.crt
-            path: ca.crt
-          name: kube-root-ca.crt
-      - downwardAPI:
-          items:
-          - fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-            path: namespace
 `)
 
 func pkgOperatorStaticpodControllerPruneManifestsPrunerPodYamlBytes() ([]byte, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210608152959-aa07cb1d7909
+# github.com/openshift/library-go v0.0.0-20210607154825-abe9feaede8b
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
… fixes"

This reverts commit 53aec2b28dc0599b55116ff1da7f54a21f454ea5.

/cc @osherdp 
/hold
It seems like a quite recent addition to ocp makes some api requests containing Impersonate headers to return "invalid header name". trying a couple of reverts to pinpoint the problem