### PR TITLE
introduces KubeAPIReadinessChecker used by startup monitor to assess Kube API server readiness/health condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20210706092853-b63d499a70ce
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1
+	github.com/openshift/library-go v0.0.0-20210720093535-f8ed43828870
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1 h1:jclNeKbYKeXiq05pt1PdnjcgKV76oqQIcp8h7uqO3V0=
-github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1/go.mod h1:rln3LbFNOpENSvhmsfH7g/hqc58IF78+o96yAAp5mq0=
+github.com/openshift/library-go v0.0.0-20210720093535-f8ed43828870 h1:xhtl3hJFfICWRPhLfu0xvX44rhR2Gf91LPRND2TdPPY=
+github.com/openshift/library-go v0.0.0-20210720093535-f8ed43828870/go.mod h1:rln3LbFNOpENSvhmsfH7g/hqc58IF78+o96yAAp5mq0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/operator/startupmonitorreadiness/readiness_checks.go
+++ b/pkg/operator/startupmonitorreadiness/readiness_checks.go
@@ -1,0 +1,324 @@
+package startupmonitorreadiness
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// KubeAPIReadinessChecker is a struct that holds necessary data
+// to perform a set of checks against a Kube API server to assess its health condition
+type KubeAPIReadinessChecker struct {
+	// configuration for authN/authZ against the server
+	// populated from kubeconfig and set by the startup monitor pod
+	restConfig *rest.Config
+
+	// client we use to perform HTTP checks
+	client *http.Client
+
+	// defined here for easier testing
+	baseRawURL string
+
+	kubeClient *kubernetes.Clientset
+}
+
+var _ startupmonitor.ReadinessChecker = &KubeAPIReadinessChecker{}
+var _ startupmonitor.WantsRestConfig = &KubeAPIReadinessChecker{}
+
+// New creates a new Kube API readiness checker
+func New() *KubeAPIReadinessChecker {
+	return &KubeAPIReadinessChecker{
+		baseRawURL: "https://localhost:6443",
+	}
+}
+
+// SetRestConfig called by startup monitor to provide a valid configuration for authN/authZ against Kube API server
+func (ch *KubeAPIReadinessChecker) SetRestConfig(config *rest.Config) {
+	ch.restConfig = config
+
+	// note that we will be talking to Kube API over localhost and in case of an error/timeout requests will be retired for 5 min.
+	// setting the global timeout to a short value seems to be fine
+	ch.restConfig.Timeout = 4 * time.Second
+
+	ch.restConfig.Burst = 15
+	ch.restConfig.QPS = 10
+}
+
+// IsReady performs a series of checks for assessing Kube API server readiness condition
+func (ch *KubeAPIReadinessChecker) IsReady(ctx context.Context, revision int) ( /*ready*/ bool /*reason*/, string /*message*/, string /*err*/, error) {
+	if ch.restConfig == nil {
+		return false, "", "", fmt.Errorf("missing restConfig, use SetRestConfig() metod to set one")
+
+	}
+	if ch.client == nil {
+		client, err := createHTTPClient(ch.restConfig)
+		if err != nil {
+			return false, "", "", fmt.Errorf("failed to create an HTTP client due to %v", err)
+		}
+		ch.client = client
+	}
+
+	if ch.kubeClient == nil {
+		kubeClient, err := kubernetes.NewForConfig(ch.restConfig)
+		if err != nil {
+			return false, "", "", fmt.Errorf("failed to create kubernetes clientset due to %v", err)
+		}
+		ch.kubeClient = kubeClient
+	}
+
+	// loop through a list of ordered checks for assessing Kube API readiness condition
+	for _, checkFn := range []func(context.Context) (bool, string, string){
+		//	TODO: watch /var/log/kube-apiserver/termination.log for the first start-up attempt (beware of the race of startup-monitor startup and kube-apiserver startup). Set Reason=NeverStartedUp when this times out.
+		//	TODO: watch /var/log/kube-apiserver/termination.log for more than one start-up attempt. Set Reason=CrashLooping if more than one is found and the monitor times out.
+
+		// checks if we are not dealing with the old kas
+		noOldRevisionPodExists(ch.kubeClient.CoreV1().Pods(operatorclient.TargetNamespace), revision),
+
+		// check kube-apiserver /healthz/etcd endpoint
+		goodHealthzEtcdEndpoint(ch.client, ch.baseRawURL),
+
+		// check kube-apiserver /healthz endpoint
+		goodHealthzEndpoint(ch.client, ch.baseRawURL),
+
+		// check kube-apiserver /readyz endpoint
+		goodReadyzEndpoint(ch.client, ch.baseRawURL, 3, 5*time.Second),
+
+		// check if the kas pod is running at the expected revision
+		newRevisionPodExists(ch.kubeClient.CoreV1().Pods(operatorclient.TargetNamespace), revision),
+
+		// check that kubelet has reporting readiness for the new pod
+		newPodRunning(ch.kubeClient.CoreV1().Pods(operatorclient.TargetNamespace), revision),
+	} {
+		select {
+		case <-ctx.Done():
+			return false, "", "", ctx.Err()
+		default:
+		}
+
+		if ready, reason, message := checkFn(ctx); !ready {
+			return ready, reason, message, nil
+		}
+	}
+
+	// at this point Kube API is ready!
+	return true, "", "", nil
+}
+
+// newPodRunning checks if kas pod is in PodRunning phase and has PodReady condition set to true
+func newPodRunning(podClient corev1client.PodInterface, monitorRevision int) func(context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		apiServerPods, err := podClient.List(ctx, metav1.ListOptions{LabelSelector: "apiserver=true"})
+		if err != nil {
+			return false, "PodListError", fmt.Sprintf("unable to check the pod's status, falied to get Kube API server pod due to %v", err)
+		}
+		if len(apiServerPods.Items) == 0 {
+			return false, "PodNotRunning", "unable to check the pod's status, waiting for Kube API server pod to show up"
+		}
+		if len(apiServerPods.Items) != 1 {
+			return false, "PodListError", fmt.Sprintf("unable to check the pod's status, unexpected number of Kube API server pods %d, expected only one pod", len(apiServerPods.Items))
+		}
+
+		kasPod := apiServerPods.Items[0]
+		if kasPod.Status.Phase != corev1.PodRunning {
+			return false, "PodNodReady", fmt.Sprintf("waiting for Kube API server pod to be in PodRunning phase, the current phase is %v", kasPod.Status.Phase)
+		}
+
+		if kasPod.Status.Phase == corev1.PodRunning && !func(pod corev1.Pod) bool {
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}(kasPod) {
+			return false, "PodNodReady", "waiting for Kube API server pod to have PodReady state set to true"
+		}
+
+		return checkRevision(&kasPod, monitorRevision)
+	}
+}
+
+// newRevisionPodExists check if the kas pod is running at the expected revision
+func newRevisionPodExists(podClient corev1client.PodInterface, monitorRevision int) func(context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		return checkRevisionOnPod(ctx, podClient, monitorRevision, true)
+	}
+}
+
+// noOldRevisionPodExists checks if we are not dealing with the old kas
+// it is useful when you want to avoid false positive - failing readyz check when the previous instance is still running
+//
+// note that:
+// it won't fail when getting the pod from the api server fails as that might mean the new instance is not ready/healthy
+func noOldRevisionPodExists(podClient corev1client.PodInterface, monitorRevision int) func(context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		return checkRevisionOnPod(ctx, podClient, monitorRevision, false)
+	}
+}
+
+// checkRevisionOnPod checks if the kas pod is running at the expected revision
+//
+// strictMode controls whether a certain errors like: failing to get the pod or absence of the pod should be fatal
+// it is useful when you want to avoid false positive - failing readyz check when the previous instance is still running
+func checkRevisionOnPod(ctx context.Context, podClient corev1client.PodInterface, monitorRevision int, strictMode bool) (bool, string, string) {
+	apiServerPods, err := podClient.List(ctx, metav1.ListOptions{LabelSelector: "apiserver=true"})
+	if err != nil {
+		return !strictMode, "PodListError", fmt.Sprintf("unable to check a revison, failed to get Kube API server pod due to %v", err)
+	}
+	if len(apiServerPods.Items) == 0 {
+		return !strictMode, "PodNotRunning", "unable to check a revision, waiting for Kube API server pod to show up"
+	}
+	if len(apiServerPods.Items) != 1 {
+		return !strictMode, "PodListError", fmt.Sprintf("unable to check a revision, unexpected number of Kube API server pods %d, expected only one pod", len(apiServerPods.Items))
+	}
+
+	return checkRevision(&apiServerPods.Items[0], monitorRevision)
+}
+
+func checkRevision(kasPod *corev1.Pod, monitorRevision int) (bool, string, string) {
+	revisionString, found := kasPod.Labels["revision"]
+	if !found {
+		return false, "InvalidPod", fmt.Sprintf("pod %s doesn't have revision label", kasPod.Name)
+	}
+	if len(revisionString) == 0 {
+		return false, "InvalidRevision", fmt.Sprintf("empty revision label on %s pod", kasPod.Name)
+	}
+	revision, err := strconv.Atoi(revisionString)
+	if err != nil || revision < 0 {
+		return false, "InvalidRevision", fmt.Sprintf("invalid revision label on pod %s: %q", kasPod.Name, revisionString)
+	}
+
+	if revision != monitorRevision {
+		return false, "UnexpectedRevision", fmt.Sprintf("the running Kube API (%s) is at unexpected revision %d, expected %d", kasPod.Name, revision, monitorRevision)
+	}
+
+	return true, "", ""
+}
+
+// goodReadyzEndpoint performs HTTP checks against readyz?verbose=true endpoint
+//  returns true, "", "", when we got HTTP 200 "successThreshold" times
+//  returns false, "NotReady", EntireResponseBody (if any) on HTTP != 200
+//  returns false, "NotReadyError", EntireResponseBody (if any) in case of any error or timeout
+func goodReadyzEndpoint(client *http.Client, rawURL string, successThreshold int, interval time.Duration) func(ctx context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/readyz?verbose=true", rawURL), "NotReady", doHTTPCheckMultipleTimes(successThreshold, interval))
+	}
+}
+
+// goodHealthzEndpoint performs an HTTP check against healthz?verbose=true endpoint
+//  returns true, "", "", on HTTP 200
+//  returns false, "Unhealthy", EntireResponseBody (if any) on HTTP != 200
+//  returns false, "UnhealthyError", EntireResponseBody (if any) in case of any error or timeout
+func goodHealthzEndpoint(client *http.Client, rawURL string) func(context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/healthz?verbose=true", rawURL), "Unhealthy", doHTTPCheck)
+	}
+}
+
+// goodHealthzEtcdEndpoint performs an HTTP check against healthz/etcd endpoint
+//  returns true, "", "", on HTTP 200
+//  returns false, "EtcdUnhealthy", EntireResponseBody (if any) on HTTP != 200
+//  returns false, "EtcdUnhealthyError", EntireResponseBody (if any) in case of any error or timeout
+func goodHealthzEtcdEndpoint(client *http.Client, rawURL string) func(context.Context) (bool, string, string) {
+	return func(ctx context.Context) (bool, string, string) {
+		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/healthz/etcd", rawURL), "EtcdUnhealthy", doHTTPCheck)
+	}
+}
+
+func doHTTPCheckAndTransform(ctx context.Context, client *http.Client, rawURL string, checkName string, httpCheckFn func(ctx context.Context, client *http.Client, rawURL string) (int, string, error)) (bool, string, string) {
+	statusCode, response, err := httpCheckFn(ctx, client, rawURL)
+	if err != nil {
+		errMsg := err.Error()
+		if len(response) > 0 {
+			errMsg = fmt.Sprintf("%v, a response from the server was %v", errMsg, response)
+		}
+		return false, fmt.Sprintf("%vError", checkName), errMsg
+	}
+	if statusCode != http.StatusOK {
+		return false, checkName, response
+	}
+
+	return true, "", ""
+}
+
+func doHTTPCheck(ctx context.Context, client *http.Client, rawURL string) (int, string, error) {
+	targetURL, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, "", err
+	}
+	newReq, err := http.NewRequestWithContext(ctx, "GET", targetURL.String(), nil)
+	if err != nil {
+		return 0, "", err
+	}
+
+	resp, err := client.Do(newReq)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+
+	// we expect small responses from the server
+	// so it is okay to read the entire body
+	rawResponse, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", fmt.Errorf("error while reading body from %v, err %v", targetURL.String(), err)
+	}
+
+	return resp.StatusCode, string(rawResponse), nil
+}
+
+func createHTTPClient(restConfig *rest.Config) (*http.Client, error) {
+	transportConfig, err := restConfig.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := transport.TLSConfigFor(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: utilnet.SetTransportDefaults(&http.Transport{
+			TLSClientConfig: tlsConfig,
+		}),
+		Timeout: restConfig.Timeout,
+	}
+
+	return client, nil
+}
+
+// doHTTPCheckMultipleTimes calls doHTTPCheck "n" times with an "interval" between each invocation
+// it stops on a non 200 HTTP status code or when an error is returned from doHTTPCheck method
+func doHTTPCheckMultipleTimes(n int, interval time.Duration) func(ctx context.Context, client *http.Client, rawURL string) (int, string, error) {
+	return func(ctx context.Context, client *http.Client, rawURL string) (int, string, error) {
+		var lastResponse string
+		var lastError error
+		var lastStatusCode int
+		for i := 1; i <= n; i++ {
+			lastStatusCode, lastResponse, lastError = doHTTPCheck(ctx, client, rawURL)
+			if lastError != nil || lastStatusCode != http.StatusOK {
+				return lastStatusCode, lastResponse, lastError
+			}
+			if i != n {
+				time.Sleep(interval)
+			}
+		}
+		return lastStatusCode, lastResponse, lastError
+	}
+}

--- a/pkg/operator/startupmonitorreadiness/readiness_checks_test.go
+++ b/pkg/operator/startupmonitorreadiness/readiness_checks_test.go
@@ -1,0 +1,486 @@
+package startupmonitorreadiness
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNewPodHasStateRunning(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		healthy         bool
+		reason          string
+		msg             string
+		monitorRevision int
+
+		initialObjects []runtime.Object
+	}{
+		{
+			name:            "scenario 1: happy path",
+			healthy:         true,
+			monitorRevision: 3,
+			initialObjects:  []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas")},
+		},
+
+		{
+			name:    "scenario 2: no pod",
+			healthy: false,
+			reason:  "PodNotRunning",
+			msg:     "unable to check the pod's status, waiting for Kube API server pod to show up",
+		},
+
+		{
+			name:           "scenario 3: pending pod",
+			healthy:        false,
+			reason:         "PodNodReady",
+			msg:            "waiting for Kube API server pod to be in PodRunning phase, the current phase is Pending",
+			initialObjects: []runtime.Object{newPod(corev1.PodPending, corev1.ConditionTrue, "3", "kas")},
+		},
+
+		{
+			name:           "scenario 4: not ready pod",
+			healthy:        false,
+			reason:         "PodNodReady",
+			msg:            "waiting for Kube API server pod to have PodReady state set to true",
+			initialObjects: []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionFalse, "3", "kas")},
+		},
+
+		{
+			name:            "scenario 5: unexpected revision",
+			healthy:         false,
+			reason:          "UnexpectedRevision",
+			msg:             "the running Kube API (kas) is at unexpected revision 4, expected 3",
+			monitorRevision: 3,
+			initialObjects:  []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "kas")},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			fakeKubeClient := fake.NewSimpleClientset(scenario.initialObjects...)
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) {
+				return newPodRunning(fakeKubeClient.CoreV1().Pods("openshift-kube-apiserver"), scenario.monitorRevision)(context.TODO())
+			}, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+}
+
+func TestNoOldRevisionPodExists(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		healthy bool
+		reason  string
+		msg     string
+
+		monitorRevision int
+		initialObjects  []runtime.Object
+	}{
+		{
+			name:            "scenario 1: happy path",
+			healthy:         false,
+			monitorRevision: 3,
+			reason:          "UnexpectedRevision",
+			msg:             "the running Kube API (kas) is at unexpected revision 2, expected 3",
+			initialObjects:  []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "2", "kas")},
+		},
+
+		{
+			name:            "scenario 2: no pod",
+			healthy:         true,
+			monitorRevision: 3,
+			reason:          "PodNotRunning",
+			msg:             "waiting for Kube API server pod to show up",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			fakeKubeClient := fake.NewSimpleClientset(scenario.initialObjects...)
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) {
+				return noOldRevisionPodExists(fakeKubeClient.CoreV1().Pods("openshift-kube-apiserver"), scenario.monitorRevision)(context.TODO())
+			}, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+
+}
+
+func TestNewRevisionPodExists(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		healthy bool
+		reason  string
+		msg     string
+
+		monitorRevision int
+		initialObjects  []runtime.Object
+	}{
+		{
+			name:            "scenario 1: happy path",
+			healthy:         true,
+			monitorRevision: 3,
+			initialObjects:  []runtime.Object{newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas")},
+		},
+
+		{
+			name:            "scenario 2: no pod",
+			healthy:         false,
+			monitorRevision: 3,
+			reason:          "PodNotRunning",
+			msg:             "waiting for Kube API server pod to show up",
+		},
+
+		{
+			name:            "scenario 3: multipe pods",
+			healthy:         false,
+			monitorRevision: 4,
+			initialObjects: []runtime.Object{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas-old"),
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "4", "kas-new"),
+			},
+			reason: "PodListError",
+			msg:    "unexpected number of Kube API server pods 2, expected only one pod",
+		},
+
+		{
+			name:            "scenario 4: old running",
+			healthy:         false,
+			monitorRevision: 4,
+			initialObjects: []runtime.Object{
+				newPod(corev1.PodRunning, corev1.ConditionTrue, "3", "kas-old"),
+			},
+			reason: "UnexpectedRevision",
+			msg:    "the running Kube API (kas-old) is at unexpected revision 3, expected 4",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			fakeKubeClient := fake.NewSimpleClientset(scenario.initialObjects...)
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) {
+				return newRevisionPodExists(fakeKubeClient.CoreV1().Pods("openshift-kube-apiserver"), scenario.monitorRevision)(context.TODO())
+			}, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+}
+
+func TestGoodReadyzEndpoint(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		healthy     bool
+		reason      string
+		msg         string
+		rspWriterFn func(w http.ResponseWriter)
+	}{
+
+		{
+			name:    "scenario 1: happy path, HTTP 200, empty reason and msg",
+			healthy: true,
+		},
+
+		{
+			name: "scenario 2: HTTP 500, unhealthy reason and msg",
+			rspWriterFn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("kube is on fire"))
+			},
+			healthy: false,
+			reason:  "NotReady",
+			msg:     "kube is on fire",
+		},
+
+		{
+			name: "scenario 3: HTTP 500 on the 2nd call, unhealthy reason and msg",
+			rspWriterFn: func() func(w http.ResponseWriter) {
+				var counter int
+				return func(w http.ResponseWriter) {
+					counter++
+					if counter == 2 {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(fmt.Sprintf("failed on %d invocation", counter)))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+			}(),
+			healthy: false,
+			reason:  "NotReady",
+			msg:     "failed on 2 invocation",
+		},
+
+		{
+			name: "scenario 4: HTTP 500 on the 3nd call, unhealthy reason and msg",
+			rspWriterFn: func() func(w http.ResponseWriter) {
+				var counter int
+				return func(w http.ResponseWriter) {
+					counter++
+					if counter == 3 {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(fmt.Sprintf("failed on %d invocation", counter)))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+			}(),
+			healthy: false,
+			reason:  "NotReady",
+			msg:     "failed on 3 invocation",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			//t.Parallel()
+			// set up the server and the client
+			rspWriterFn := func(w http.ResponseWriter) {
+				fmt.Fprintf(w, "ok")
+			}
+			ts, client := setupServerClient(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/readyz" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(fmt.Sprintf("a req received at unexpected path: %v", r.URL.Path)))
+					return
+				}
+				if r.URL.RawQuery != "verbose=true" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(fmt.Sprintf("unexpected query params received: %v", r.URL.RawQuery)))
+					return
+				}
+				rspWriterFn(w)
+			})
+			defer ts.Close()
+
+			// rewrite rsp handler if provided
+			if scenario.rspWriterFn != nil {
+				rspWriterFn = scenario.rspWriterFn
+			}
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) {
+				return goodReadyzEndpoint(client, ts.URL, 3, 50*time.Millisecond)(context.TODO())
+			}, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+}
+
+func TestGoodHealthzEndpoint(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		healthy     bool
+		reason      string
+		msg         string
+		rspWriterFn func(w http.ResponseWriter)
+	}{
+		{
+			name:    "scenario 1: happy path, HTTP 200, empty reason and msg",
+			healthy: true,
+		},
+
+		{
+			name: "scenario 2: HTTP 500, unhealthy reason and msg",
+			rspWriterFn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("kube is on fire"))
+			},
+			healthy: false,
+			reason:  "Unhealthy",
+			msg:     "kube is on fire",
+		},
+
+		{
+			name: "scenario 3: unexpected err from the server",
+			rspWriterFn: func(w http.ResponseWriter) {
+				panic("bum")
+			},
+			healthy: false,
+			reason:  "UnhealthyError",
+			// we don't check the entire rsp from the server
+			msg: "/healthz?verbose=true\": EOF",
+		},
+		{
+			name: "scenario 4: no rsp from the server",
+			rspWriterFn: func(w http.ResponseWriter) {
+				time.Sleep(2 * time.Second)
+			},
+			healthy: false,
+			reason:  "UnhealthyError",
+			// we don't check the entire rsp from the server
+			msg: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// set up the server and the client
+			rspWriterFn := func(w http.ResponseWriter) {
+				fmt.Fprintf(w, "ok")
+			}
+			ts, client := setupServerClient(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/healthz" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(fmt.Sprintf("a req received at unexpected path: %v", r.URL.Path)))
+					return
+				}
+				if r.URL.RawQuery != "verbose=true" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(fmt.Sprintf("unexpected query params received: %v", r.URL.RawQuery)))
+					return
+				}
+				rspWriterFn(w)
+			})
+			defer ts.Close()
+
+			// rewrite rsp handler if provided
+			if scenario.rspWriterFn != nil {
+				rspWriterFn = scenario.rspWriterFn
+			}
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) { return goodHealthzEndpoint(client, ts.URL)(context.TODO()) }, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+}
+
+func TestHealthzEtcdEndpoint(t *testing.T) {
+	scenarios := []struct {
+		name        string
+		healthy     bool
+		reason      string
+		msg         string
+		rspWriterFn func(w http.ResponseWriter)
+	}{
+		{
+			name:    "scenario 1: happy path, HTTP 200, empty reason and msg",
+			healthy: true,
+		},
+
+		{
+			name: "scenario 2: HTTP 500, unhealthy reason and msg",
+			rspWriterFn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("etcd is on fire"))
+			},
+			healthy: false,
+			reason:  "EtcdUnhealthy",
+			msg:     "etcd is on fire",
+		},
+		{
+			name: "scenario 3: unexpected err from the server",
+			rspWriterFn: func(w http.ResponseWriter) {
+				panic("bum")
+			},
+			healthy: false,
+			reason:  "EtcdUnhealthyError",
+			// we don't check the entire rsp from the server
+			msg: "/healthz/etcd\": EOF",
+		},
+		{
+			name: "scenario 4: no rsp from the server",
+			rspWriterFn: func(w http.ResponseWriter) {
+				time.Sleep(2 * time.Second)
+			},
+			healthy: false,
+			reason:  "EtcdUnhealthyError",
+			// we don't check the entire rsp from the server
+			msg: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// set up the server and the client
+			rspWriterFn := func(w http.ResponseWriter) {
+				fmt.Fprintf(w, "ok")
+			}
+			ts, client := setupServerClient(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/healthz/etcd" {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte("a req received at unexpected path"))
+					return
+				}
+				rspWriterFn(w)
+			})
+			defer ts.Close()
+
+			// rewrite rsp handler if provided
+			if scenario.rspWriterFn != nil {
+				rspWriterFn = scenario.rspWriterFn
+			}
+
+			// act and validate
+			doCheckAndValidate(t, func() (bool, string, string) { return goodHealthzEtcdEndpoint(client, ts.URL)(context.TODO()) }, scenario.healthy, scenario.reason, scenario.msg)
+		})
+	}
+
+}
+
+func doCheckAndValidate(t *testing.T, checkFn func() (bool, string, string), expectedHealthy bool, expectedReason, expectedMessage string) {
+	actualHealthy, actualReason, actualMsg := checkFn()
+	if expectedHealthy != actualHealthy {
+		t.Errorf("unexpected health condition (healthy=%v), expected healthy=%v", actualHealthy, expectedHealthy)
+	}
+	if expectedReason != actualReason {
+		t.Errorf("unexpected reason %v, expected %v", actualReason, expectedReason)
+	}
+	if !strings.Contains(actualMsg, expectedMessage) {
+		t.Errorf("unexpected message %v, expected %v", actualMsg, expectedMessage)
+	}
+	if len(expectedMessage) == 0 && len(actualMsg) > 0 {
+		t.Errorf("unexpected message %v received (didn't expect a msg)", actualMsg)
+	}
+}
+
+func setupServerClient(handlerFn http.HandlerFunc) (*httptest.Server, *http.Client) {
+	// set up the server
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerFn(w, r)
+	}))
+	ts.EnableHTTP2 = true
+	ts.Start()
+
+	// set the client timeout
+	client := ts.Client()
+	client.Timeout = time.Second
+	return ts, client
+}
+
+func newPod(phase corev1.PodPhase, ready corev1.ConditionStatus, revision, name string) *corev1.Pod {
+	pod := corev1.Pod{
+		TypeMeta: v1.TypeMeta{Kind: "Pod"},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-kube-apiserver",
+			Labels: map[string]string{
+				"revision":  revision,
+				"apiserver": "true",
+			}},
+		Spec: corev1.PodSpec{},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: ready,
+			}},
+		},
+	}
+
+	return &pod
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock.go
@@ -1,0 +1,22 @@
+package flock
+
+import (
+	"os"
+	"sync"
+)
+
+// FLock a type that supports file locking to coordinate work between processes
+type FLock struct {
+	locker sync.Mutex
+
+	lockFilePath string
+	lockedFile   *os.File
+}
+
+// New instantiates *FLock on the given path.
+// The path must point to a file not a directory.
+// The file doesn't have to exist prior to calling this method.
+// It will be creating on the first call to TryLock method.
+func New(filePath string) *FLock {
+	return &FLock{locker: sync.Mutex{}, lockFilePath: filePath}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock_linux.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock_linux.go
@@ -1,0 +1,96 @@
+// +build linux
+
+package flock
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// TryLock tries to acquire an exclusive lock on a file
+// until it succeeds, an error is returned or the timeout is reached.
+//
+// The callers MUST call the corresponding Unlock method to release the lock and associated resources except when an error
+// is returned (including the timeout).
+//
+// This method is safe for concurrent access.
+//
+// Note the given timeout shouldn't be less than 1 second.
+func (f *FLock) TryLock(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return f.Lock(ctx)
+}
+
+// ock tries to acquire an exclusive lock on a file
+// until it succeeds, an error is returned or the context is done.
+//
+// The callers MUST call the corresponding Unlock method to release the lock and associated resources except when an error
+// is returned (including the context being done).
+//
+// This method is safe for concurrent access.
+//
+// Note the given context shouldn't last less than 1 second to be able to acquire the lock.
+func (f *FLock) Lock(ctx context.Context) error {
+	f.locker.Lock()
+	defer f.locker.Unlock()
+	if err := f.openLockFile(); err != nil {
+		return err
+	}
+	if err := wait.PollUntil(300*time.Millisecond, f.tryLock, ctx.Done()); err != nil {
+		if closeErr := f.closeLockedFile(); closeErr != nil {
+			return closeErr
+		}
+		return err
+	}
+	return nil
+}
+
+// Unlock releases the lock and associated resources.
+func (f *FLock) Unlock() error {
+	f.locker.Lock()
+	defer f.locker.Unlock()
+
+	if err := syscall.Flock(int(f.lockedFile.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+
+	return f.closeLockedFile()
+}
+
+func (f *FLock) tryLock() (bool, error) {
+	err := syscall.Flock(int(f.lockedFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+
+	if err == nil {
+		return true, nil // we have a lock
+	}
+	if err == syscall.EWOULDBLOCK {
+		return false, nil // another process holds a lock on the file
+	}
+	return false, err // an unknown err
+}
+
+func (f *FLock) openLockFile() error {
+	if f.lockedFile != nil {
+		return nil
+	}
+	file, err := os.OpenFile(f.lockFilePath, os.O_CREATE|os.O_RDONLY, os.FileMode(0644))
+	if err != nil {
+		return err
+	}
+
+	f.lockedFile = file
+	return nil
+}
+
+func (f *FLock) closeLockedFile() error {
+	if err := f.lockedFile.Close(); err != nil {
+		return err
+	}
+	f.lockedFile = nil
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock_others.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/flock/flock_others.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+package flock
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TryLock is not supported/implemented on this platform
+func (f *FLock) TryLock(timeout time.Duration) error {
+	return fmt.Errorf("flock is not supported on this platform")
+}
+
+func (f *FLock) Lock(ctx context.Context) error {
+	return fmt.Errorf("flock is not supported on this platform")
+}
+
+// Unlock is not supported/implemented on this platform
+func (f *FLock) Unlock() error {
+	return fmt.Errorf("flock is not supported on this platform")
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations/annotations.go
@@ -1,0 +1,7 @@
+package annotations
+
+const (
+	FallbackForRevision = "startup-monitor.static-pods.openshift.io/fallback-for-revision"
+	FallbackReason      = "startup-monitor.static-pods.openshift.io/fallback-reason"
+	FallbackMessage     = "startup-monitor.static-pods.openshift.io/fallback-message"
+)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/assets/startup-monitor-pod.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{.TargetNamespace}}
+  name: {{.TargetName}}-startup-monitor
+  labels:
+    revision: "REVISION"
+spec:
+  containers:
+    - name: startup-monitor
+      image: {{.OperatorImage}}
+      imagePullPolicy: IfNotPresent
+      terminationMessagePolicy: FallbackToLogsOnError
+      command: [{{.Command}}]
+      args:
+        - {{.Verbosity}}
+        - --fallback-timeout-duration=300s
+        - --target-name={{.TargetName}}
+        - --manifests-dir=/etc/kubernetes/manifests
+        - --resource-dir=/etc/kubernetes/static-pod-resources
+        - --installer-lock-file=/var/lock/{{.TargetName}}-installer.lock
+        - --revision=REVISION
+        - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig #TODO: use a different config
+      volumeMounts:
+        - mountPath: /etc/kubernetes/manifests
+          name: manifests
+        - mountPath: /etc/kubernetes/static-pod-resources
+          name: resource-dir
+        - mountPath: /etc/kubernetes/static-pod-resources/secrets
+          subPath: secrets
+          name: pod-resource-dir
+          readOnly: true
+        - mountPath: /etc/kubernetes/static-pod-resources/configmaps
+          subPath: configmaps
+          name: pod-resource-dir
+          readOnly: true
+        - mountPath: /var/lock
+          name: var-lock
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 5m
+      securityContext:
+        privileged: true
+  hostNetwork: true
+  terminationGracePeriodSeconds: 5
+  priorityClassName: system-node-critical
+  tolerations:
+    - operator: "Exists"
+  volumes:
+    - name: resource-dir
+      hostPath:
+        path: /etc/kubernetes/static-pod-resources
+    - name: manifests
+      hostPath:
+        path: /etc/kubernetes/manifests
+    - hostPath:
+        path: /etc/kubernetes/static-pod-resources/kube-apiserver-pod-REVISION
+      name: pod-resource-dir
+    - hostPath:
+        path: /var/lock
+      name: var-lock

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/bindata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/bindata.go
@@ -1,0 +1,24 @@
+package startupmonitor
+
+import (
+	"embed"
+)
+
+//go:embed assets/*
+var f embed.FS
+
+// asset reads and returns the content of the named file.
+func asset(name string) ([]byte, error) {
+	return f.ReadFile(name)
+}
+
+// mustAsset reads and returns the content of the named file or panics
+// if something went wrong.
+func mustAsset(name string) []byte {
+	data, err := f.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/cmd.go
@@ -1,0 +1,197 @@
+package startupmonitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/config/client"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/flock"
+)
+
+// ReadinessChecker is a contract between the startup monitor and operators.
+type ReadinessChecker interface {
+	IsReady(ctx context.Context, revision int) (ready bool, reason string, message string, err error)
+}
+
+// WantsRestConfig an optional interface used for setting rest config for Kube API
+type WantsRestConfig interface {
+	SetRestConfig(config *rest.Config)
+}
+
+type Options struct {
+	// Revision identifier for this particular installation instance
+	Revision int
+
+	// FallbackTimeout specifies a timeout after which the monitor starts the fall back procedure
+	FallbackTimeout time.Duration
+
+	// ResourceDir directory that holds all files supporting the static pod manifest
+	ResourceDir string
+
+	// ManifestDir directory for the static pod manifest
+	ManifestDir string
+
+	// TargetName identifies operand used to construct the final file name when reading the current and previous manifests
+	TargetName string
+
+	// KubeConfig file for authn/authz against Kube API
+	KubeConfig string
+
+	// installerLock blocks the installer from running in parallel. The monitor will run
+	// every iteration of the probe interval with this lock taken.
+	InstallerLockFile string
+
+	// Check is the readiness step.
+	Check ReadinessChecker
+}
+
+func NewCommand(check ReadinessChecker) *cobra.Command {
+	o := Options{
+		Check: check,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "startup-monitor",
+		Short: "Monitors the provided static pod revision and if it proves unhealthy rolls back to the previous revision.",
+		Run: func(cmd *cobra.Command, args []string) {
+			klog.V(1).Info(cmd.Flags())
+			klog.V(1).Info(spew.Sdump(o))
+
+			if err := o.Validate(); err != nil {
+				klog.Exit(err)
+			}
+
+			shutdownCtx := setupSignalContext(context.TODO())
+
+			m := newMonitor(o.Check.IsReady).
+				withRevision(o.Revision).
+				withManifestPath(o.ManifestDir).
+				withTargetName(o.TargetName).
+				withProbeInterval(time.Second).
+				withTimeout(o.FallbackTimeout)
+
+			fb := newFallback().
+				withRevision(o.Revision).
+				withManifestPath(o.ManifestDir).
+				withStaticPodResourcesPath(o.ResourceDir).
+				withTargetName(o.TargetName)
+
+			if len(o.KubeConfig) > 0 {
+				clientConfig, err := client.GetKubeConfigOrInClusterConfig(o.KubeConfig, nil)
+				if err != nil {
+					klog.Fatal(err)
+				}
+
+				restConfig := rest.CopyConfig(clientConfig)
+				if c, ok := o.Check.(WantsRestConfig); ok {
+					c.SetRestConfig(restConfig)
+				}
+			}
+
+			// use flock based locking with installer. We will try to release the lock cleanly, but the
+			// Linux kernel will release the lock in case we hit the unavoidable race. In worst case,
+			// we leave the lock file, but avoid racing about the startup-monitor static pod manifest.
+			var installerLock Locker = nullMutex{}
+			if len(o.InstallerLockFile) > 0 {
+				installerLock = flock.New(o.InstallerLockFile)
+			}
+
+			suicider := &o
+
+			if err := run(shutdownCtx, installerLock, m, fb, suicider); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.KubeConfig, "kubeconfig", o.KubeConfig, "kubeconfig file or empty")
+	fs.IntVar(&o.Revision, "revision", o.Revision, "identifier for this particular installation instance")
+	fs.DurationVar(&o.FallbackTimeout, "fallback-timeout-duration", 33*time.Second, "maximum time in seconds to wait for the operand to become healthy (default 33s)")
+	fs.StringVar(&o.ResourceDir, "resource-dir", o.ResourceDir, "directory that holds all files supporting the static pod manifests")
+	fs.StringVar(&o.ManifestDir, "manifests-dir", o.ManifestDir, "directory for the static pod manifest")
+	fs.StringVar(&o.TargetName, "target-name", o.TargetName, "identifies operand used to construct the final file name when reading the current and previous manifests")
+	fs.StringVar(&o.ResourceDir, "installer-lock-file", o.InstallerLockFile, "file path for the installer flock based lock file")
+}
+
+func (o *Options) Validate() error {
+	if o.FallbackTimeout == 0 {
+		return fmt.Errorf("--fallback-timeout-duration cannot be 0")
+	}
+	if len(o.ResourceDir) == 0 {
+		return fmt.Errorf("--resource-dir is required")
+	}
+	if len(o.ManifestDir) == 0 {
+		return fmt.Errorf("--manifests-dir is required")
+	}
+	if len(o.TargetName) == 0 {
+		return fmt.Errorf("--target-name is required")
+	}
+	return nil
+}
+
+type suicider interface {
+	// suicide terminates this process, while trying to release the installer lock cleanly if it can.
+	//
+	// suicide does not return.
+	suicide(installerLock Locker)
+}
+
+func (o *Options) suicide(installerLock Locker) {
+	if err := os.Remove(filepath.Join(o.ManifestDir, fmt.Sprintf("%s-startup-monitor.yaml", o.TargetName))); err != nil && !os.IsNotExist(err) {
+		installerLock.Unlock()
+		klog.Exit("Failed to suicide: %v", err)
+	}
+	installerLock.Unlock()
+	klog.Info("Waiting for SIGTERM...")
+	for {
+	}
+}
+
+// run runs the monitor, initiates fallback or mark revision as good and suicides.
+//
+// run only returns on error or when ctx is done. Otherwise, it suicides the process.
+func run(ctx context.Context, installerLock Locker, m Monitor, fb fallback, s suicider) error {
+	ready, reason, message, err := m.Run(ctx, installerLock)
+	if err != nil {
+		return err
+	}
+
+	// fallback or leave ready target running
+
+	if ready {
+		if err := fb.markRevisionGood(); err != nil {
+			return err
+		}
+	} else {
+		if err := fb.fallbackToPreviousRevision(reason, message); err != nil {
+			return err
+		}
+	}
+
+	// NOTE: here installLock is taken
+
+	select {
+	case <-ctx.Done():
+		installerLock.Unlock()
+		return nil
+	default:
+	}
+
+	// suicide
+	s.suicide(installerLock)
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/fallback.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/fallback.go
@@ -1,0 +1,219 @@
+package startupmonitor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations"
+)
+
+// fallback implements falling back to the previous version in case the current version
+// not ready with a given timeout.
+type fallback interface {
+	fallbackToPreviousRevision(reason, message string) error
+	markRevisionGood() error
+}
+
+// staticPodFallback implement fallback using static pod last-known-good symlink.
+type staticPodFallback struct {
+	// revision at which the monitor was started
+	revision int
+
+	// targetName hold the name of the operand
+	// used to construct the final file name when reading the current and previous manifests
+	targetName string
+
+	// manifestsPath points to the directory that holds the root manifests
+	manifestsPath string
+
+	// staticPodResourcesPath points to the directory that holds all files supporting the static pod manifests
+	staticPodResourcesPath string
+
+	// io collects file system level operations that need to be mocked out during tests
+	io ioInterface
+}
+
+var _ fallback = &staticPodFallback{}
+
+func newFallback() *staticPodFallback {
+	return &staticPodFallback{io: realFS{}}
+}
+
+// TODO: pruner|installer: protect the linked revision
+func (f *staticPodFallback) fallbackToPreviousRevision(reason, message string) error {
+	// step 0: if the last known good revision doesn't exist
+	//         find latest previous revision to work with
+	//         return in case no revision has been found
+	// TODO: or commit suicide as this seems to be fatal
+	lastKnownExists, err := f.fileExists(f.lastKnownGoodManifestDstPath())
+	if err != nil {
+		return err
+	}
+	if !lastKnownExists {
+		prevRev, found, err := f.findPreviousRevision()
+		if err != nil {
+			return err
+		}
+		if !found {
+			klog.Info("Unable to roll back because no previous revision hasn't been found for %s", f.targetName)
+			// here we didn't find a previous revision. Not much we can do other than timing out and suicide, leaving the failing pod alone
+			return nil
+		}
+
+		targetManifestForPrevRevExists, err := f.fileExists(f.targetManifestPathFor(prevRev))
+		if err != nil {
+			return err // retry, a transient err
+		}
+		if !targetManifestForPrevRevExists {
+			klog.Info("Unable to roll back because a manifest %q hasn't been found for the previous revision %d", f.targetManifestPathFor(prevRev), prevRev)
+			// here we didn't find a previous revision. Not much we can do other than timing out and suicide, leaving the failing pod alone
+			return nil
+		}
+
+		// step 1: create the last known good revision file
+		if err := f.createLastKnowGoodRevisionFor(prevRev, false); err != nil {
+			return err
+		}
+	}
+
+	// step 2:
+	//
+	// If the last known good revision exists and we got here that could mean one of:
+	// - the current revision is broken
+	// - we just created the last known good revision file
+	// - the previous iteration of the isReady loop returned an error
+	//
+	// In that case just:
+	// - annotate the manifest
+	// - copy the last known good revision manifest (= start the old revision pod)
+	lastKnownGoodPod, err := readPod(f.io, f.lastKnownGoodManifestDstPath())
+	if err != nil {
+		return err
+	}
+	if lastKnownGoodPod.Annotations == nil {
+		lastKnownGoodPod.Annotations = map[string]string{}
+	}
+	lastKnownGoodPod.Annotations[annotations.FallbackForRevision] = fmt.Sprintf("%d", f.revision)
+	lastKnownGoodPod.Annotations[annotations.FallbackReason] = reason
+	lastKnownGoodPod.Annotations[annotations.FallbackMessage] = message
+
+	// the kubelet has a bug that prevents graceful termination from working on static pods with the same name, filename
+	// and uuid.  By setting the pod UID we can work around the kubelet bug and get our graceful termination honored.
+	// Per the node team, this is hard to fix in the kubelet, though it will affect all static pods.
+	lastKnownGoodPod.UID = uuid.NewUUID()
+
+	// remove the existing file to ensure kubelet gets "create" event from inotify watchers
+	rootTargetManifestPath := filepath.Join(f.manifestsPath, fmt.Sprintf("%s-pod.yaml", f.targetName))
+	if err := f.io.Remove(rootTargetManifestPath); err == nil {
+		klog.Infof("Removed existing static pod manifest %q", filepath.Join(rootTargetManifestPath))
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	lastKnownGoodPodBytes := []byte(resourceread.WritePodV1OrDie(lastKnownGoodPod))
+	klog.Infof("Writing a static pod manifest %q\n\n%s", filepath.Join(rootTargetManifestPath), lastKnownGoodPodBytes)
+	if err := f.io.WriteFile(filepath.Join(rootTargetManifestPath), lastKnownGoodPodBytes, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *staticPodFallback) markRevisionGood() error {
+	return f.createLastKnowGoodRevisionFor(f.revision, true)
+}
+
+func (f *staticPodFallback) createLastKnowGoodRevisionFor(revision int, strict bool) error {
+	var revisionedTargetManifestPath = f.targetManifestPathFor(revision)
+
+	// step 0: in strict mode remove the previous last good known revision if exists
+	if strict {
+		if exists, err := f.fileExists(f.lastKnownGoodManifestDstPath()); err != nil {
+			return err
+		} else if exists {
+			if err := f.io.Remove(f.lastKnownGoodManifestDstPath()); err != nil {
+				return err
+			}
+			klog.Info("Removed existing last known good revision manifest %s", f.lastKnownGoodManifestDstPath())
+		}
+	}
+
+	// step 1: create last known good revision
+	if err := f.io.Symlink(revisionedTargetManifestPath, f.lastKnownGoodManifestDstPath()); err != nil {
+		return fmt.Errorf("failed to create a symbolic link %q for %q due to %v", f.lastKnownGoodManifestDstPath(), revisionedTargetManifestPath, err)
+	}
+	klog.Infof("Created a symlink %s for %s", f.lastKnownGoodManifestDstPath(), revisionedTargetManifestPath)
+	return nil
+}
+
+func (f *staticPodFallback) findPreviousRevision() (int, bool, error) {
+	files, err := f.io.ReadDir(f.staticPodResourcesPath)
+	if err != nil {
+		return 0, false, err
+	}
+
+	var nonCurrentRevisions []int
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(file.Name(), f.targetName+"-pod-") {
+			continue
+		}
+
+		klog.V(4).Infof("Considering %s for revision extraction", file.Name())
+		// now split the file name to get just the revision
+		fileSplit := strings.Split(file.Name(), f.targetName+"-pod-")
+		if len(fileSplit) != 2 {
+			klog.Warningf("Skipping misnamed revision dir %q", file.Name())
+			continue
+		}
+		revision, err := strconv.Atoi(fileSplit[1])
+		if err != nil {
+			klog.Warningf("Skipping misnamed revision dir %q: %v", file.Name(), err)
+			continue
+		}
+
+		if revision == f.revision {
+			continue
+		}
+
+		nonCurrentRevisions = append(nonCurrentRevisions, revision)
+	}
+
+	if len(nonCurrentRevisions) == 0 {
+		return 0, false, nil
+	}
+	sort.IntSlice(nonCurrentRevisions).Sort()
+	return nonCurrentRevisions[len(nonCurrentRevisions)-1], true, nil
+}
+
+func (f *staticPodFallback) fileExists(filepath string) (bool, error) {
+	fileInfo, err := f.io.Stat(filepath)
+	if err == nil {
+		if fileInfo.IsDir() {
+			return false, fmt.Errorf("the provided path %v is incorrect and points to a directory", filepath)
+		}
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (f *staticPodFallback) lastKnownGoodManifestDstPath() string {
+	return filepath.Join(f.staticPodResourcesPath, fmt.Sprintf("%s-last-known-good", f.targetName))
+}
+
+func (f *staticPodFallback) targetManifestPathFor(revision int) string {
+	return filepath.Join(f.staticPodResourcesPath, fmt.Sprintf("%s-pod-%d", f.targetName, revision), fmt.Sprintf("%s-pod.yaml", f.targetName))
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/manage_pod.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/manage_pod.go
@@ -1,0 +1,59 @@
+package startupmonitor
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+type startupMonitorTemplate struct {
+	Command         string
+	TargetNamespace string
+	TargetName      string
+	OperatorImage   string
+	Verbosity       string
+}
+
+func ManagePodTemplate(operatorSpec *operatorv1.StaticPodOperatorSpec, command []string, targetNamespace, targetName, targetImagePullSpec string) (string, error) {
+	rawStartupMonitorManifest := mustAsset("assets/startup-monitor-pod.yaml")
+
+	var verbosity string
+	switch operatorSpec.LogLevel {
+	case operatorv1.Normal:
+		verbosity = fmt.Sprintf(" -v=%d", 2)
+	case operatorv1.Debug:
+		verbosity = fmt.Sprintf(" -v=%d", 4)
+	case operatorv1.Trace:
+		verbosity = fmt.Sprintf(" -v=%d", 6)
+	case operatorv1.TraceAll:
+		verbosity = fmt.Sprintf(" -v=%d", 8)
+	default:
+		verbosity = fmt.Sprintf(" -v=%d", 2)
+	}
+
+	for idx, cmd := range command {
+		command[idx] = fmt.Sprintf("\"%s\"", cmd)
+	}
+
+	tmplVal := startupMonitorTemplate{
+		Command:         strings.Join(command, ","),
+		TargetNamespace: targetNamespace,
+		TargetName:      targetName,
+		OperatorImage:   targetImagePullSpec,
+		Verbosity:       verbosity,
+	}
+	tmpl, err := template.New("monitor").Parse(string(rawStartupMonitorManifest))
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, tmplVal)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/monitor.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/monitor.go
@@ -1,0 +1,199 @@
+package startupmonitor
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+type ReadinessFunc func(ctx context.Context, revision int) (ready bool, reason string, message string, err error)
+
+type Locker interface {
+	Lock(ctx context.Context) error
+	Unlock() error
+}
+
+type Monitor interface {
+	// Run checks the target for readiness and returns with true if the all readiness
+	// checks return true within the given timeout duration, or false if the timeout
+	// has passed. It will return an error if the context is done before the timeout
+	// expired.
+	//
+	// When Run returns without error, the lock is kept (and must be released by the caller.
+	// In the case it does neither timeout nor the target gets ready, the lock is released.
+	//
+	// installerLock blocks the installer from running in parallel. The monitor will run
+	// every iteration of the probe interval with this lock taken. When Run returns
+	// without error, the lock is kept (and must be released by the caller.
+	// In the case it does neither timeout nor the target gets ready, the lock is released.
+	Run(ctx context.Context, installerLock Locker) (ready bool, reason string, message string, err error)
+}
+
+// monitor watches an operand's readiness condition
+//
+// This monitor understands a directory structure created by an OCP installation. That is:
+//  The root manifest are looked up in the manifestPath
+//  The revisioned manifest are looked up in the staticPodResourcesPath
+//  The target (operand) name is derived from the targetName.
+type monitor struct {
+	// probeInterval specifies a time interval at which health of the target will be assessed
+	// be mindful of not setting it too low, on each iteration, an i/o is involved
+	probeInterval time.Duration
+
+	// timeout specifies the time the monitor will attempt to wait for readiness
+	timeout time.Duration
+
+	// revision at which the monitor was started
+	revision int
+
+	// targetName hold the name of the operand
+	// used to construct the final file name when reading the current and previous manifests
+	targetName string
+
+	// manifestsPath points to the directory that holds the root manifests
+	manifestsPath string
+
+	// check is the readiness check funcs called in order until the first fails.
+	check ReadinessFunc
+
+	// io collects file system level operations that need to be mocked out during tests
+	io ioInterface
+}
+
+var _ Monitor = &monitor{}
+
+func newMonitor(isReady ReadinessFunc) *monitor {
+	return &monitor{check: isReady, io: realFS{}}
+}
+
+func (m *monitor) Run(ctx context.Context, installerLock Locker) (ready bool, reason string, message string, err error) {
+	klog.Infof("Waiting for readiness (interval %v, timeout %v)...", m.probeInterval, m.timeout)
+
+	lastReady := false
+	var lastReason, lastMessage string
+	iteration := func(ctx context.Context) {
+		// acquire an exclusive lock to coordinate work with the installer pod, e.g.:
+		//
+		// an installer is in progress and wants to install a new revision
+		// the current revision is not healthy and we are about to fall back to the previous version (fallbackToPreviousRevision method)
+		// the installer writes the new file and we immediately overwrite it
+		//
+		// additional benefit is that we read consistent operand's manifest
+		if err := installerLock.Lock(ctx); err != nil {
+			klog.Error(err)
+			return
+		}
+
+		var err error
+		lastReady, lastReason, lastMessage, err = m.isReady(ctx)
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+		if len(lastReason) > 0 {
+			klog.Infof("Watching %s of revision %d: %s (%s)", m.targetName, m.revision, lastMessage, lastReason)
+		}
+	}
+
+	// we use wait.Until because it uses sliding interval, wait.Poll does not.
+	withTimeoutCtx, cancel := context.WithTimeout(ctx, m.timeout-m.probeInterval) // last iteration is done manually to have control over the Unlock
+	wait.UntilWithContext(withTimeoutCtx, func(ctx context.Context) {
+		defer func() {
+			if lastReady {
+				installerLock.Unlock()
+			}
+		}()
+		iteration(ctx)
+		if lastReady {
+			cancel()
+		}
+	}, m.probeInterval)
+	if !lastReady {
+		iteration(ctx) // do last iteration without Unlock
+	}
+
+	if lastReady {
+		return true, "", "", nil
+	}
+
+	// outer context done is different, as this will likely be from a signal.
+	select {
+	case <-ctx.Done():
+		installerLock.Unlock()
+		return false, "", "", ctx.Err()
+	default:
+	}
+
+	return false, lastReason, lastMessage, nil
+}
+
+func (m *monitor) isReady(ctx context.Context) (ready bool, reason string, message string, err error) {
+	// to avoid issues on startup and downgrade (before the startup monitor was introduced check the current target's revision.
+	// refrain from any further processing in case we have a mismatch.
+	currentTargetRevision, err := m.loadRootTargetPodAndExtractRevision()
+	if err != nil {
+		return false, "", "", err
+	}
+	if m.revision != currentTargetRevision {
+		return false, "UnexpectedRevision", fmt.Sprintf("expected revision %d, found %d", m.revision, currentTargetRevision), nil
+	}
+
+	// first check if the target is ready.
+	return m.check(ctx, m.revision)
+}
+
+// note that there is a fight between the installer pod (writer) and the startup monitor (reader) when dealing with the target manifest file.
+// since the monitor is resynced every probeInterval it seems we can deal with an error or stale content
+//
+// note if this code will return buffered data due to perf reason revisit fallbackToPreviousRevision
+// as it currently assumes strong consistency
+func (m *monitor) loadRootTargetPodAndExtractRevision() (int, error) {
+	currentTargetPod, err := readPod(m.io, path.Join(m.manifestsPath, fmt.Sprintf("%s-pod.yaml", m.targetName)))
+	if err != nil {
+		return 0, err
+	}
+
+	revisionString, found := currentTargetPod.Labels["revision"]
+	if !found {
+		return 0, fmt.Errorf("pod %s doesn't have revision label", currentTargetPod.Name)
+	}
+	if len(revisionString) == 0 {
+		return 0, fmt.Errorf("empty revision label on %s pod", currentTargetPod.Name)
+	}
+	revision, err := strconv.Atoi(revisionString)
+	if err != nil || revision < 0 {
+		return 0, fmt.Errorf("invalid revision label on pod %s: %q", currentTargetPod.Name, revisionString)
+	}
+
+	return revision, nil
+}
+
+func readPod(io ioInterface, filepath string) (*corev1.Pod, error) {
+	rawManifest, err := io.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+	currentTargetPod, err := resourceread.ReadPodV1(rawManifest)
+	if err != nil {
+		return nil, err
+	}
+	return currentTargetPod, nil
+}
+
+type nullMutex struct{}
+
+func (m nullMutex) Lock(ctx context.Context) error {
+	return nil
+}
+
+func (m nullMutex) Unlock() error {
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/options.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/options.go
@@ -1,0 +1,60 @@
+package startupmonitor
+
+import "time"
+
+// withProbeInterval probeInterval specifies a time interval at which health of the target will be assessed.
+// Be mindful of not setting it too low, on each iteration, an i/o is involved
+func (m *monitor) withProbeInterval(probeInterval time.Duration) *monitor {
+	m.probeInterval = probeInterval
+	return m
+}
+
+// withTimeout sets the readiness timeout.
+func (m *monitor) withTimeout(timeout time.Duration) *monitor {
+	m.timeout = timeout
+	return m
+}
+
+// withTargetName specifies the name of the operand
+// used to construct the final file name when reading the current and previous manifests
+func (m *monitor) withTargetName(targetName string) *monitor {
+	m.targetName = targetName
+	return m
+}
+
+// withManifestPath points to the directory that holds the root manifests
+func (m *monitor) withManifestPath(manifestsPath string) *monitor {
+	m.manifestsPath = manifestsPath
+	return m
+}
+
+// withRevision specifies the current revision number
+func (m *monitor) withRevision(revision int) *monitor {
+	m.revision = revision
+	return m
+}
+
+// withTargetName specifies the name of the operand
+// used to construct the final file name when reading the current and previous manifests
+func (f *staticPodFallback) withTargetName(targetName string) *staticPodFallback {
+	f.targetName = targetName
+	return f
+}
+
+// withManifestPath points to the directory that holds the root manifests
+func (f *staticPodFallback) withManifestPath(manifestsPath string) *staticPodFallback {
+	f.manifestsPath = manifestsPath
+	return f
+}
+
+// withStaticPodResourcesPath points to the directory that holds all files supporting the static pod manifests
+func (f *staticPodFallback) withStaticPodResourcesPath(staticPodResourcesPath string) *staticPodFallback {
+	f.staticPodResourcesPath = staticPodResourcesPath
+	return f
+}
+
+// withRevision specifies the current revision number
+func (f *staticPodFallback) withRevision(revision int) *staticPodFallback {
+	f.revision = revision
+	return f
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/os.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/os.go
@@ -1,0 +1,50 @@
+package startupmonitor
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"os"
+)
+
+// ioInterface collects file system level operations that need to be mocked out during tests
+type ioInterface interface {
+	Symlink(oldname string, newname string) error
+	Stat(path string) (os.FileInfo, error)
+	Remove(path string) error
+	ReadFile(filename string) ([]byte, error)
+	ReadDir(dirname string) ([]fs.FileInfo, error)
+	WriteFile(filename string, data []byte, perm fs.FileMode) error
+}
+
+// realFS is used to dispatch the real system level operations.
+type realFS struct{}
+
+// Symlink will call os.Symlink to create a symbolic link.
+func (realFS) Symlink(oldname string, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
+// Stat will call os.Stat to get the FileInfo for a given path
+func (realFS) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// Remove will call os.Remove to remove the path.
+func (realFS) Remove(path string) error {
+	return os.Remove(path)
+}
+
+// ReadFile will call ioutil.ReadFile to read data
+func (realFS) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+// ReadDir will call ioutil.ReadDir to get a list of fs.FileInfo for the given directory
+func (realFS) ReadDir(dirname string) ([]fs.FileInfo, error) {
+	return ioutil.ReadDir(dirname)
+}
+
+// WriteFile will call ioutil.WriteFile to write data
+func (realFS) WriteFile(filename string, data []byte, perm fs.FileMode) error {
+	return ioutil.WriteFile(filename, data, perm)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/signal.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/signal.go
@@ -1,0 +1,21 @@
+package startupmonitor
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog/v2"
+)
+
+// setupSignalContext registers for SIGTERM and SIGINT and returns a context
+// that will be cancelled once a signal is received.
+func setupSignalContext(baseCtx context.Context) context.Context {
+	shutdownCtx, cancel := context.WithCancel(baseCtx)
+	shutdownHandler := server.SetupSignalHandler()
+	go func() {
+		defer cancel()
+		<-shutdownHandler
+		klog.Infof("Received SIGTERM or SIGINT signal, shutting down the process.")
+	}()
+	return shutdownCtx
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210715155611-70a39c8ba7a1
+# github.com/openshift/library-go v0.0.0-20210720093535-f8ed43828870
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
@@ -284,7 +284,10 @@ github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/bindata
 github.com/openshift/library-go/pkg/operator/staticpod/controller/revision
 github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate
 github.com/openshift/library-go/pkg/operator/staticpod/installerpod
+github.com/openshift/library-go/pkg/operator/staticpod/internal/flock
 github.com/openshift/library-go/pkg/operator/staticpod/prune
+github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor
+github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller


### PR DESCRIPTION
this PR implements the following checks

- checks if we are not dealing with the old kas
- checks kube-apiserver /healthz/etcd endpoint
- checks kube-apiserver /healthz endpoint
- checks kube-apiserver /readyz endpoint
- checks if the kas pod is running at the expected revision
- checks that kubelet has reporting readiness for the new pod

xref: openshift/enhancements#833