### PR TITLE
clear encryption conditions when there is no work to be done

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20210616173328-fb4df74c2da9
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210702104503-39570b4a2ae8
+	github.com/openshift/library-go v0.0.0-20210705141012-3f317d1cb3be
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210702104503-39570b4a2ae8 h1:vgvVr4EnUiUpl2u5QltMw3/IoBLx8SW2GRcGEXnzmGQ=
-github.com/openshift/library-go v0.0.0-20210702104503-39570b4a2ae8/go.mod h1:PkxPzGpVgObkue/pqw6JSKE+z58AUcHVYgME6W4pM0g=
+github.com/openshift/library-go v0.0.0-20210705141012-3f317d1cb3be h1:AZNzJztZHZsKR5LllxgZ0iOnenI9r00teIjKSnIohpc=
+github.com/openshift/library-go v0.0.0-20210705141012-3f317d1cb3be/go.mod h1:PkxPzGpVgObkue/pqw6JSKE+z58AUcHVYgME6W4pM0g=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -104,56 +105,42 @@ func NewMigrationController(
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-migration-controller"))
 }
 
-func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionMigrationControllerDegraded", Status: operatorv1.ConditionFalse}
+	progressingCondition := &operatorv1.OperatorCondition{Type: "EncryptionMigrationControllerProgressing", Status: operatorv1.ConditionFalse}
+	defer func() {
+		if degradedCondition == nil && progressingCondition == nil {
+			return
+		}
+		conditions := []v1helpers.UpdateStatusFunc{
+			v1helpers.UpdateConditionFn(*degradedCondition),
+			v1helpers.UpdateConditionFn(*progressingCondition),
+		}
+		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, conditions...); updateError != nil {
+			err = updateError
+		}
+	}()
+
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+			progressingCondition = nil
+		}
 		return err // we will get re-kicked when the operator status updates
 	}
 
 	migratingResources, migrationError := c.migrateKeysIfNeededAndRevisionStable(ctx, syncCtx, c.provider.EncryptedGRs())
-
-	// update failing condition
-	degraded := operatorv1.OperatorCondition{
-		Type:   "EncryptionMigrationControllerDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
 	if migrationError != nil {
-		degraded.Status = operatorv1.ConditionTrue
-		degraded.Reason = "Error"
-		degraded.Message = migrationError.Error()
-	}
-
-	// update progressing condition
-	progressing := operatorv1.OperatorCondition{
-		Type:   "EncryptionMigrationControllerProgressing",
-		Status: operatorv1.ConditionFalse,
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "Error"
+		degradedCondition.Message = migrationError.Error()
 	}
 	if len(migratingResources) > 0 {
-		progressing.Status = operatorv1.ConditionTrue
-		progressing.Reason = "Migrating"
-		progressing.Message = fmt.Sprintf("migrating resources to a new write key: %v", grsToHumanReadable(migratingResources))
+		progressingCondition.Status = operatorv1.ConditionTrue
+		progressingCondition.Reason = "Migrating"
+		progressingCondition.Message = fmt.Sprintf("migrating resources to a new write key: %v", grsToHumanReadable(migratingResources))
 	}
-
-	if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(degraded), operatorv1helpers.UpdateConditionFn(progressing)); updateError != nil {
-		return updateError
-	}
-
 	return migrationError
-}
-
-func (c *migrationController) setProgressing(migrating bool, reason, message string, args ...interface{}) error {
-	// update progressing condition
-	progressing := operatorv1.OperatorCondition{
-		Type:    "EncryptionMigrationControllerProgressing",
-		Status:  operatorv1.ConditionTrue,
-		Reason:  reason,
-		Message: fmt.Sprintf(message, args...),
-	}
-	if !migrating {
-		progressing.Status = operatorv1.ConditionFalse
-	}
-
-	_, _, err := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(progressing))
-	return err
 }
 
 // TODO doc

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
@@ -76,27 +76,30 @@ func NewPruneController(
 	).ToController(c.name, eventRecorder.WithComponentSuffix("encryption-prune-controller"))
 }
 
-func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *pruneController) sync(_ context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := &operatorv1.OperatorCondition{Type: "EncryptionPruneControllerDegraded", Status: operatorv1.ConditionFalse}
+	defer func() {
+		if degradedCondition == nil {
+			return
+		}
+		if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(*degradedCondition)); updateError != nil {
+			err = updateError
+		}
+	}()
+
 	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+		}
 		return err // we will get re-kicked when the operator status updates
 	}
 
 	configError := c.deleteOldMigratedSecrets(syncCtx, c.provider.EncryptedGRs())
-
-	// update failing condition
-	cond := operatorv1.OperatorCondition{
-		Type:   "EncryptionPruneControllerDegraded",
-		Status: operatorv1.ConditionFalse,
-	}
 	if configError != nil {
-		cond.Status = operatorv1.ConditionTrue
-		cond.Reason = "Error"
-		cond.Message = configError.Error()
+		degradedCondition.Status = operatorv1.ConditionTrue
+		degradedCondition.Reason = "Error"
+		degradedCondition.Message = configError.Error()
 	}
-	if _, _, updateError := operatorv1helpers.UpdateStatus(c.operatorClient, operatorv1helpers.UpdateConditionFn(cond)); updateError != nil {
-		return updateError
-	}
-
 	return configError
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210702104503-39570b4a2ae8
+# github.com/openshift/library-go v0.0.0-20210705141012-3f317d1cb3be
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
It turns out that the new precondition checker added in 4.8 might prevent the encryption controllers from running and clearing the stale conditions.
This can happen especially on upgrades from 4.7 to 4.8.

https://github.com/openshift/library-go/pull/1125 changed the encryption controllers to clear stale conditions when the preconditions are not fulfilled. 

This PR incorporates it into this operator.