### PR TITLE
Bug 1989461: kube-apiserver: make flock wait for release and remove port wait

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -19,16 +19,46 @@ spec:
       volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: audit-dir
-      command: ['/usr/bin/timeout', '105', '/bin/bash', '-ec'] # a bit more than 60s for graceful termination + 35s for minimum-termination-duration, 5s extra cri-o's graceful termination period
+      command: ['/usr/bin/timeout', '{{.SetupContainerTimeoutDuration}}', '/bin/bash', '-ec']
       args:
       - |
-        echo -n "Fixing audit permissions."
+        echo "Fixing audit permissions ..."
         chmod 0700 /var/log/kube-apiserver && touch /var/log/kube-apiserver/audit.log && chmod 0600 /var/log/kube-apiserver/*
-        echo -n "Waiting for port :6443 and :6080 to be released."
-        while [ -n "$(ss -Htan '( sport = 6443 or sport = 6080 )')" ]; do
-          echo -n "."
-          sleep 1
-        done
+
+        LOCK=/var/log/kube-apiserver/.lock
+        echo "Acquiring exclusive lock ${LOCK} ..."
+
+        # Waiting for {{.GracefulTerminationDuration}}s max for old kube-apiserver's watch-termination process to exit and remove the lock.
+        # Two cases:
+        # 1. if kubelet does not start the old and new in parallel (i.e. works as expected), the flock will always succeed without any time.
+        # 2. if kubelet does overlap old and new pods for up to 130s, the flock will wait and immediate return when the old finishes.
+        #
+        # NOTE: We can increase {{.GracefulTerminationDuration}}s for a bigger expected overlap. But a higher value means less noise about the broken kubelet behaviour, i.e. we hide a bug.
+        # NOTE: Do not tweak these timings without considering the livenessProbe initialDelaySeconds
+        exec {LOCK_FD}>${LOCK} && flock --verbose -w {{.GracefulTerminationDuration}} "${LOCK_FD}" || {
+          echo "$(date -Iseconds -u) kubelet did not terminate old kube-apiserver before new one" >> /var/log/kube-apiserver/lock.log
+          echo -n ": WARNING: kubelet did not terminate old kube-apiserver before new one."
+
+          # We failed to acquire exclusive lock, which means there is old kube-apiserver running in system.
+          # Since we utilize SO_REUSEPORT, we need to make sure the old kube-apiserver stopped listening.
+          #
+          # NOTE: This is a fallback for broken kubelet, if you observe this please report a bug.
+          echo -n "Waiting for port 6443 to be released due to likely bug in kubelet or CRI-O "
+          while [ -n "$(ss -Htan state listening '( sport = 6443 or sport = 6080 )')" ]; do
+            echo -n "."
+            sleep 1
+            (( tries += 1 ))
+            if [[ "${tries}" -gt 10 ]]; then
+              echo "Timed out waiting for port :6443 and :6080 to be released, this is likely a bug in kubelet or CRI-O"
+              exit 1
+            fi
+          done
+          #  This is to make sure the server has terminated independently from the lock.
+          #  After the port has been freed (requests can be pending and need 60s max).
+          sleep 65
+        }
+        # We cannot hold the lock from the init container to the main container. We release it here. There is no risk, at this point we know we are safe.
+        flock -u "${LOCK_FD}"
       securityContext:
         privileged: true
       resources:
@@ -44,30 +74,16 @@ spec:
     args:
         - |
           LOCK=/var/log/kube-apiserver/.lock
-          echo -n "Acquiring exclusive lock ${LOCK}"
-          exec {LOCK_FD}>${LOCK} && flock -n "${LOCK_FD}" || {
-            echo "$(date -Iseconds -u) kubelet did not terminate old kube-apiserver before new one" >> /var/log/kube-apiserver/lock.log
-            echo -n ": WARNING: kubelet did not terminate old kube-apiserver before new one."
-            # we didn't get an exclusive lock. We keep going with the risk to corrupt audit logs.
+          # We should be able to acquire the lock immediatelly. If not, it means the init container has not released it yet and kubelet or CRI-O started container prematurely.
+          exec {LOCK_FD}>${LOCK} && flock --verbose -w 30 "${LOCK_FD}" || {
+            echo "Failed to acquire lock for kube-apiserver. Please check setup container for details. This is likely kubelet or CRI-O bug."
+            exit 1
           }
-          echo
-
           if [ -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
-            echo "Copying system trust bundle"
+            echo "Copying system trust bundle ..."
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          echo -n "Waiting for port :6443 to be released."
-          tries=0
-          while [ -n "$(ss -Htan '( sport = 6443 )')" ]; do
-            echo -n "."
-            sleep 1
-            (( tries += 1 ))
-            if [[ "${tries}" -gt 105 ]]; then
-              echo "timed out waiting for port :6443 to be released"
-              exit 1
-            fi
-          done
-          echo
+
           exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration={{.GracefulTerminationDuration}}s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} {{.Verbosity}} --permit-address-sharing --runtime-config="admissionregistration.k8s.io/v1beta1=false,apiextensions.k8s.io/v1beta1=false"
     resources:
       requests:

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -493,10 +493,11 @@ func gracefulTerminationDurationFromConfig(operatorSpec *operatorv1.StaticPodOpe
 }
 
 type kasTemplate struct {
-	Image                       string
-	OperatorImage               string
-	Verbosity                   string
-	GracefulTerminationDuration int
+	Image                         string
+	OperatorImage                 string
+	Verbosity                     string
+	GracefulTerminationDuration   int
+	SetupContainerTimeoutDuration int
 }
 
 func manageTemplate(rawTemplate string, imagePullSpec string, operatorImagePullSpec string, operatorSpec *operatorv1.StaticPodOperatorSpec) (string, error) {
@@ -533,6 +534,8 @@ func manageTemplate(rawTemplate string, imagePullSpec string, operatorImagePullS
 		OperatorImage:               operatorImagePullSpec,
 		Verbosity:                   verbosity,
 		GracefulTerminationDuration: gracefulTerminationDuration,
+		// 80s for minimum-termination-duration (10s port wait, 65s to let pending requests finish after port has been freed) + 5s extra cri-o's graceful termination period
+		SetupContainerTimeoutDuration: gracefulTerminationDuration + 80 + 5,
 	}
 	tmpl, err := template.New("kas").Parse(rawTemplate)
 	if err != nil {


### PR DESCRIPTION
This change the current logic of running kube-apiserver to following:

* **setup** init container (timeout={{.GracefulTerminationDuration + 35 + 5}})
  * `flock -w {{.GracefulTerminationDuration}}` (normally 135s)
  * on error: wait 60s for 8443 port to be released
  * `flock -u`

* **kube-apiserver** container (_livenessProbe_ initial timeout=45s (time apiserver must respond to livez or die))
  * `flock -w 30` (just to be safe)
  * on error: exit(1)
  * run watch-termination that run kube-apiserver

There are two cases we might hit:

* kubelet/CRI-O will launch a new kube-apiserver process while the previous one is still terminating: in that case, the setup container will wait up to 130s for the old kube-apiserver to release the lock. If it fails, it will wait for extra 60s for the 8443 port to be released for the new kube-apiserver. After that, it will finish by releasing the lock.

* kubelet/CRI-O will not launch new kube-apiserver before old kube-apiserver process is finished, which means the lock is released by kernel. In that case, the setup container will acquire the lock immediately and right after that it will release it for kube-apiserver container

The goal of this change is to minimize the delay between API server replacement and API downtime caused by waiting for the port to be freed by the kernel (what we do today). Since we utilize SO_REUSEPORT, we should be able to bind on the same port even if the kernel is thinking the port is still taken (usually this adds ~60s of downtime). To make sure we are safe, we need to make sure the old process is finished, otherwise, we corrupt audit logs and termination logs or at least be sure the terminating API server is not listening, so we don't end up in a spot where kernel route traffic to two API servers, where one of them is shutting down.

By theory, we should be able to cut ~60s of API downtime on a single node with this change.