### PR TITLE
Drop kubelet-https removed in 1.22

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -107,8 +107,6 @@ apiServerArguments:
     - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt
   kubelet-client-key:
     - /etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key
-  kubelet-https:
-    - "true"
   kubelet-preferred-address-types:
     - InternalIP # all of our kubelets have internal IPs and we *only* support communicating with them via that internal IP so that NO_PROXY always works and is lightweight
   kubelet-read-only-port:


### PR DESCRIPTION
Connections to kubelets have used HTTPS unconditionally since 1.19

Needed to land https://github.com/openshift/kubernetes/pull/862

/assign @sttts 