### PR TITLE
Bug 1985997: scaffolding for e2e tests for the static pod monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ test-e2e: GO_TEST_FLAGS += -p 1
 test-e2e: test-unit
 .PHONY: test-e2e
 
+test-e2e-sno-disruptive: GO_TEST_PACKAGES :=./test/e2e-sno-disruptive/...
+test-e2e-sno-disruptive: GO_TEST_FLAGS += -v
+test-e2e-sno-disruptive: GO_TEST_FLAGS += -timeout 3h
+test-e2e-sno-disruptive: GO_TEST_FLAGS += -p 1
+test-e2e-sno-disruptive: test-unit
+.PHONY: test-e2e-sno-disruptive
+
 clean:
 	$(RM) ./cluster-kube-apiserver-operator
 .PHONY: clean

--- a/test/e2e-sno-disruptive/sno_disruptive_test.go
+++ b/test/e2e-sno-disruptive/sno_disruptive_test.go
@@ -1,0 +1,7 @@
+package e2e_sno_disruptive
+
+import "testing"
+
+func TestFallback(t *testing.T) {
+	t.Log("implement me")
+}


### PR DESCRIPTION
I am going to define a dedicated CI job for the new tests.