### PR TITLE
test/e2e/TestNamedCertificates: sign using root CA

### DIFF
--- a/test/e2e/user_certs_test.go
+++ b/test/e2e/user_certs_test.go
@@ -37,9 +37,9 @@ func TestNamedCertificates(t *testing.T) {
 
 	// details of the test certs that will be created, keyed by an string "id"
 	testCertInfoById := map[string]*testCertInfo{
-		"one":   newTestCertInfo(t, "one", rootCA.Certificate, "one.test"),
-		"two":   newTestCertInfo(t, "two", rootCA.Certificate, "two.test"),
-		"three": newTestCertInfo(t, "three", rootCA.Certificate, "three.test", "four.test"),
+		"one":   newTestCertInfo(t, "one", rootCA, "one.test"),
+		"two":   newTestCertInfo(t, "two", rootCA, "two.test"),
+		"three": newTestCertInfo(t, "three", rootCA, "three.test", "four.test"),
 	}
 
 	// initialize clients
@@ -387,7 +387,7 @@ type testCertInfo struct {
 	crypto *test.CryptoMaterials
 }
 
-func newTestCertInfo(t *testing.T, id string, signer *x509.Certificate, hosts ...string) *testCertInfo {
+func newTestCertInfo(t *testing.T, id string, signer *test.CryptoMaterials, hosts ...string) *testCertInfo {
 	return &testCertInfo{
 		secretName: strings.ToLower(test.GenerateNameForTest(t, id+"-")),
 		hosts:      hosts,

--- a/test/library/crypto.go
+++ b/test/library/crypto.go
@@ -19,7 +19,7 @@ type CryptoMaterials struct {
 
 // NewServerCertificate returns crypto materials suitable for use by a server. The hosts specified will be added as
 // subject alternate names.
-func NewServerCertificate(t *testing.T, signerCert *x509.Certificate, hosts ...string) *CryptoMaterials {
+func NewServerCertificate(t *testing.T, signer *CryptoMaterials, hosts ...string) *CryptoMaterials {
 	var err error
 	server := &CryptoMaterials{}
 	if server.PrivateKey, err = rsa.GenerateKey(rand.Reader, 2048); err != nil {
@@ -41,7 +41,7 @@ func NewServerCertificate(t *testing.T, signerCert *x509.Certificate, hosts ...s
 		DNSNames:              hosts,
 	}
 	var certs []byte
-	if certs, err = x509.CreateCertificate(rand.Reader, template, signerCert, server.PrivateKey.Public(), server.PrivateKey); err != nil {
+	if certs, err = x509.CreateCertificate(rand.Reader, template, signer.Certificate, server.PrivateKey.Public(), signer.PrivateKey); err != nil {
 		panic(err)
 	}
 	if server.Certificate, err = x509.ParseCertificate(certs); err != nil {


### PR DESCRIPTION
Currently, server certs are signed using the server private key.
They should be signed by the CA's private key.

This fixes it.

/cc @openshift/openshift-team-auth-maintainers @soltysh @sttts 