### PR TITLE
alerts/cpu-utilization: exclude iowait from CPU Utilisation

### DIFF
--- a/bindata/assets/alerts/cpu-utilization.yaml
+++ b/bindata/assets/alerts/cpu-utilization.yaml
@@ -20,7 +20,7 @@ spec:
               To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
             sum(
-              100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100)
+              100 - (avg by (instance) (sum without (mode) (rate(node_cpu_seconds_total{mode=~"idle|iowait"}[1m]))) * 100)
               AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
             )
             /
@@ -43,7 +43,7 @@ spec:
               kube-apiservers are also under-provisioned.
               To fix this, increase the CPU and memory on your control plane nodes.
           expr: |
-            100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[1m])) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
+            100 - (avg by (instance) (sum without (mode) (rate(node_cpu_seconds_total{mode=~"idle|iowait"}[1m]))) * 100) > 90 AND on (instance) label_replace( kube_node_role{role="master"}, "instance", "$1", "node", "(.+)" )
           for: 5m
           labels:
             namespace: openshift-kube-apiserver


### PR DESCRIPTION
'iowait' indicates a specific idle state, which shouldn't be
counted into CPU Utilisation. Also see
https://github.com/prometheus-operator/kube-prometheus/pull/796 and
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/667.

Per the iostat man page:

%idle
Show the percentage of time that the CPU or CPUs were idle and the
system did not have an outstanding disk I/O request.

%iowait
Show the percentage of time that the CPU or CPUs were idle during
which the system had an outstanding disk I/O request.


Note that what these alerts actually warn about is insufficient
_remaining_ CPU capacity. So in contrast to some of the other related
changes, we should not exclude the 'steal' time here. On the contrary,
for a system that experiences substantial CPU stealing we currently
_overestimate_ the remaining capacity (as some of it will most likely be
stolen as well).

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>