### PR TITLE
Create alert for API Server audit log errors

### DIFF
--- a/bindata/assets/alerts/audit-errors.yaml
+++ b/bindata/assets/alerts/audit-errors.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: audit-errors
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+  - name: apiserver-audit
+    rules:
+    - alert: AuditLogError
+      annotations:
+        summary: |-
+          An API Server instance was unable to write audit logs. This could be
+          triggered by the node running out of space, or a malicious actor
+          tampering with the audit logs.
+        description: An API Server had an error writing to an audit log.
+      expr: |
+        sum by (apiserver,instance)(rate(apiserver_audit_error_total{apiserver=~".+-apiserver"}[5m])) / sum by (apiserver,instance) (rate(apiserver_audit_event_total{apiserver=~".+-apiserver"}[5m])) > 0
+      for: 1m
+      labels:
+        severity: warning


### PR DESCRIPTION
This takes into use the audit log metrics defined in the documentation
[1] and applies them to an alarm.

The purpose of the alarm is to inform administrators that there are
errors writing audit logs which might be an issue for incident response
teams as the audit logs become unreliable at this point. The alarm has a
query that provides appropriate labels to identify the API server
type and instance that's failing.

The alert is left vague enough that this will catch any API Server
causing these types of issues; but is still usable via the
aforementioned labels.

The alert will trigger if there are any errors detected (threshold above 0).
However, this happening is not a common occurrence, and would most
likely trigger for the following reasons:

* Node's disk space is full
* Someone actually got into the node as is tampering with the audit logs
  to the point that they're un-usable (changing modes or attributes).

[1] https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#parameter-tuning

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>