### PR TITLE
[testing-only] Set max-requests[-mutating]-inflight to 50.

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -127,10 +127,10 @@ apiServerArguments:
     - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-    - "1000"
+    - "17"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
-    - "3000"
+    - "33"
   min-request-timeout:
     - "3600"
   proxy-client-cert-file:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -127,10 +127,10 @@ apiServerArguments:
     - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-    - "17"
+    - "34"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
-    - "33"
+    - "66"
   min-request-timeout:
     - "3600"
   proxy-client-cert-file:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -127,10 +127,10 @@ apiServerArguments:
     - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-    - "17"
+    - "67"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
-    - "33"
+    - "133"
   min-request-timeout:
     - "3600"
   proxy-client-cert-file:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -127,10 +127,10 @@ apiServerArguments:
     - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-    - "34"
+    - "17"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
-    - "66"
+    - "33"
   min-request-timeout:
     - "3600"
   proxy-client-cert-file:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -127,10 +127,10 @@ apiServerArguments:
     - "0"
   # value should logically scale with max-requests-inflight
   max-mutating-requests-inflight:
-    - "67"
+    - "17"
   # value needed to be bumped for scale tests.  The kube-apiserver did ok here
   max-requests-inflight:
-    - "133"
+    - "33"
   min-request-timeout:
     - "3600"
   proxy-client-cert-file:

--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -84,7 +84,7 @@ spec:
             cp -f /etc/kubernetes/static-pod-certs/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
 
-          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration={{.GracefulTerminationDuration}}s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} {{.Verbosity}} --permit-address-sharing --runtime-config="admissionregistration.k8s.io/v1beta1=false,apiextensions.k8s.io/v1beta1=false"
+          exec watch-termination --termination-touch-file=/var/log/kube-apiserver/.terminating --termination-log-file=/var/log/kube-apiserver/termination.log --graceful-termination-duration={{.GracefulTerminationDuration}}s --kubeconfig=/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig -- hyperkube kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-address=${HOST_IP} -v=3 --permit-address-sharing --runtime-config="admissionregistration.k8s.io/v1beta1=false,apiextensions.k8s.io/v1beta1=false"
     resources:
       requests:
         memory: 1Gi

--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,4 +1,35 @@
 apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
+kind: FlowSchema
+metadata:
+  name: exempt-watches
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  matchingPrecedence: 2
+  priorityLevelConfiguration:
+    # Exempt all watches from APF (effectively the same as pre-4.9 behavior).
+    # https://github.com/kubernetes/kubernetes/issues/105409
+    name: exempt
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - 'watch'
+    subjects:
+    - group: 'system:authenticated'
+      kind: Group
+    - group: 'system:unauthenticated'
+      kind: Group
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta1
 kind: PriorityLevelConfiguration
 metadata:
   name: openshift-control-plane-operators


### PR DESCRIPTION
Gathering some quick metrics from presubmit jobs under a
significantly-reduced request concurrency limit.

/hold