### PR TITLE
Bug 1994857: targetcontroller: check external dependencies (csr-controller-ca configmap) only on SNO

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -169,6 +169,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
 		kubeInformersForNamespaces,
+		configInformers.Config().V1().Infrastructures(),
 		kubeClient,
 		startupmonitorreadiness.IsStartupMonitorEnabledFunction(configInformers.Config().V1().Infrastructures().Lister(), operatorClient),
 		controllerContext.EventRecorder,


### PR DESCRIPTION
/assign @sttts 

@hexfusion  based on comments from Stefan we might want to change the deps check, he says that relying on managed fields is not reliable enough. What was the annotation you initially wanted to check?
