### PR TITLE
bug 1998031: Deploy PDB to prevent more than one replica going unavailable

### DIFF
--- a/bindata/assets/kube-apiserver/pdb.yaml
+++ b/bindata/assets/kube-apiserver/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-apiserver-pdb
+  namespace: openshift-kube-apiserver
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: openshift-kube-apiserver
+      apiserver: "true"

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -148,6 +148,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"assets/kube-apiserver/apiserver.openshift.io_apirequestcount.yaml",
 			"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
 			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
+			"assets/kube-apiserver/pdb.yaml",
 			"assets/alerts/api-usage.yaml",
 			"assets/alerts/audit-errors.yaml",
 			"assets/alerts/cpu-utilization.yaml",


### PR DESCRIPTION
In case master nodes are drained to quickly in a row there's no
waiting until instances go back to available. So it's possible
for two or more replicas to go unavailable which may lead
to all instances going unavailable.

Based on https://github.com/openshift/library-go/pull/1056/commits/8efd1883d406cc389eb25e2a257c4451dfbd668c