### PR TITLE
Bug 1985447: Add namespace label to remaining apiserver alerts

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -18,6 +18,7 @@ spec:
             group(apiserver_requested_deprecated_apis{removed_release="1.23"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
+            namespace: openshift-kube-apiserver
             severity: info
         - alert: APIRemovedInNextEUSReleaseInUse
           annotations:
@@ -31,4 +32,5 @@ spec:
 
           for: 1h
           labels:
+            namespace: openshift-kube-apiserver
             severity: info

--- a/bindata/assets/alerts/audit-errors.yaml
+++ b/bindata/assets/alerts/audit-errors.yaml
@@ -18,4 +18,5 @@ spec:
         sum by (apiserver,instance)(rate(apiserver_audit_error_total{apiserver=~".+-apiserver"}[5m])) / sum by (apiserver,instance) (rate(apiserver_audit_event_total{apiserver=~".+-apiserver"}[5m])) > 0
       for: 1m
       labels:
+        namespace: openshift-kube-apiserver
         severity: warning

--- a/bindata/assets/alerts/cpu-utilization.yaml
+++ b/bindata/assets/alerts/cpu-utilization.yaml
@@ -28,6 +28,7 @@ spec:
             > 60
           for: 10m
           labels:
+            namespace: openshift-kube-apiserver
             severity: warning
         - alert: ExtremelyHighIndividualControlPlaneCPU
           annotations:
@@ -45,4 +46,5 @@ spec:
             100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
           for: 5m
           labels:
+            namespace: openshift-kube-apiserver
             severity: critical


### PR DESCRIPTION
QE caught some additional alerts that didn't have the namespace set. This sets those namespaces.