### PR TITLE
Bug 1982726: encryption-controller: sync secrets conditionally

### DIFF
--- a/cmd/cluster-kube-apiserver-operator/main.go
+++ b/cmd/cluster-kube-apiserver-operator/main.go
@@ -66,7 +66,7 @@ func NewOperatorCommand(ctx context.Context) *cobra.Command {
 
 	cmd.AddCommand(operatorcmd.NewOperator())
 	cmd.AddCommand(render.NewRenderCommand())
-	cmd.AddCommand(installerpod.NewInstaller())
+	cmd.AddCommand(installerpod.NewInstaller(ctx))
 	cmd.AddCommand(prune.NewPrune())
 	cmd.AddCommand(resourcegraph.NewResourceChainCommand())
 	cmd.AddCommand(certsyncpod.NewCertSyncControllerCommand(operator.CertConfigMaps, operator.CertSecrets))

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20211108165917-be1be0e89115
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83
-	github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6
+	github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83 h1:TGBy40xVBCqDqvu8gaakva4u+08JtOt/LfekiwbCMyc=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83/go.mod h1:iSeqKIqUKxVec3gV1kNvwS1tjDpzpdP134RimkLc3BE=
-github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6 h1:dAwIJESWIaTAJoWUIAZbMgJIGvMIbBeuKSa/256Tl58=
-github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
+github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e h1:1DAAE0G8ixeUDJ8hBTImY++RkLNgQuUYK4FlORScTlU=
+github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -97,7 +97,7 @@ func (o *Options) Run(ctx context.Context) error {
 		return err
 	}
 
-	certRotationScale, err := certrotation.GetCertRotationScale(kubeClient, operatorclient.GlobalUserSpecifiedConfigNamespace)
+	certRotationScale, err := certrotation.GetCertRotationScale(ctx, kubeClient, operatorclient.GlobalUserSpecifiedConfigNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -251,7 +251,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	certRotationScale, err := certrotation.GetCertRotationScale(kubeClient, operatorclient.GlobalUserSpecifiedConfigNamespace)
+	certRotationScale, err := certrotation.GetCertRotationScale(ctx, kubeClient, operatorclient.GlobalUserSpecifiedConfigNamespace)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	}
 
 	staticPodNodeProvider := encryptiondeployer.StaticPodNodeProvider{OperatorClient: operatorClient}
-	deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", operatorclient.TargetNamespace, kubeInformersForNamespaces, resourceSyncController, kubeClient.CoreV1(), kubeClient.CoreV1(), staticPodNodeProvider)
+	deployer, err := encryptiondeployer.NewRevisionLabelPodDeployer("revision", operatorclient.TargetNamespace, kubeInformersForNamespaces, kubeClient.CoreV1(), kubeClient.CoreV1(), staticPodNodeProvider)
 	if err != nil {
 		return err
 	}
@@ -292,6 +292,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 		kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
+		resourceSyncController,
 	)
 	if err != nil {
 		return err

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -215,7 +215,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	controllerRef := b.componentOwnerReference
 
 	if controllerRef == nil {
-		controllerRef, err = events.GetControllerReferenceForCurrentPod(kubeClient, namespace, nil)
+		controllerRef, err = events.GetControllerReferenceForCurrentPod(ctx, kubeClient, namespace, nil)
 		if err != nil {
 			klog.Warningf("unable to get owner reference (falling back to namespace): %v", err)
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -77,7 +77,7 @@ func NewCertRotationController(
 }
 
 func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	syncErr := c.syncWorker()
+	syncErr := c.syncWorker(ctx)
 
 	// running this function with RunOnceContextKey value context will make this "run-once" without updating status.
 	isRunOnce, ok := ctx.Value(RunOnceContextKey).(bool)
@@ -105,18 +105,18 @@ func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncCo
 	return syncErr
 }
 
-func (c CertRotationController) syncWorker() error {
-	signingCertKeyPair, err := c.rotatedSigningCASecret.ensureSigningCertKeyPair(context.TODO())
+func (c CertRotationController) syncWorker(ctx context.Context) error {
+	signingCertKeyPair, err := c.rotatedSigningCASecret.ensureSigningCertKeyPair(ctx)
 	if err != nil {
 		return err
 	}
 
-	cabundleCerts, err := c.CABundleConfigMap.ensureConfigMapCABundle(context.TODO(), signingCertKeyPair)
+	cabundleCerts, err := c.CABundleConfigMap.ensureConfigMapCABundle(ctx, signingCertKeyPair)
 	if err != nil {
 		return err
 	}
 
-	if err := c.RotatedSelfSignedCertKeySecret.ensureTargetCertKeyPair(context.TODO(), signingCertKeyPair, cabundleCerts); err != nil {
+	if err := c.RotatedSelfSignedCertKeySecret.ensureTargetCertKeyPair(ctx, signingCertKeyPair, cabundleCerts); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
@@ -13,10 +13,10 @@ import (
 
 // GetCertRotationScale  The normal scale is based on a day.  The value returned by this function
 // is used to scale rotation durations instead of a day, so you can set it shorter.
-func GetCertRotationScale(client kubernetes.Interface, namespace string) (time.Duration, error) {
+func GetCertRotationScale(ctx context.Context, client kubernetes.Interface, namespace string) (time.Duration, error) {
 	certRotationScale := time.Duration(0)
 	err := wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
-		certRotationConfig, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "unsupported-cert-rotation-config", metav1.GetOptions{})
+		certRotationConfig, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, "unsupported-cert-rotation-config", metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go
@@ -207,7 +207,7 @@ func ensureConnectivityCheckCRDExists(ctx context.Context, syncContext factory.S
 	if errors.IsNotFound(err) {
 		// create the podnetworkconnectivitycheck crd that should exist
 		applyResults := resourceapply.ApplyDirectly(
-			context.TODO(),
+			ctx,
 			resourceapply.NewClientHolder().WithAPIExtensionsClient(client),
 			syncContext.Recorder(),
 			func(name string) ([]byte, error) { return bindata.Asset(name) },

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
@@ -82,7 +82,7 @@ func (c *conditionController) sync(ctx context.Context, _ factory.SyncContext) (
 	}
 
 	encryptedGRs := c.provider.EncryptedGRs()
-	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil || len(transitioningReason) > 0 {
 		// do not update the encryption condition (cond). Note: progressing is set elsewhere.
 		cond = nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -146,7 +146,7 @@ func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncCont
 // TODO doc
 func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) (migratingResources []schema.GroupResource, err error) {
 	// no storage migration during revision changes
-	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 		return nil, nil
 	}
 
-	encryptionSecrets, err := secrets.ListKeySecrets(c.secretClient, c.encryptionSecretSelector)
+	encryptionSecrets, err := secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 			continue
 		}
 		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			s, err := c.secretClient.Secrets(oldWriteKey.Namespace).Get(context.TODO(), oldWriteKey.Name, metav1.GetOptions{})
+			s, err := c.secretClient.Secrets(oldWriteKey.Namespace).Get(ctx, oldWriteKey.Name, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to get key secret %s/%s: %v", oldWriteKey.Namespace, oldWriteKey.Name, err)
 			}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators/inprocess.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators/inprocess.go
@@ -147,7 +147,7 @@ func (m *InProcessMigrator) runMigration(gvr schema.GroupVersionResource, writeK
 			}
 		}
 	})
-	result = listProcessor.run(gvr)
+	result = listProcessor.run(ctx, gvr)
 }
 
 func (m *InProcessMigrator) PruneMigration(gr schema.GroupResource) error {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators/inprocess_processor.go
@@ -47,10 +47,10 @@ func newListProcessor(ctx context.Context, dynamicClient dynamic.Interface, work
 
 // run starts processing all the instance of the given GVR in batches.
 // Note that this operation block until all resources have been process, we can't get the next page or the context has been cancelled
-func (p *listProcessor) run(gvr schema.GroupVersionResource) error {
+func (p *listProcessor) run(ctx context.Context, gvr schema.GroupVersionResource) error {
 	listPager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 		for {
-			allResource, err := p.dynamicClient.Resource(gvr).List(context.TODO(), opts)
+			allResource, err := p.dynamicClient.Resource(gvr).List(ctx, opts)
 			if err != nil {
 				klog.Warningf("List of %v failed: %v", gvr, err)
 				if errors.IsResourceExpired(err) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
@@ -115,7 +115,7 @@ type eventWithReason struct {
 }
 
 func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/deployer/revisionedpod.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/deployer/revisionedpod.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptionconfig"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -53,30 +52,17 @@ var (
 // a label storing the deployed encryption config revision, like the pods created
 // by the staticpod controllers.
 //
-// It syns the encryption-config-<targetNamespace> from openshift-config-managed
-// namespace to the target namespace as encryption-config. From there it is
-// revisioned and deployed to the static pods. The last deployed encryption
-// config is read from encryption-config-<revision>.
-//
-// For testing, resourceSyncer might be nil.
+// It revisiones and deployes the synchronized encryption-config from the
+// operator namespace to the static pods. The last deployed encryption config is
+// read from encryption-config-<revision>.
 func NewRevisionLabelPodDeployer(
 	revisionLabel string,
 	targetNamespace string,
 	namespaceInformers operatorv1helpers.KubeInformersForNamespaces,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 	podClient corev1client.PodsGetter,
 	secretClient corev1client.SecretsGetter,
 	nodeProvider MasterNodeProvider,
 ) (*RevisionLabelPodDeployer, error) {
-	if resourceSyncer != nil {
-		if err := resourceSyncer.SyncSecret(
-			resourcesynccontroller.ResourceLocation{Namespace: targetNamespace, Name: encryptionconfig.EncryptionConfSecretName},
-			resourcesynccontroller.ResourceLocation{Namespace: "openshift-config-managed", Name: fmt.Sprintf("%s-%s", encryptionconfig.EncryptionConfSecretName, targetNamespace)},
-		); err != nil {
-			return nil, err
-		}
-	}
-
 	return &RevisionLabelPodDeployer{
 		podClient:                podClient.Pods(targetNamespace),
 		secretClient:             secretClient.Secrets(targetNamespace),
@@ -88,7 +74,7 @@ func NewRevisionLabelPodDeployer(
 
 // DeployedEncryptionConfigSecret returns the deployed encryption config and whether all
 // instances of the operand have acknowledged it.
-func (d *RevisionLabelPodDeployer) DeployedEncryptionConfigSecret() (secret *corev1.Secret, converged bool, err error) {
+func (d *RevisionLabelPodDeployer) DeployedEncryptionConfigSecret(ctx context.Context) (secret *corev1.Secret, converged bool, err error) {
 	nodes, err := d.nodeProvider.MasterNodeNames()
 	if err != nil {
 		return nil, false, err
@@ -98,7 +84,7 @@ func (d *RevisionLabelPodDeployer) DeployedEncryptionConfigSecret() (secret *cor
 	}
 
 	// do a live list so we never get confused about what revision we are on
-	apiServerPods, err := d.podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "apiserver=true"})
+	apiServerPods, err := d.podClient.List(ctx, metav1.ListOptions{LabelSelector: "apiserver=true"})
 	if err != nil {
 		return nil, false, err
 	}
@@ -111,7 +97,7 @@ func (d *RevisionLabelPodDeployer) DeployedEncryptionConfigSecret() (secret *cor
 		return nil, false, nil
 	}
 
-	s, err := d.secretClient.Get(context.TODO(), encryptionconfig.EncryptionConfSecretName+"-"+revision, metav1.GetOptions{})
+	s, err := d.secretClient.Get(ctx, encryptionconfig.EncryptionConfSecretName+"-"+revision, metav1.GetOptions{})
 	if err != nil {
 		// if encryption is not enabled at this revision or the secret was deleted, we should not error
 		if errors.IsNotFound(err) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/deployer/unionrevisionedpod.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/deployer/unionrevisionedpod.go
@@ -1,6 +1,7 @@
 package deployer
 
 import (
+	"context"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,11 +29,11 @@ func NewUnionRevisionLabelPodDeployer(delegates ...statemachine.Deployer) *Union
 }
 
 // DeployedEncryptionConfigSecret returns the actual encryption configuration across multiple deployers
-func (d *UnionRevisionLabelPodDeployer) DeployedEncryptionConfigSecret() (secret *corev1.Secret, converged bool, err error) {
+func (d *UnionRevisionLabelPodDeployer) DeployedEncryptionConfigSecret(ctx context.Context) (secret *corev1.Secret, converged bool, err error) {
 	seenSecrets := []*corev1.Secret{}
 
 	for _, delegate := range d.delegates {
-		secret, converged, err := delegate.DeployedEncryptionConfigSecret()
+		secret, converged, err := delegate.DeployedEncryptionConfigSecret(ctx)
 		if !converged || err != nil {
 			return nil, converged, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
@@ -127,8 +127,8 @@ func (m *MigratedGroupResources) HasResource(resource schema.GroupResource) bool
 }
 
 // ListKeySecrets returns the current key secrets from openshift-config-managed.
-func ListKeySecrets(secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
-	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(context.TODO(), encryptionSecretSelector)
+func ListKeySecrets(ctx context.Context, secretClient corev1client.SecretsGetter, encryptionSecretSelector metav1.ListOptions) ([]*corev1.Secret, error) {
+	encryptionSecretList, err := secretClient.Secrets("openshift-config-managed").List(ctx, encryptionSecretSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
@@ -30,6 +30,9 @@ type Recorder interface {
 	// WithComponentSuffix is similar to ForComponent except it just suffix the current component name instead of overriding.
 	WithComponentSuffix(componentNameSuffix string) Recorder
 
+	// WithContext allows to set a context for event create API calls.
+	WithContext(ctx context.Context) Recorder
+
 	// ComponentName returns the current source component name for the event.
 	// This allows to suffix the original component name with 'sub-component'.
 	ComponentName() string
@@ -50,42 +53,42 @@ var podNameEnvFunc = func() string {
 // The pod name must be provided via the POD_NAME name.
 // Even if this method returns an error, it always return valid reference to the namespace. It allows the callers to control the logging
 // and decide to fail or accept the namespace.
-func GetControllerReferenceForCurrentPod(client kubernetes.Interface, targetNamespace string, reference *corev1.ObjectReference) (*corev1.ObjectReference, error) {
+func GetControllerReferenceForCurrentPod(ctx context.Context, client kubernetes.Interface, targetNamespace string, reference *corev1.ObjectReference) (*corev1.ObjectReference, error) {
 	if reference == nil {
 		// Try to get the pod name via POD_NAME environment variable
 		reference := &corev1.ObjectReference{Kind: "Pod", Name: podNameEnvFunc(), Namespace: targetNamespace}
 		if len(reference.Name) != 0 {
-			return GetControllerReferenceForCurrentPod(client, targetNamespace, reference)
+			return GetControllerReferenceForCurrentPod(ctx, client, targetNamespace, reference)
 		}
 		// If that fails, lets try to guess the pod by listing all pods in namespaces and using the first pod in the list
-		reference, err := guessControllerReferenceForNamespace(client.CoreV1().Pods(targetNamespace))
+		reference, err := guessControllerReferenceForNamespace(ctx, client.CoreV1().Pods(targetNamespace))
 		if err != nil {
 			// If this fails, do not give up with error but instead use the namespace as controller reference for the pod
 			// NOTE: This is last resort, if we see this often it might indicate something is wrong in the cluster.
 			//       In some cases this might help with flakes.
 			return getControllerReferenceForNamespace(targetNamespace), err
 		}
-		return GetControllerReferenceForCurrentPod(client, targetNamespace, reference)
+		return GetControllerReferenceForCurrentPod(ctx, client, targetNamespace, reference)
 	}
 
 	switch reference.Kind {
 	case "Pod":
-		pod, err := client.CoreV1().Pods(reference.Namespace).Get(context.TODO(), reference.Name, metav1.GetOptions{})
+		pod, err := client.CoreV1().Pods(reference.Namespace).Get(ctx, reference.Name, metav1.GetOptions{})
 		if err != nil {
 			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if podController := metav1.GetControllerOf(pod); podController != nil {
-			return GetControllerReferenceForCurrentPod(client, targetNamespace, makeObjectReference(podController, targetNamespace))
+			return GetControllerReferenceForCurrentPod(ctx, client, targetNamespace, makeObjectReference(podController, targetNamespace))
 		}
 		// This is a bare pod without any ownerReference
 		return makeObjectReference(&metav1.OwnerReference{Kind: "Pod", Name: pod.Name, UID: pod.UID, APIVersion: "v1"}, pod.Namespace), nil
 	case "ReplicaSet":
-		rs, err := client.AppsV1().ReplicaSets(reference.Namespace).Get(context.TODO(), reference.Name, metav1.GetOptions{})
+		rs, err := client.AppsV1().ReplicaSets(reference.Namespace).Get(ctx, reference.Name, metav1.GetOptions{})
 		if err != nil {
 			return getControllerReferenceForNamespace(reference.Namespace), err
 		}
 		if rsController := metav1.GetControllerOf(rs); rsController != nil {
-			return GetControllerReferenceForCurrentPod(client, targetNamespace, makeObjectReference(rsController, targetNamespace))
+			return GetControllerReferenceForCurrentPod(ctx, client, targetNamespace, makeObjectReference(rsController, targetNamespace))
 		}
 		// This is a replicaSet without any ownerReference
 		return reference, nil
@@ -116,8 +119,8 @@ func makeObjectReference(owner *metav1.OwnerReference, targetNamespace string) *
 }
 
 // guessControllerReferenceForNamespace tries to guess what resource to reference.
-func guessControllerReferenceForNamespace(client corev1client.PodInterface) (*corev1.ObjectReference, error) {
-	pods, err := client.List(context.TODO(), metav1.ListOptions{})
+func guessControllerReferenceForNamespace(ctx context.Context, client corev1client.PodInterface) (*corev1.ObjectReference, error) {
+	pods, err := client.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +158,9 @@ type recorder struct {
 	eventClient       corev1client.EventInterface
 	involvedObjectRef *corev1.ObjectReference
 	sourceComponent   string
+
+	// TODO: This is not the right way to pass the context, but there is no other way without breaking event interface
+	ctx context.Context
 }
 
 func (r *recorder) ComponentName() string {
@@ -167,6 +173,11 @@ func (r *recorder) ForComponent(componentName string) Recorder {
 	newRecorderForComponent := *r
 	newRecorderForComponent.sourceComponent = componentName
 	return &newRecorderForComponent
+}
+
+func (r *recorder) WithContext(ctx context.Context) Recorder {
+	r.ctx = ctx
+	return r
 }
 
 func (r *recorder) WithComponentSuffix(suffix string) Recorder {
@@ -186,7 +197,11 @@ func (r *recorder) Warningf(reason, messageFmt string, args ...interface{}) {
 // Event emits the normal type event.
 func (r *recorder) Event(reason, message string) {
 	event := makeEvent(r.involvedObjectRef, r.sourceComponent, corev1.EventTypeNormal, reason, message)
-	if _, err := r.eventClient.Create(context.TODO(), event, metav1.CreateOptions{}); err != nil {
+	ctx := context.Background()
+	if r.ctx != nil {
+		ctx = r.ctx
+	}
+	if _, err := r.eventClient.Create(ctx, event, metav1.CreateOptions{}); err != nil {
 		klog.Warningf("Error creating event %+v: %v", event, err)
 	}
 }
@@ -194,7 +209,11 @@ func (r *recorder) Event(reason, message string) {
 // Warning emits the warning type event.
 func (r *recorder) Warning(reason, message string) {
 	event := makeEvent(r.involvedObjectRef, r.sourceComponent, corev1.EventTypeWarning, reason, message)
-	if _, err := r.eventClient.Create(context.TODO(), event, metav1.CreateOptions{}); err != nil {
+	ctx := context.Background()
+	if r.ctx != nil {
+		ctx = r.ctx
+	}
+	if _, err := r.eventClient.Create(ctx, event, metav1.CreateOptions{}); err != nil {
 		klog.Warningf("Error creating event %+v: %v", event, err)
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -11,6 +12,7 @@ import (
 type inMemoryEventRecorder struct {
 	events []*corev1.Event
 	source string
+	ctx    context.Context
 	sync.Mutex
 }
 
@@ -43,6 +45,11 @@ func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
 	r.Lock()
 	defer r.Unlock()
 	r.source = component
+	return r
+}
+
+func (r *inMemoryEventRecorder) WithContext(ctx context.Context) Recorder {
+	r.ctx = ctx
 	return r
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -9,6 +10,12 @@ import (
 
 type LoggingEventRecorder struct {
 	component string
+	ctx       context.Context
+}
+
+func (r *LoggingEventRecorder) WithContext(ctx context.Context) Recorder {
+	r.ctx = ctx
+	return r
 }
 
 // NewLoggingEventRecorder provides event recorder that will log all recorded events via klog.

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -33,6 +34,7 @@ func NewKubeRecorder(client corev1client.EventInterface, sourceComponentName str
 // upstreamRecorder is an implementation of Recorder interface.
 type upstreamRecorder struct {
 	client            corev1client.EventInterface
+	clientCtx         context.Context
 	component         string
 	broadcaster       record.EventBroadcaster
 	eventRecorder     record.EventRecorder
@@ -46,6 +48,11 @@ type upstreamRecorder struct {
 	// fallbackRecorder is used when the kube recorder is shutting down
 	// in that case we create the events directly.
 	fallbackRecorder Recorder
+}
+
+func (r *upstreamRecorder) WithContext(ctx context.Context) Recorder {
+	r.clientCtx = ctx
+	return r
 }
 
 // RecommendedClusterSingletonCorrelatorOptions provides recommended event correlator options for components that produce

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -12,9 +12,16 @@ type ResourceLocation struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// PreconditionsFulfilled is a function that indicates whether all prerequisites
+// are met and a resource can be synced.
+type preconditionsFulfilled func() (bool, error)
+
+func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
+
 type syncRuleSource struct {
 	ResourceLocation
-	syncedKeys sets.String // defines the set of keys to sync from source to dest
+	syncedKeys               sets.String            // defines the set of keys to sync from source to dest
+	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
 }
 
 type syncRules map[ResourceLocation]syncRuleSource

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -100,10 +100,20 @@ func (c *ResourceSyncController) Name() string {
 }
 
 func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
-	return c.SyncPartialConfigMap(destination, source)
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions)
 }
 
 func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocation, source ResourceLocation, keys ...string) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncConfigMapConditionally adds a new configmap that the resource sync
+// controller will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncConfigMapConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncConfigMap(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
 	if !c.knownNamespaces.Has(destination.Namespace) {
 		return fmt.Errorf("not watching namespace %q", destination.Namespace)
 	}
@@ -114,8 +124,9 @@ func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocati
 	c.syncRuleLock.Lock()
 	defer c.syncRuleLock.Unlock()
 	c.configMapSyncRules[destination] = syncRuleSource{
-		ResourceLocation: source,
-		syncedKeys:       sets.NewString(keys...),
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 
 	// make sure the new rule is picked up
@@ -124,10 +135,20 @@ func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocati
 }
 
 func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
-	return c.SyncPartialSecret(destination, source)
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions)
 }
 
 func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceLocation, keys ...string) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncSecretConditionally adds a new secret that the resource sync controller
+// will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncSecretConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncSecret(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
 	if !c.knownNamespaces.Has(destination.Namespace) {
 		return fmt.Errorf("not watching namespace %q", destination.Namespace)
 	}
@@ -138,8 +159,9 @@ func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceL
 	c.syncRuleLock.Lock()
 	defer c.syncRuleLock.Unlock()
 	c.secretSyncRules[destination] = syncRuleSource{
-		ResourceLocation: source,
-		syncedKeys:       sets.NewString(keys...),
+		ResourceLocation:         source,
+		syncedKeys:               sets.NewString(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
 	}
 
 	// make sure the new rule is picked up
@@ -171,6 +193,14 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 	errors := []error{}
 
 	for destination, source := range c.configMapSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
 		if source.ResourceLocation == emptyResourceLocation {
 			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
 			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
@@ -191,6 +221,14 @@ func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncC
 		}
 	}
 	for destination, source := range c.secretSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
 		if source.ResourceLocation == emptyResourceLocation {
 			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
 			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/prune/prune_controller.go
@@ -34,7 +34,7 @@ type PruneController struct {
 	// prunerPodImageFn returns the image name for the pruning pod
 	prunerPodImageFn func() string
 	// retrieveStatusConfigMapOwnerRefsFn gets the revision status ConfigMap and returns an owner ref, or empty slice on error.
-	retrieveStatusConfigMapOwnerRefsFn func(revision int32) ([]metav1.OwnerReference, error)
+	retrieveStatusConfigMapOwnerRefsFn func(ctx context.Context, revision int32) ([]metav1.OwnerReference, error)
 
 	operatorClient v1helpers.StaticPodOperatorClient
 
@@ -206,7 +206,7 @@ func (c *PruneController) ensurePrunePod(ctx context.Context, recorder events.Re
 		fmt.Sprintf("--static-pod-name=%s", c.podResourcePrefix),
 	)
 
-	ownerRefs, err := c.retrieveStatusConfigMapOwnerRefsFn(revision)
+	ownerRefs, err := c.retrieveStatusConfigMapOwnerRefsFn(ctx, revision)
 	if err != nil {
 		return fmt.Errorf("unable to set pruner pod ownerrefs: %+v", err)
 	}
@@ -216,8 +216,8 @@ func (c *PruneController) ensurePrunePod(ctx context.Context, recorder events.Re
 	return err
 }
 
-func (c *PruneController) createStatusConfigMapOwnerRefs(revision int32) ([]metav1.OwnerReference, error) {
-	statusConfigMap, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(context.TODO(), fmt.Sprintf("revision-status-%d", revision), metav1.GetOptions{})
+func (c *PruneController) createStatusConfigMapOwnerRefs(ctx context.Context, revision int32) ([]metav1.OwnerReference, error) {
+	statusConfigMap, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(ctx, fmt.Sprintf("revision-status-%d", revision), metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -53,8 +53,7 @@ func init() {
 
 type StaticResourceController struct {
 	name                   string
-	manifests              resourceapply.AssetFunc
-	files                  []string
+	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
 
 	operatorClient v1helpers.OperatorClient
@@ -65,6 +64,19 @@ type StaticResourceController struct {
 	factory          *factory.Factory
 	restMapper       meta.RESTMapper
 	categoryExpander restmapper.CategoryExpander
+}
+
+type conditionalManifests struct {
+	// shouldCreateFn controls whether the manifests should be created and updated.
+	// If it returns true, the manifests should be applied.
+	shouldCreateFn resourceapply.ConditionalFunction
+	// shouldDeleteFn controls whether the manifests should be deleted.
+	// If it returns true, the manifests should be removed.
+	shouldDeleteFn resourceapply.ConditionalFunction
+
+	manifests resourceapply.AssetFunc
+
+	files []string
 }
 
 // NewStaticResourceController returns a controller that maintains certain static manifests. Most "normal" types are supported,
@@ -81,9 +93,7 @@ func NewStaticResourceController(
 	eventRecorder events.Recorder,
 ) *StaticResourceController {
 	c := &StaticResourceController{
-		name:      name,
-		manifests: manifests,
-		files:     files,
+		name: name,
 
 		operatorClient: operatorClient,
 		clients:        clients,
@@ -92,6 +102,7 @@ func NewStaticResourceController(
 
 		factory: factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
 	}
+	c.WithConditionalResources(manifests, files, nil, nil)
 
 	return c
 }
@@ -106,76 +117,114 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 	return c
 }
 
+// WithConditionalResources adds a set of manifests to be created when the shouldCreateFnArg is true and should be
+// deleted when the shouldDeleteFnArg is true.
+// If shouldCreateFnArg is nil, then it is always create.
+// If shouldDeleteFnArg is nil, then it is !shouldCreateFnArg
+//  1. shouldCreateFnArg == true && shouldDeleteFnArg == true - produces an error
+//  2. shouldCreateFnArg == false && shouldDeleteFnArg == false - does nothing as expected
+//  3. shouldCreateFnArg == true applies the manifests
+//  4. shouldDeleteFnArg == true deletes the manifests
+func (c *StaticResourceController) WithConditionalResources(manifests resourceapply.AssetFunc, files []string, shouldCreateFnArg, shouldDeleteFnArg resourceapply.ConditionalFunction) *StaticResourceController {
+	var shouldCreateFn resourceapply.ConditionalFunction
+	if shouldCreateFnArg == nil {
+		shouldCreateFn = func() bool {
+			return true
+		}
+	} else {
+		shouldCreateFn = shouldCreateFnArg
+	}
+
+	var shouldDeleteFn resourceapply.ConditionalFunction
+	if shouldDeleteFnArg == nil {
+		shouldDeleteFn = func() bool {
+			return !shouldCreateFn()
+		}
+	} else {
+		shouldDeleteFn = shouldDeleteFnArg
+	}
+
+	c.manifests = append(c.manifests, conditionalManifests{
+		shouldCreateFn: shouldCreateFn,
+		shouldDeleteFn: shouldDeleteFn,
+		manifests:      manifests,
+		files:          files,
+	})
+	return c
+}
+
 func (c *StaticResourceController) AddKubeInformers(kubeInformersByNamespace v1helpers.KubeInformersForNamespaces) *StaticResourceController {
 	// set the informers so we can have caching clients
 	c.clients = c.clients.WithKubernetesInformers(kubeInformersByNamespace)
 
 	ret := c
-	for _, file := range c.files {
-		objBytes, err := c.manifests(file)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("missing %q: %v", file, err))
-			continue
-		}
-		requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("cannot decode %q: %v", file, err))
-			continue
-		}
-		metadata, err := meta.Accessor(requiredObj)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("cannot get metadata %q: %v", file, err))
-			continue
-		}
-
-		// find the right subset of informers.  Interestingly, cluster scoped resources require cluster scoped informers
-		var informer informers.SharedInformerFactory
-		if _, ok := requiredObj.(*corev1.Namespace); ok {
-			informer = kubeInformersByNamespace.InformersFor(metadata.GetName())
-			if informer == nil {
-				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetName()))
+	for _, conditionalManifest := range c.manifests {
+		for _, file := range conditionalManifest.files {
+			objBytes, err := conditionalManifest.manifests(file)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("missing %q: %v", file, err))
 				continue
 			}
-		} else {
-			informer = kubeInformersByNamespace.InformersFor(metadata.GetNamespace())
-			if informer == nil {
-				utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetNamespace()))
+			requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("cannot decode %q: %v", file, err))
 				continue
 			}
-		}
+			metadata, err := meta.Accessor(requiredObj)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("cannot get metadata %q: %v", file, err))
+				continue
+			}
 
-		// iterate through the resources we know that are related to kube informers and add the pertinent informers
-		switch t := requiredObj.(type) {
-		case *corev1.Namespace:
-			ret = ret.AddNamespaceInformer(informer.Core().V1().Namespaces().Informer(), t.Name)
-		case *corev1.Service:
-			ret = ret.AddInformer(informer.Core().V1().Namespaces().Informer())
-		case *corev1.Pod:
-			ret = ret.AddInformer(informer.Core().V1().Pods().Informer())
-		case *corev1.ServiceAccount:
-			ret = ret.AddInformer(informer.Core().V1().ServiceAccounts().Informer())
-		case *corev1.ConfigMap:
-			ret = ret.AddInformer(informer.Core().V1().ConfigMaps().Informer())
-		case *corev1.Secret:
-			ret = ret.AddInformer(informer.Core().V1().Secrets().Informer())
-		case *rbacv1.ClusterRole:
-			ret = ret.AddInformer(informer.Rbac().V1().ClusterRoles().Informer())
-		case *rbacv1.ClusterRoleBinding:
-			ret = ret.AddInformer(informer.Rbac().V1().ClusterRoleBindings().Informer())
-		case *rbacv1.Role:
-			ret = ret.AddInformer(informer.Rbac().V1().Roles().Informer())
-		case *rbacv1.RoleBinding:
-			ret = ret.AddInformer(informer.Rbac().V1().RoleBindings().Informer())
-		case *policyv1.PodDisruptionBudget:
-			ret = ret.AddInformer(informer.Policy().V1().PodDisruptionBudgets().Informer())
-		case *storagev1.StorageClass:
-			ret = ret.AddInformer(informer.Storage().V1().StorageClasses().Informer())
-		case *storagev1.CSIDriver:
-			ret = ret.AddInformer(informer.Storage().V1().CSIDrivers().Informer())
-		default:
-			// if there's a missing case, the caller can add an informer or count on a time based trigger.
-			// if the controller doesn't handle it, then there will be failure from the underlying apply.
-			klog.V(4).Infof("unhandled type %T", requiredObj)
+			// find the right subset of informers.  Interestingly, cluster scoped resources require cluster scoped informers
+			var informer informers.SharedInformerFactory
+			if _, ok := requiredObj.(*corev1.Namespace); ok {
+				informer = kubeInformersByNamespace.InformersFor(metadata.GetName())
+				if informer == nil {
+					utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetName()))
+					continue
+				}
+			} else {
+				informer = kubeInformersByNamespace.InformersFor(metadata.GetNamespace())
+				if informer == nil {
+					utilruntime.HandleError(fmt.Errorf("missing informer for namespace %q; no dynamic wiring added, time-based only.", metadata.GetNamespace()))
+					continue
+				}
+			}
+
+			// iterate through the resources we know that are related to kube informers and add the pertinent informers
+			switch t := requiredObj.(type) {
+			case *corev1.Namespace:
+				ret = ret.AddNamespaceInformer(informer.Core().V1().Namespaces().Informer(), t.Name)
+			case *corev1.Service:
+				ret = ret.AddInformer(informer.Core().V1().Namespaces().Informer())
+			case *corev1.Pod:
+				ret = ret.AddInformer(informer.Core().V1().Pods().Informer())
+			case *corev1.ServiceAccount:
+				ret = ret.AddInformer(informer.Core().V1().ServiceAccounts().Informer())
+			case *corev1.ConfigMap:
+				ret = ret.AddInformer(informer.Core().V1().ConfigMaps().Informer())
+			case *corev1.Secret:
+				ret = ret.AddInformer(informer.Core().V1().Secrets().Informer())
+			case *rbacv1.ClusterRole:
+				ret = ret.AddInformer(informer.Rbac().V1().ClusterRoles().Informer())
+			case *rbacv1.ClusterRoleBinding:
+				ret = ret.AddInformer(informer.Rbac().V1().ClusterRoleBindings().Informer())
+			case *rbacv1.Role:
+				ret = ret.AddInformer(informer.Rbac().V1().Roles().Informer())
+			case *rbacv1.RoleBinding:
+				ret = ret.AddInformer(informer.Rbac().V1().RoleBindings().Informer())
+			case *policyv1.PodDisruptionBudget:
+				ret = ret.AddInformer(informer.Policy().V1().PodDisruptionBudgets().Informer())
+			case *storagev1.StorageClass:
+				ret = ret.AddInformer(informer.Storage().V1().StorageClasses().Informer())
+			case *storagev1.CSIDriver:
+				ret = ret.AddInformer(informer.Storage().V1().CSIDrivers().Informer())
+			default:
+				// if there's a missing case, the caller can add an informer or count on a time based trigger.
+				// if the controller doesn't handle it, then there will be failure from the underlying apply.
+				klog.V(4).Infof("unhandled type %T", requiredObj)
+			}
 		}
 	}
 
@@ -213,14 +262,34 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 
 	errors := []error{}
 	var notFoundErrorsCount int
-	directResourceResults := resourceapply.ApplyDirectly(ctx, c.clients, syncContext.Recorder(), c.manifests, c.files...)
-	for _, currResult := range directResourceResults {
-		if apierrors.IsNotFound(currResult.Error) {
-			notFoundErrorsCount++
-		}
-		if currResult.Error != nil {
-			errors = append(errors, fmt.Errorf("%q (%T): %v", currResult.File, currResult.Type, currResult.Error))
+	for _, conditionalManifest := range c.manifests {
+		shouldCreate := conditionalManifest.shouldCreateFn()
+		shouldDelete := conditionalManifest.shouldDeleteFn()
+
+		var directResourceResults []resourceapply.ApplyResult
+
+		switch {
+		case !shouldCreate && !shouldDelete:
+			// no action required
 			continue
+		case shouldCreate && shouldDelete:
+			errors = append(errors, fmt.Errorf("cannot create and delete %v at the same time, skipping", strings.Join(conditionalManifest.files, ", ")))
+			continue
+
+		case shouldCreate:
+			directResourceResults = resourceapply.ApplyDirectly(ctx, c.clients, syncContext.Recorder(), conditionalManifest.manifests, conditionalManifest.files...)
+		case shouldDelete:
+			directResourceResults = resourceapply.DeleteAll(ctx, c.clients, syncContext.Recorder(), conditionalManifest.manifests, conditionalManifest.files...)
+		}
+
+		for _, currResult := range directResourceResults {
+			if apierrors.IsNotFound(currResult.Error) {
+				notFoundErrorsCount++
+			}
+			if currResult.Error != nil {
+				errors = append(errors, fmt.Errorf("%q (%T): %v", currResult.File, currResult.Type, currResult.Error))
+				continue
+			}
 		}
 	}
 
@@ -230,7 +299,6 @@ func (c StaticResourceController) Sync(ctx context.Context, syncContext factory.
 		Reason:  "AsExpected",
 		Message: "",
 	}
-
 	if len(errors) > 0 {
 		message := ""
 		for _, err := range errors {
@@ -276,43 +344,45 @@ func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference,
 	acc := make([]configv1.ObjectReference, 0)
 	errors := []error{}
 
-	for _, file := range c.files {
-		// parse static asset
-		objBytes, err := c.manifests(file)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		metadata, err := meta.Accessor(requiredObj)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		// map gvk to gvr
-		gvk := requiredObj.GetObjectKind().GroupVersionKind()
-		mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		gvr := mapping.Resource
-		// filter out namespaced resources within "all" alias from result
-		if metadata.GetNamespace() != "" {
-			if _, ok := lookup[gvr.GroupResource()]; ok {
+	for _, conditionalManifest := range c.manifests {
+		for _, file := range conditionalManifest.files {
+			// parse static asset
+			objBytes, err := conditionalManifest.manifests(file)
+			if err != nil {
+				errors = append(errors, err)
 				continue
 			}
+			requiredObj, _, err := genericCodec.Decode(objBytes, nil, nil)
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+			metadata, err := meta.Accessor(requiredObj)
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+			// map gvk to gvr
+			gvk := requiredObj.GetObjectKind().GroupVersionKind()
+			mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+			gvr := mapping.Resource
+			// filter out namespaced resources within "all" alias from result
+			if metadata.GetNamespace() != "" {
+				if _, ok := lookup[gvr.GroupResource()]; ok {
+					continue
+				}
+			}
+			acc = append(acc, configv1.ObjectReference{
+				Group:     gvk.Group,
+				Resource:  gvr.Resource,
+				Namespace: metadata.GetNamespace(),
+				Name:      metadata.GetName(),
+			})
 		}
-		acc = append(acc, configv1.ObjectReference{
-			Group:     gvk.Group,
-			Resource:  gvr.Resource,
-			Namespace: metadata.GetNamespace(),
-			Name:      metadata.GetName(),
-		})
 	}
 
 	return acc, utilerrors.NewAggregate(errors)

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/test_helpers.go
@@ -140,7 +140,7 @@ func (c *fakeStaticPodOperatorClient) UpdateStaticPodOperatorSpec(ctx context.Co
 func (c *fakeStaticPodOperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
 	return &c.fakeStaticPodOperatorSpec.OperatorSpec, &c.fakeStaticPodOperatorStatus.OperatorStatus, c.resourceVersion, nil
 }
-func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(context.Context, string, *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
+func (c *fakeStaticPodOperatorClient) UpdateOperatorSpec(ctx context.Context, s string, p *operatorv1.OperatorSpec) (spec *operatorv1.OperatorSpec, resourceVersion string, err error) {
 	panic("not supported")
 }
 func (c *fakeStaticPodOperatorClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20211110085240-047b536a17c6
+# github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Update the version of library-go to include the latest changes that
allow the encryption controller to synchronize the encryption-config
secret only when the encryption controller should be run. This prevents
the secrets from being unnecessarily deleted in the apiserver namespace
whenever it doesn't exist in the config-managed namespace.

Follow-up to https://github.com/openshift/library-go/pull/1243