### PR TITLE
graceful-termination-duration: reduce to 15s for SNO

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -53,14 +53,14 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 		// scenario 4
 		{
 			name:                  "sno: shutdown-delay-duration reduced to 0s",
-			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "60"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 		},
 
 		// scenario 4
 		{
 			name:                  "sno takes precedence over platform type",
-			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "60"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 			platformType:          configv1.AWSPlatformType,
 		},
@@ -81,7 +81,7 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 			}
 
 			// act
-			observedKubeAPIConfig, err := ObserveWatchTerminationDuration(listers, eventRecorder, scenario.existingKubeAPIConfig)
+			observedKubeAPIConfig, err := ObserveGracefulTerminationDuration(listers, eventRecorder, scenario.existingKubeAPIConfig)
 
 			// validate
 			if len(err) > 0 {

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -120,7 +120,7 @@ func NewConfigObserver(
 			apiserver.ObserveUserClientCABundle,
 			apiserver.ObserveAdditionalCORSAllowedOrigins,
 			apiserver.ObserveShutdownDelayDuration,
-			apiserver.ObserveWatchTerminationDuration,
+			apiserver.ObserveGracefulTerminationDuration,
 			libgoapiserver.ObserveTLSSecurityProfile,
 			libgoapiserver.NewAuditObserver(auditPolicypathGetter),
 			auth.ObserveAuthMetadata,


### PR DESCRIPTION
To get under 60s for termination+startup.

We might add a more graceful O(10s) timeout to non-long-running requests during termination as follow-up, if this solution turns out to be too bumpy.