### PR TITLE
Bug 1992541: all the alert rules' annotations "summary" and "description" should comply with the OpenShift alerting guidelines

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -9,7 +9,8 @@ spec:
       rules:
         - alert: APIRemovedInNextReleaseInUse
           annotations:
-            message: >-
+            summary: Deprecated API that will be removed in the next version is being used.
+            description: >-
               Deprecated API that will be removed in the next version is being used. Removing the workload that is using
               the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next cluster version.
@@ -21,7 +22,8 @@ spec:
             severity: info
         - alert: APIRemovedInNextEUSReleaseInUse
           annotations:
-            message: >-
+            summary: Deprecated API that will be removed in the next EUS version is being used.
+            description: >-
               Deprecated API that will be removed in the next EUS version is being used. Removing the workload that is using
               the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
               a successful upgrade to the next EUS cluster version.

--- a/bindata/assets/alerts/cpu-utilization.yaml
+++ b/bindata/assets/alerts/cpu-utilization.yaml
@@ -12,7 +12,7 @@ spec:
             summary: >-
               CPU utilization across all three control plane nodes is higher than two control plane nodes can sustain; a single control plane node outage may
               cause a cascading failure; increase available CPU.
-            message: >-
+            description: >-
               Given three control plane nodes, the overall CPU utilization may only be about 2/3 of all available capacity.
               This is because if a single control plane node fails, the remaining two must handle the load of the cluster in order to be HA.
               If the cluster is using more than 2/3 of all capacity, if one control plane node fails, the remaining two are likely to
@@ -33,7 +33,7 @@ spec:
           annotations:
             summary: >-
               CPU utilization on a single control plane node is very high, more CPU pressure is likely to cause a failover; increase available CPU.
-            message: >-
+            description: >-
               Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
               When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
               causing even more CPU pressure.

--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -46,7 +46,10 @@ spec:
     rules:
     - alert: TechPreviewNoUpgrade
       annotations:
-        message: Cluster has enabled tech preview features that will prevent upgrades.
+        summary: Cluster has enabled tech preview features that will prevent upgrades.
+        description: >-
+          Cluster has enabled Technology Preview features that cannot be undone and will prevent upgrades.
+          The TechPreviewNoUpgrade feature set is not recommended on production clusters.
       expr: |
         cluster_feature_set{name!="", namespace="openshift-kube-apiserver-operator"} == 0
       for: 10m


### PR DESCRIPTION
1. Changed `message` annotations to `description` annotations.
2. Added `summary` annotations.
3. Ensure that the`description` annotation is _"...providing details about what is happening and how to resolve the issue"_.