### PR TITLE
bug 2026352: Sync with library-go to pick fixes for pruner panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20211108165917-be1be0e89115
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83
-	github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e
+	github.com/openshift/library-go v0.0.0-20211129085416-f8f37b01e6b6
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83 h1:TGBy40xVBCqDqvu8gaakva4u+08JtOt/LfekiwbCMyc=
 github.com/openshift/client-go v0.0.0-20210916133943-9acee1a0fb83/go.mod h1:iSeqKIqUKxVec3gV1kNvwS1tjDpzpdP134RimkLc3BE=
-github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e h1:1DAAE0G8ixeUDJ8hBTImY++RkLNgQuUYK4FlORScTlU=
-github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
+github.com/openshift/library-go v0.0.0-20211129085416-f8f37b01e6b6 h1:fIWNH48tocs6Hc7D798dozNOx95mLtD9/V8eyv6oceA=
+github.com/openshift/library-go v0.0.0-20211129085416-f8f37b01e6b6/go.mod h1:b1cKE6TuNqjl7wT0y3W4g0qREuab1mH6WOJm9pT8L/A=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/prune/cmd.go
@@ -128,6 +128,13 @@ func (o *PruneOptions) Run() error {
 		return nil
 	}
 
+	// If the cert dir does not exist, do nothing.
+	// The dir will get eventually created by an installer pod.
+	if _, err := os.Stat(path.Join(o.ResourceDir, o.CertDir)); os.IsNotExist(err) {
+		klog.Infof("Skipping %s as it does not exist", path.Join(o.ResourceDir, o.CertDir))
+		return nil
+	}
+
 	return filepath.Walk(path.Join(o.ResourceDir, o.CertDir),
 		func(filePath string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20211117092436-da55329d6d2e
+# github.com/openshift/library-go v0.0.0-20211129085416-f8f37b01e6b6
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
```
2021-11-03T04:25:43.102203390Z F1103 04:25:43.102194       1 cmd.go:48] lstat /etc/kubernetes/static-pod-resources/kube-scheduler-certs: no such file or directory
2021-11-03T04:25:43.194947275Z goroutine 1 [running]:
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.stacks(0xc000012001, 0xc0001c81c0, 0x84, 0xda)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:1026 +0xb9
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.(*loggingT).output(0x3a8bd60, 0xc000000003, 0x0, 0x0, 0xc0003c81c0, 0x1, 0x2f628ac, 0x6, 0x30, 0x414600)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:975 +0x1e5
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.(*loggingT).printDepth(0x3a8bd60, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x1, 0xc000496910, 0x1, 0x1)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:735 +0x185
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.(*loggingT).print(...)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:717
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.Fatal(...)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:1494
2021-11-03T04:25:43.194947275Z github.com/openshift/library-go/pkg/operator/staticpod/prune.NewPrune.func1(0xc000267680, 0xc0003cb680, 0x0, 0x6)
2021-11-03T04:25:43.194947275Z     github.com/openshift/library-go@v0.0.0-20210915142033-188c3c82f817/pkg/operator/staticpod/prune/cmd.go:48 +0x3aa
2021-11-03T04:25:43.194947275Z github.com/spf13/cobra.(*Command).execute(0xc000267680, 0xc0003cb620, 0x6, 0x6, 0xc000267680, 0xc0003cb620)
2021-11-03T04:25:43.194947275Z     github.com/spf13/cobra@v1.1.3/command.go:856 +0x2c2
2021-11-03T04:25:43.194947275Z github.com/spf13/cobra.(*Command).ExecuteC(0xc000266c80, 0xc000056080, 0xc000266c80, 0xc000000180)
2021-11-03T04:25:43.194947275Z     github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
2021-11-03T04:25:43.194947275Z github.com/spf13/cobra.(*Command).Execute(...)
2021-11-03T04:25:43.194947275Z     github.com/spf13/cobra@v1.1.3/command.go:897
2021-11-03T04:25:43.194947275Z main.main()
2021-11-03T04:25:43.194947275Z     github.com/openshift/cluster-kube-scheduler-operator/cmd/cluster-kube-scheduler-operator/main.go:34 +0x176
2021-11-03T04:25:43.194947275Z 
2021-11-03T04:25:43.194947275Z goroutine 6 [chan receive]:
2021-11-03T04:25:43.194947275Z k8s.io/klog/v2.(*loggingT).flushDaemon(0x3a8bd60)
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:1169 +0x8b
2021-11-03T04:25:43.194947275Z created by k8s.io/klog/v2.init.0
2021-11-03T04:25:43.194947275Z     k8s.io/klog/v2@v2.9.0/klog.go:420 +0xdf
2021-11-03T04:25:43.194947275Z 
2021-11-03T04:25:43.194947275Z goroutine 64 [runnable]:
2021-11-03T04:25:43.194947275Z k8s.io/apimachinery/pkg/util/wait.Forever(0x27490f0, 0x12a05f200)
2021-11-03T04:25:43.194947275Z     k8s.io/apimachinery@v0.22.1/pkg/util/wait/wait.go:80
2021-11-03T04:25:43.194947275Z created by k8s.io/component-base/logs.InitLogs
2021-11-03T04:25:43.194947275Z     k8s.io/component-base@v0.22.1/logs/logs.go:58 +0x8a
```

To avoid Failing the pruner pods until the cert directory is created:

```
NAME                                                                READY  STATUS     RESTARTS  AGE    IP           NODE
installer-7-ip-10-0-17-153.us-west-2.compute.internal               0/1    Succeeded  0         9h30m  10.130.0.27  ip-10-0-17-153.us-west-2.compute.internal
installer-8-ip-10-0-17-153.us-west-2.compute.internal               0/1    Succeeded  0         9h30m  10.130.0.28  ip-10-0-17-153.us-west-2.compute.internal
revision-pruner-6-ip-10-0-17-153.us-west-2.compute.internal         0/1    Failed     0         9h32m  10.130.0.21  ip-10-0-17-153.us-west-2.compute.internal
revision-pruner-7-ip-10-0-17-153.us-west-2.compute.internal         0/1    Failed     0         9h31m  10.130.0.24  ip-10-0-17-153.us-west-2.compute.internal
revision-pruner-8-ip-10-0-17-153.us-west-2.compute.internal         0/1    Succeeded  0         9h30m  10.130.0.29  ip-10-0-17-153.us-west-2.compute.internal
```