### PR TITLE
Bug 1993800: bump(library-go): staticpod/installer: fix backoff of installers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20210521075222-e273a339932a
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06
+	github.com/openshift/library-go v0.0.0-20210825122301-7f0bf922c345
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99 h1:KrCYRAJcgZYzMCB1PjJHJMYPu/d+dEkelq5eYyi0fDw=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210419140141-620426e63a99/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06 h1:WWpq96l210DQR5XiTNwwEf4wFZUqJIKnAcLt+bLthrI=
-github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
+github.com/openshift/library-go v0.0.0-20210825122301-7f0bf922c345 h1:L8XeTZSonLKMLZVUo71LXVhBGE6yu1yeZ0BkpNgLPEw=
+github.com/openshift/library-go v0.0.0-20210825122301-7f0bf922c345/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -234,7 +234,6 @@ func (c RevisionController) createNewRevision(recorder events.Recorder, revision
 		Name:       statusConfigMap.Name,
 		UID:        statusConfigMap.UID,
 	}}
-
 	for _, cm := range c.configMaps {
 		obj, _, err := resourceapply.SyncConfigMap(c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -218,7 +218,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210727084322-8a96c0a97c06
+# github.com/openshift/library-go v0.0.0-20210825122301-7f0bf922c345
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Bumping to get https://github.com/openshift/library-go/pull/1180