### PR TITLE
Bug 1956081: add sigterm handler to insecurereadyz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489
+	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -401,6 +401,7 @@ golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/plan9


### PR DESCRIPTION
This PR reopens https://github.com/openshift/cluster-kube-apiserver-operator/pull/1130 to add graceful termination shutdown to the readyz endpoint. Originally we thought the bug had been fully fixed.