### PR TITLE
Bug 1964231: Ensure kubelet client cert change does not require a restart

### DIFF
--- a/bindata/v4.1.0/config/defaultconfig.yaml
+++ b/bindata/v4.1.0/config/defaultconfig.yaml
@@ -104,9 +104,9 @@ apiServerArguments:
   kubelet-certificate-authority:
     - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
   kubelet-client-certificate:
-    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
+    - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt
   kubelet-client-key:
-    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+    - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key
   kubelet-https:
     - "true"
   kubelet-preferred-address-types:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -442,7 +442,6 @@ var RevisionConfigMaps = []revision.RevisionResource{
 var RevisionSecrets = []revision.RevisionResource{
 	// these need to removed, but if we remove them now, the cluster will die because we don't reload them yet
 	{Name: "etcd-client"},
-	{Name: "kubelet-client"},
 	// etcd encryption
 	{Name: "encryption-config", Optional: true},
 
@@ -476,6 +475,7 @@ var CertSecrets = []installer.UnrevisionedResource{
 	{Name: "bound-service-account-signing-key"},
 	{Name: "control-plane-node-admin-client-cert-key"},
 	{Name: "check-endpoints-client-cert-key"},
+	{Name: "kubelet-client"},
 
 	{Name: "node-kubeconfigs"},
 

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -847,9 +847,9 @@ apiServerArguments:
   kubelet-certificate-authority:
     - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
   kubelet-client-certificate:
-    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt
+    - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt
   kubelet-client-key:
-    - /etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key
+    - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key
   kubelet-https:
     - "true"
   kubelet-preferred-address-types:


### PR DESCRIPTION
The kubelet client cert - used by the apiserver to connect to the kubelet to execute commands such as such as `log` and `exec` - is already loaded dynamically. Update ckao to reflect this capability by writing the kubelet client cert secret to the unrevisioned cert path.

In addition to determining that dynamic reloading should be configured for non-empty cert and key file paths (as per the execution chain below), I manually verified cert reloading by adding debug logging to the dynamic cert loader that confirmed that the certs were loaded (at most once per second) on every invocation of log/exec/etc.

Execution chain guaranteeing dynamic loading of client cert + key:
- [Definition of kubelet client cert and key options](https://github.com/openshift/kubernetes/blob/master/cmd/kube-apiserver/app/options/options.go#L259)
- [NewNodeConnectionInfoGetter accepts the options via KubeletClientConfig and calls MakeTransport](https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/client/kubelet_client.go#L176)
- [MakeTransport calls makeTransport](https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/client/kubelet_client.go#L79)
- [makeTransport creates a transport.Config object (which embeds the client cert+key file options) by calling config.transportConfig](https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/client/kubelet_client.go#L91)
- [makeTransport provides transport.Config to TLSConfigFor](https://github.com/openshift/kubernetes/blob/master/pkg/kubelet/client/kubelet_client.go#L98)
- [transport.TLSConfig calls loadTLSFiles](https://github.com/openshift/kubernetes/blob/master/staging/src/k8s.io/client-go/transport/transport.go#L67)
- [loadTLSFiles sets ReloadTLSFiles to true if cert file and key file have non-zero length](https://github.com/openshift/kubernetes/blob/master/staging/src/k8s.io/client-go/transport/transport.go#L146)
- [TLSConfigFor configures dynamicCertLoader if ReloadTLSFiles is true](https://github.com/openshift/kubernetes/blob/master/staging/src/k8s.io/client-go/transport/transport.go#L99)

/cc @sttts @deads2k @p0lyn0mial 