### PR TITLE
Temporarily turn APIRemovedInNextReleaseInUse into critical alert

### DIFF
--- a/bindata/v4.1.0/alerts/api-usage.yaml
+++ b/bindata/v4.1.0/alerts/api-usage.yaml
@@ -18,7 +18,7 @@ spec:
             group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
-            severity: info
+            severity: critical
         - alert: APIRemovedInNextEUSReleaseInUse
           annotations:
             message: >-

--- a/pkg/operator/v410_00_assets/bindata.go
+++ b/pkg/operator/v410_00_assets/bindata.go
@@ -107,7 +107,7 @@ spec:
             group(apiserver_requested_deprecated_apis{removed_release="1.22"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
-            severity: info
+            severity: critical
         - alert: APIRemovedInNextEUSReleaseInUse
           annotations:
             message: >-


### PR DESCRIPTION
We will revert this after rebase lands.