### PR TITLE
deadman: add command to reset clusteroperators conditions to unknown

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -177,6 +177,30 @@ spec:
     volumeMounts:
     - mountPath: /etc/kubernetes/static-pod-resources
       name: resource-dir
+  - name: kube-apiserver-deadman
+    env:
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+    image: {{.OperatorImage}}
+    imagePullPolicy: IfNotPresent
+    terminationMessagePolicy: FallbackToLogsOnError
+    command: ["cluster-kube-apiserver-operator", "deadman"]
+    args:
+      - --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
+      - --namespace=$(POD_NAMESPACE)
+      - --heartbeat-file=/var/log/kube-apiserver/.heartbeat
+      - -v=2
+    resources:
+      requests:
+        memory: 50Mi
+        cpu: 5m
+    volumeMounts:
+      - mountPath: /etc/kubernetes/static-pod-resources
+        name: resource-dir
+      - mountPath: /var/log/kube-apiserver
+        name: audit-dir
   - name: kube-apiserver-insecure-readyz
     image: {{.OperatorImage}}
     imagePullPolicy: IfNotPresent

--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/certregenerationcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/checkendpoints"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/deadman"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/insecurereadyz"
 	operatorcmd "github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/operator"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/cmd/render"
@@ -73,6 +74,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(certregenerationcontroller.NewCertRegenerationControllerCommand(ctx))
 	cmd.AddCommand(insecurereadyz.NewInsecureReadyzCommand())
 	cmd.AddCommand(checkendpoints.NewCheckEndpointsCommand())
+	cmd.AddCommand(deadman.NewDeadmanCommand(ctx))
 	cmd.AddCommand(startupmonitor.NewCommand(startupmonitorreadiness.New(), func(config *rest.Config) (operatorclientv1.KubeAPIServerInterface, error) {
 		client, err := operatorclientv1.NewForConfig(config)
 		if err != nil {

--- a/pkg/cmd/deadman/deadman.go
+++ b/pkg/cmd/deadman/deadman.go
@@ -1,0 +1,123 @@
+package deadman
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	errutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/version"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configeversionedclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+)
+
+type Options struct {
+	controllerContext *controllercmd.ControllerContext
+	heartBeatFile     string
+}
+
+func NewDeadmanCommand(ctx context.Context) *cobra.Command {
+	o := &Options{}
+
+	ccc := controllercmd.NewControllerCommandConfig("deadman", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+		o.controllerContext = controllerContext
+
+		err := o.Validate(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = o.Complete(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = o.Run(ctx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	ccc.DisableServing = true
+	cmd := ccc.NewCommandWithContext(ctx)
+	cmd.Use = "deadman"
+	cmd.Short = "Reset cluster operators status to unknown after cluster shutdown"
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.heartBeatFile, "heartbeat-file", o.heartBeatFile, "The file to use to store the last heart beat timestamp")
+}
+
+func (o *Options) Validate(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Complete(ctx context.Context) error {
+	return nil
+}
+
+func (o *Options) Run(ctx context.Context) error {
+	configClient, err := configeversionedclient.NewForConfig(o.controllerContext.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config client: %w", err)
+	}
+	return (&Heartbeat{
+		file:            o.heartBeatFile,
+		interval:        1 * time.Minute,
+		maxDeadDuration: 60 * time.Minute,
+		callbackFn: func(ctx context.Context) error {
+			clusteroperators, err := configClient.ConfigV1().ClusterOperators().List(ctx, v1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to list cluster operator: %v", err)
+			}
+			clusterOperatorsToUpdate := []*configv1.ClusterOperator{}
+			for _, clusterOperator := range clusteroperators.Items {
+				needUpdate := false
+				hasTransition := false
+				operator := clusterOperator.DeepCopy()
+				for i, c := range clusterOperator.Status.Conditions {
+					if c.Status == configv1.ConditionUnknown {
+						continue
+					}
+					if time.Now().Sub(c.LastTransitionTime.Time) < 30*time.Minute {
+						hasTransition = true
+						continue
+					}
+					operator.Status.Conditions[i].Status = configv1.ConditionUnknown
+					operator.Status.Conditions[i].Reason = "WaitingForOperatorUpdate"
+					operator.Status.Conditions[i].Message = "Waiting for operator to provide current operand status"
+					needUpdate = true
+				}
+				// operator need update only if there is condition that is not in unknown state and the operator has not made any progress
+				// for last 30 minutes.
+				if needUpdate && !hasTransition {
+					clusterOperatorsToUpdate = append(clusterOperatorsToUpdate, operator)
+				}
+			}
+			var errors []error
+			for i := range clusterOperatorsToUpdate {
+				err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					_, updateErr := configClient.ConfigV1().ClusterOperators().Update(ctx, clusterOperatorsToUpdate[i], v1.UpdateOptions{})
+					return updateErr
+				})
+				if err != nil {
+					errors = append(errors, err)
+				}
+			}
+			return errutil.NewAggregate(errors)
+		},
+	}).Run(ctx)
+}

--- a/pkg/cmd/deadman/heartbeat.go
+++ b/pkg/cmd/deadman/heartbeat.go
@@ -1,0 +1,73 @@
+package deadman
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type Heartbeat struct {
+	file     string
+	interval time.Duration
+
+	// maxDeadDuration represents a duration to tolerate between last stored heartbeat timestamp and current time.
+	// if the duration is exceeded the callbackFn is being triggered.
+	// the callbackFn is triggered only when this process starts.
+	maxDeadDuration time.Duration
+	callbackFn      func(ctx context.Context) error
+}
+
+func (h *Heartbeat) Run(ctx context.Context) error {
+	var lastRecordedHeartbeat int64
+
+	lastRecordedHeartbeatBytes, err := ioutil.ReadFile(h.file)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to read existing heartbeat file %q: %v", h.file, err)
+	}
+
+	if err == nil && len(lastRecordedHeartbeatBytes) > 0 {
+		i, err := strconv.Atoi(string(lastRecordedHeartbeatBytes))
+		if err != nil {
+			return err
+		}
+		lastRecordedHeartbeat = int64(i)
+	} else {
+		// the file does not exists or there is no timestamp recorded in it
+		lastRecordedHeartbeat = time.Now().Unix()
+	}
+
+	// if last recorded heartbeat is out of tolerated duration, trigger callback function
+	if d := time.Now().Sub(time.Unix(lastRecordedHeartbeat, 0)); d > h.maxDeadDuration {
+		klog.Infof("Triggering callback function because difference between last heart beat is %s", d)
+		go func(ctx context.Context) {
+			n := time.Now()
+			defer func() {
+				klog.Infof("Callback function finished in %s", time.Now().Sub(n))
+			}()
+			if err := h.callbackFn(ctx); err != nil {
+				klog.Errorf("Callback function failed: %v", err)
+			}
+		}(ctx)
+	}
+
+	// keep writing timestamp to file until context is cancelled
+	wait.Forever(func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		currentHeartbeat := time.Now().Unix()
+		if err := ioutil.WriteFile(h.file, []byte(fmt.Sprintf("%d", currentHeartbeat)), os.ModePerm); err != nil {
+			klog.Fatalf("Unable to write timestamp file %q: %v", h.file, err)
+		}
+	}, h.interval)
+	return nil
+}


### PR DESCRIPTION
Background: Under some circumstances, when kubelet is not able to run operator pods, but it is able to run static pods, the `oc get clusteroperators` will lie about the current cluster state. It reports the "last known" state for cluster operators, but no operators are actually running to reconcile the status.
For example, this happens today on SNO when you shut down the cluster for some extended period of time and the CSR kubelet use expires and new CSR's require manual approval.
To mitigate, we need a process that will reset the cluster operator status to "unknown". The process needs to have a working connection to the API server, so a side-car to kube-apiserver is a natural choice.

The process here will:

* Store timestamp to file on disk every 60 seconds
* When the process comes up (after shutdown, restart, redeploy, etc..) and the difference between the current timestamp and last heartbeat timestamp is more than 60 minutes it triggers a callback function (once).
* The callback function will reset all cluster operators conditions to "Unknown" unless they made progress in the last 30 minutes (once).
* When operators come back, they should reconcile and update the conditions