### PR TITLE
Bug 2014614: Exempt metrics scrapes from APF.

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -30,7 +30,7 @@ spec:
     type: ByUser
   matchingPrecedence: 2000
   priorityLevelConfiguration:
-    name: workload-high
+    name: exempt
   rules:
   - nonResourceRules:
     - verbs:


### PR DESCRIPTION
Currently, metrics scraping requests can be rejected when all
workload-high seats are occupied, which results in missed samples.