### PR TITLE
bindata: enable podsecurity plugin

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -9,6 +9,17 @@ admission:
         externalIPNetworkCIDRs: null
         kind: ExternalIPRangerAdmissionConfig
       location: ""
+    PodSecurity:
+      configuration:
+        kind: PodSecurityConfiguration
+        apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+        defaults:
+          enforce: "privileged"
+          enforce-version: "latest"
+          audit: "baseline"
+          audit-version: "latest"
+          warn: "baseline"
+          warn-version: "latest"
 apiServerArguments:
   allow-privileged:
     - "true"
@@ -47,6 +58,7 @@ apiServerArguments:
     - PersistentVolumeLabel
     - PodNodeSelector
     - PodTolerationRestriction
+    - PodSecurity
     - Priority
     - ResourceQuota
     - RuntimeClass


### PR DESCRIPTION
This is an attempt to enable the PodSecurity plugin to enable https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement

This can be merged once 4.10 master opens, the earliest.

/hold