### PR TITLE
Bug 1974716: SA token issuer observer: fix observing api-audiences

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -17,7 +17,11 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 )
 
-var serviceAccountIssuerPath = []string{"apiServerArguments", "service-account-issuer"}
+var (
+	serviceAccountIssuerPath = []string{"apiServerArguments", "service-account-issuer"}
+	audiencesPath            = []string{"apiServerArguments", "api-audiences"}
+	jwksURIPath              = []string{"apiServerArguments", "service-account-jwks-uri"}
+)
 
 // ObserveServiceAccountIssuer changes apiServerArguments.service-account-issuer from
 // the default value if Authentication.Spec.ServiceAccountIssuer specifies a valid
@@ -30,7 +34,7 @@ func ObserveServiceAccountIssuer(
 
 	listers := genericListers.(configobservation.Listers)
 	ret, errs := observedConfig(existingConfig, listers.AuthConfigLister.Get, listers.InfrastructureLister().Get, recorder)
-	return configobserver.Pruned(ret, serviceAccountIssuerPath, []string{"apiServerArguments", "service-account-jwks-uri"}), errs
+	return configobserver.Pruned(ret, serviceAccountIssuerPath, audiencesPath, jwksURIPath), errs
 }
 
 // observedConfig returns an unstructured fragment of KubeAPIServerConfig that may


### PR DESCRIPTION
api-audiences field was getting pruned which would result in a failing
cluster in case the service account issuer changed.

/assign @deads2k 