### PR TITLE
Bug 1998552: Enforce OpenShift's defined kubelet version skew policies

### DIFF
--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
@@ -1,0 +1,255 @@
+package kubeletversionskewcontroller
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/blang/semver"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/status"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+const (
+	KubeletMinorVersionUpgradeableConditionType = "KubeletMinorVersionUpgradeable"
+
+	KubeletVersionUnknownReason                     = "KubeletVersionUnknown"
+	KubeletMinorVersionSyncedReason                 = "KubeletMinorVersionsSynced"
+	KubeletMinorVersionSupportedNextUpgradeReason   = "KubeletMinorVersionSupportedNextUpgrade"
+	KubeletMinorVersionUnsupportedNextUpgradeReason = "KubeletMinorVersionUnsupportedNextUpgrade"
+	KubeletMinorVersionUnsupportedReason            = "KubeletMinorVersionUnsupported"
+	KubeletMinorVersionAheadReason                  = "KubeletMinorVersionAhead"
+)
+
+// KubeletVersionSkewController sets Upgradeable=False if the kubelet
+// version on a node prevents upgrading to a supported OpenShift version.
+//
+// For odd OpenShift minor versions, kubelet versions 0 or 1 minor
+// versions behind the API server version are supported.
+//
+// For even OpenShift minor versions, kubelet versions 0, 1, or 2
+// minor versions behind the API server version are supported.
+type KubeletVersionSkewController interface {
+	factory.Controller
+}
+
+func NewKubeletVersionSkewController(
+	operatorClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	recorder events.Recorder,
+) *kubeletVersionSkewController {
+	openShiftVersion := semver.MustParse(status.VersionForOperatorFromEnv())
+	nextOpenShiftVersion := semver.Version{Major: openShiftVersion.Major, Minor: openShiftVersion.Minor + 1}
+	c := &kubeletVersionSkewController{
+		operatorClient:              operatorClient,
+		nodeLister:                  kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes().Lister(),
+		apiServerVersion:            semver.MustParse(status.VersionForOperandFromEnv()),
+		minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(openShiftVersion),
+		minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
+	}
+	c.Controller = factory.New().
+		WithSync(c.sync).
+		WithInformers(kubeInformersForNamespaces.InformersFor("").Core().V1().Nodes().Informer()).
+		ToController("KubeletVersionSkewController", recorder.WithComponentSuffix("kubelet-version-skew-controller"))
+	return c
+}
+
+func minSupportedKubeletSkewForOpenShiftVersion(v semver.Version) int {
+	switch v.Minor % 2 {
+	case 0: // even OpenShift versions
+		return -2
+	case 1: // odd OpenShift versions
+		return -1
+	default:
+		panic("should not happen")
+	}
+}
+
+type kubeletVersionSkewController struct {
+	factory.Controller
+	operatorClient              v1helpers.OperatorClient
+	nodeLister                  corev1listers.NodeLister
+	apiServerVersion            semver.Version
+	minSupportedSkew            int
+	minSupportedSkewNextVersion int
+}
+
+func (c *kubeletVersionSkewController) sync(_ context.Context, _ factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	nodes, err := c.nodeLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	sort.Sort(byName(nodes))
+
+	var errors nodeKubeletInfos
+	var skewedUnsupported nodeKubeletInfos
+	var skewedLimit nodeKubeletInfos
+	var skewedButOK nodeKubeletInfos
+	var synced nodeKubeletInfos
+	var unsupported nodeKubeletInfos
+
+	// for each node, check kubelet version
+	for _, node := range nodes {
+		kubeletVersion, err := nodeKubeletVersion(node)
+		if err != nil {
+			runtime.HandleError(fmt.Errorf("unable to determine kubelet version on node %s: %w", node.Name, err))
+			errors = append(errors, nodeKubeletInfo{node: node.Name, err: err})
+			continue
+		}
+		skew := int(kubeletVersion.Minor - c.apiServerVersion.Minor)
+		// Assume that an OpenShift minor version upgrade also bumps to the next kube minor version. Revisit
+		// this in the future if an OpenShift minor version upgrade ever skips or repeats a kube minor version.
+		skewNextVersion := skew - 1
+		switch {
+		case skew == 0:
+			// synced
+			synced = append(synced, nodeKubeletInfo{node: node.Name, version: &kubeletVersion})
+		case skew < c.minSupportedSkew:
+			// already in an unsupported state
+			skewedUnsupported = append(skewedUnsupported, nodeKubeletInfo{node: node.Name, version: &kubeletVersion})
+		case skewNextVersion < c.minSupportedSkewNextVersion:
+			// upgrading to next minor version of API server would result in an unsupported config
+			skewedLimit = append(skewedLimit, nodeKubeletInfo{node: node.Name, version: &kubeletVersion})
+		case skew < 0:
+			// behind, but upgrading to next minor version of API server is supported
+			skewedButOK = append(skewedButOK, nodeKubeletInfo{node: node.Name, version: &kubeletVersion})
+		default:
+			// kubelet version newer than api server version. possibly in the middle of a rollback.
+			unsupported = append(unsupported, nodeKubeletInfo{node: node.Name, version: &kubeletVersion})
+		}
+	}
+
+	condition := operatorv1.OperatorCondition{Type: KubeletMinorVersionUpgradeableConditionType}
+	// use the most "severe" reason to set the condition status
+	switch {
+	case len(skewedUnsupported) > 0:
+		condition.Reason = KubeletMinorVersionUnsupportedReason
+		condition.Status = operatorv1.ConditionFalse
+		switch len(skewedUnsupported) {
+		case 1:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor version (%v) on node %s is too far behind the target API server version (%v).", skewedUnsupported.version(), skewedUnsupported.nodes(), c.apiServerVersion)
+		case 2, 3:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on nodes %s are too far behind the target API server version (%v).", skewedUnsupported.nodes(), c.apiServerVersion)
+		default:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on %d nodes are too far behind the target API server version (%v).", len(skewedUnsupported), c.apiServerVersion)
+		}
+	case len(unsupported) > 0:
+		condition.Reason = KubeletMinorVersionAheadReason
+		condition.Status = operatorv1.ConditionUnknown
+		switch len(unsupported) {
+		case 1:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor version (%v) on node %s is ahead of the target API server version (%v).", unsupported.version(), unsupported.nodes(), c.apiServerVersion)
+		case 2, 3:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on nodes %s are ahead of the target API server version (%v).", unsupported.nodes(), c.apiServerVersion)
+		default:
+			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on %d nodes are ahead of the target API server version (%v).", len(unsupported), c.apiServerVersion)
+		}
+	case len(errors) > 0:
+		condition.Reason = KubeletVersionUnknownReason
+		condition.Status = operatorv1.ConditionUnknown
+		switch len(errors) {
+		case 1:
+			condition.Message = fmt.Sprintf("Unable to determine the kubelet version on node %s: %v", errors.nodes(), errors.error())
+		case 2, 3:
+			condition.Message = fmt.Sprintf("Unable to determine the kubelet version on nodes %s.", errors.nodes())
+		default:
+			condition.Message = fmt.Sprintf("Unable to determine the kubelet version on %d nodes.", len(errors))
+		}
+	case len(skewedLimit) > 0:
+		condition.Reason = KubeletMinorVersionUnsupportedNextUpgradeReason
+		condition.Status = operatorv1.ConditionFalse
+		switch len(skewedLimit) {
+		case 1:
+			condition.Message = fmt.Sprintf("Kubelet minor version (%v) on node %s will not be supported in the next OpenShift minor version upgrade.", skewedLimit.version(), skewedLimit.nodes())
+		case 2, 3:
+			condition.Message = fmt.Sprintf("Kubelet minor versions on nodes %s will not be supported in the next OpenShift minor version upgrade.", skewedLimit.nodes())
+		default:
+			condition.Message = fmt.Sprintf("Kubelet minor versions on %d nodes will not be supported in the next OpenShift minor version upgrade.", len(skewedLimit))
+		}
+	case len(skewedButOK) > 0:
+		condition.Reason = KubeletMinorVersionSupportedNextUpgradeReason
+		condition.Status = operatorv1.ConditionTrue
+		switch len(skewedButOK) {
+		case 1:
+			condition.Message = fmt.Sprintf("Kubelet minor version (%v) on node %s is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift minor version upgrade.", skewedButOK.version(), skewedButOK.nodes())
+		case 2, 3:
+			condition.Message = fmt.Sprintf("Kubelet minor versions on nodes %s are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift minor version upgrade.", skewedButOK.nodes())
+		default:
+			condition.Message = fmt.Sprintf("Kubelet minor versions on %d nodes are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift minor version upgrade.", len(skewedButOK))
+		}
+	default:
+		condition.Reason = KubeletMinorVersionSyncedReason
+		condition.Status = operatorv1.ConditionTrue
+		condition.Message = "Kubelet and API server minor versions are synced."
+	}
+
+	_, _, err = v1helpers.UpdateStatus(c.operatorClient, v1helpers.UpdateConditionFn(condition))
+	return err
+}
+
+type nodeKubeletInfo struct {
+	node    string
+	version *semver.Version
+	err     error
+}
+
+type nodeKubeletInfos []nodeKubeletInfo
+
+func (n nodeKubeletInfos) nodes() string {
+	var s []string
+	for _, i := range n {
+		s = append(s, i.node)
+	}
+	switch len(s) {
+	case 0, 1:
+	case 2:
+		return strings.Join(s, " and ")
+	default:
+		s[len(s)-1] = "and " + s[len(s)-1]
+	}
+	return strings.Join(s, ", ")
+}
+
+func (n nodeKubeletInfos) error() error {
+	if len(n) > 0 {
+		return n[0].err
+	}
+	return nil
+}
+
+func (n nodeKubeletInfos) version() *semver.Version {
+	if len(n) > 0 {
+		return n[0].version
+	}
+	return nil
+}
+
+func nodeKubeletVersion(node *corev1.Node) (semver.Version, error) {
+	return semver.Parse(strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v"))
+}
+
+var byNodeRegexp = regexp.MustCompile(`node [^ ]*`)
+
+type byName []*corev1.Node
+
+func (n byName) Len() int           { return len(n) }
+func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n byName) Less(i, j int) bool { return strings.Compare(n[i].Name, n[j].Name) < 0 }

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
@@ -1,0 +1,180 @@
+package kubeletversionskewcontroller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func Test_kubeletVersionSkewController_Sync(t *testing.T) {
+
+	evenOpenShiftVersion := "4.8.0"
+	oddOpenShiftVersion := "4.9.0"
+	apiServerVersion := "1.21.1"
+	skewedKubeletVersions := func(s ...int) []string {
+		var v []string
+		for i, skew := range s {
+			v = append(v, fmt.Sprintf("1.%d.%d", 21+skew, i))
+		}
+		return v
+	}
+
+	testCases := []struct {
+		name             string
+		ocpVersion       string
+		kubeletVersions  []string
+		expectedStatus   operatorv1.ConditionStatus
+		expectedReason   string
+		expectedMsgLines string
+	}{
+		{
+			name:             "Synced/Even",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSyncedReason,
+			expectedMsgLines: "Kubelet and API server minor versions are synced.",
+		},
+		{
+			name:             "Synced/Odd",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSyncedReason,
+			expectedMsgLines: "Kubelet and API server minor versions are synced.",
+		},
+		{
+			name:             "ErrorParsingKubeletVersion",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  []string{"Invalid", "1.21.2", "1.20.3"},
+			expectedStatus:   operatorv1.ConditionUnknown,
+			expectedReason:   KubeletVersionUnknownReason,
+			expectedMsgLines: "Unable to determine the kubelet version on node test000: No Major.Minor.Patch elements found",
+		},
+		{
+			name:             "UnsupportedNextUpgrade/Even",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -1, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet minor version (1.20.1) on node test001 will not be supported in the next OpenShift minor version upgrade.",
+		},
+		{
+			name:             "UnsupportedNextUpgrade/Odd",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported kubelet minor version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+		},
+		{
+			name:             "TwoNodesNotSynced",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -1, -1),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet minor versions on nodes test001 and test002 will not be supported in the next OpenShift minor version upgrade.",
+		},
+		{
+			name:             "ThreeNodesNotSynced",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet minor versions on nodes test001, test002, and test003 will not be supported in the next OpenShift minor version upgrade.",
+		},
+		{
+			name:             "ManyNodesNotSynced",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1, -1, -1, 0, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet minor versions on 5 nodes will not be supported in the next OpenShift minor version upgrade.",
+		},
+		{
+			name:             "SkewedUnsupported/Even",
+			ocpVersion:       evenOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -3, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported kubelet minor version (1.18.1) on node test001 is too far behind the target API server version (1.21.1).",
+		},
+		{
+			name:             "SkewedUnsupported/Odd",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported kubelet minor version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+		},
+		{
+			name:             "SkewedButOK/Odd",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(-1, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet minor version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift minor version upgrade.",
+		},
+		{
+			name:             "Unsupported",
+			ocpVersion:       oddOpenShiftVersion,
+			kubeletVersions:  skewedKubeletVersions(0, -1, 1),
+			expectedStatus:   operatorv1.ConditionUnknown,
+			expectedReason:   KubeletMinorVersionAheadReason,
+			expectedMsgLines: "Unsupported kubelet minor version (1.22.2) on node test002 is ahead of the target API server version (1.21.1).",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for i, kv := range tc.kubeletVersions {
+				indexer.Add(&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("test%03d", i)},
+					Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: kv}},
+				})
+			}
+			status := &operatorv1.StaticPodOperatorStatus{}
+			ocpVersion := semver.MustParse(tc.ocpVersion)
+			nextOpenShiftVersion := semver.Version{Major: ocpVersion.Major, Minor: ocpVersion.Minor + 1}
+			c := &kubeletVersionSkewController{
+				operatorClient: v1helpers.NewFakeStaticPodOperatorClient(
+					&operatorv1.StaticPodOperatorSpec{OperatorSpec: operatorv1.OperatorSpec{ManagementState: operatorv1.Managed}},
+					status, nil, nil,
+				),
+				nodeLister:                  corev1listers.NewNodeLister(indexer),
+				apiServerVersion:            semver.MustParse(apiServerVersion),
+				minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(ocpVersion),
+				minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
+			}
+			err := c.sync(nil, nil)
+			if err != nil {
+				t.Fatalf("sync() unexpected err: %v", err)
+			}
+			if len(status.Conditions) != 1 || status.Conditions[0].Type != KubeletMinorVersionUpgradeableConditionType {
+				t.Errorf("Expected %s condition type.", KubeletMinorVersionUpgradeableConditionType)
+			}
+			condition := status.Conditions[0]
+			if tc.expectedStatus != condition.Status {
+				t.Errorf("Condition status: expected %s, actual %s", tc.expectedStatus, condition.Status)
+			}
+			if tc.expectedReason != condition.Reason {
+				t.Errorf("Condition reason: expected %s, actual %s", tc.expectedReason, condition.Reason)
+			}
+			if tc.expectedMsgLines != condition.Message {
+				t.Errorf("Expected condition message to match %q.", tc.expectedMsgLines)
+				t.Log(diff.StringDiff(tc.expectedMsgLines, condition.Message))
+			}
+			if t.Failed() {
+				t.Logf(condition.Message)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/connectivitycheckcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/featureupgradablecontroller"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/kubeletversionskewcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/nodekubeconfigcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/resourcesynccontroller"
@@ -335,6 +336,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
+	kubeletVersionSkewController := kubeletversionskewcontroller.NewKubeletVersionSkewController(
+		operatorClient,
+		kubeInformersForNamespaces,
+		controllerContext.EventRecorder,
+	)
+
 	// register termination metrics
 	terminationobserver.RegisterMetrics()
 
@@ -364,6 +371,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go auditPolicyController.Run(ctx, 1)
 	go staleConditionsController.Run(ctx, 1)
 	go connectivityCheckController.Run(ctx, 1)
+	go kubeletVersionSkewController.Run(ctx, 1)
 
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
Add `KubeletVersionSkewController` in support of enhancement user story: [APIServer - Enforce OpenShift's defined kubelet version skew policies](https://github.com/openshift/enhancements/blob/master/enhancements/update/eus-upgrades-mvp.md)

### Condition

```go
// KubeletVersionSkewController sets Upgradeable=False if the kubelet
// version on a node prevents upgrading to a supported OCP version.
//
// For odd OCP minor versions, kubelet versions 0 or 1 minor version
// behind the API server version are supported.
//
// For even OCP minor versions, kubelet versions 0, 1, or 2 minor
// versions behind the API server version are supported.
const KubletVersionSkewLimitUpgradeable = "KubletVersionSkewLimitUpgradeable"
```

### Reasons



Reason | Upgradeable? | Description
-- | -- | --
KubeletVersionUnknown | Unknown | Error determining kubelet version.
KubeletMinorVersionsSynced | True | Kubelet and API server version minor versions are synced.
KubeletMinorVersionSupportedNextUpgrade | True | Kubelet version on a node will be supported in the next OCP minor version upgrade.
KubeletMinorVersionUnsupportedNextUpgrade | False | Kubelet version on a node will not be supported in the next OCP minor version upgrade.
KubeletMinorVersionUnsupported | False | Unsupported kubelet minor version on a node is too far behind the expected API server version.
KubeletMinorVersionAhead | Unknown | Unsupported kubelet minor version on a node is newer than expected API server version.


### Kublet minor version skew limits

* If OCP minor version is odd, kubelet versions older than 1 minor version of the API server version set `Upgradeable=False`.
* If OCP minor version is even, kubelet versions must be in sync with API server version in order to set `Upgradeable=True`.

### Supported kublet minor versions

A re-statement of the of the kubelet minor version skew limits above as supported kubelet minor versions:

* If OCP minor version is odd, kubelet versions 0 or 1 minor version behind the API server version are supported.
* If OCP minor version is even, kubelet versions 0, 1, or 2 minor versions behind the API server version are supported.
 
### Upstream kubelet compatibility

For reference, here is the upstream specification for kubelet/api server compatibility:

* https://kubernetes.io/releases/version-skew-policy/#kubelet