### PR TITLE
Bug 1994257: Actually create prometheus rule for audit error alert

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -149,6 +149,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
 			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
 			"assets/alerts/api-usage.yaml",
+			"assets/alerts/audit-errors.yaml",
 			"assets/alerts/cpu-utilization.yaml",
 			"assets/alerts/kube-apiserver-requests.yaml",
 			"assets/alerts/kube-apiserver-slos.yaml",


### PR DESCRIPTION
This was added on https://github.com/openshift/cluster-kube-apiserver-operator/pull/1166
but that PR didn't actually create the rule. This fixes that.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>