### PR TITLE
[WIP][Release 4.9] Bug 2013838 bump library-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7
-	github.com/openshift/library-go v0.0.0-20210915142033-188c3c82f817
+	github.com/openshift/library-go v0.0.0-20211013205920-86426cb40139
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -478,8 +478,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7 h1:iKVU5Tga76kiCWpq9giPi0TfI/gZcFoYb7/x+1SkgwM=
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=
-github.com/openshift/library-go v0.0.0-20210915142033-188c3c82f817 h1:qshYZlcU0Wt5wqR67O4LMTRIaJ76x+u4Kb/MquGZk2o=
-github.com/openshift/library-go v0.0.0-20210915142033-188c3c82f817/go.mod h1:fKtzrsRXSWMLiBT1SM8cEVT2YyL7ihx/TEuT3gmgFgQ=
+github.com/openshift/library-go v0.0.0-20211013205920-86426cb40139 h1:+/Zm1E9mJ2RKEJDp0A9dQ+bnd0RRnCcXKW6RGvX477E=
+github.com/openshift/library-go v0.0.0-20211013205920-86426cb40139/go.mod h1:fKtzrsRXSWMLiBT1SM8cEVT2YyL7ihx/TEuT3gmgFgQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/certsyncpod/certsync_controller.go
@@ -264,7 +264,7 @@ func (c *CertSyncController) sync(ctx context.Context, syncCtx factory.SyncConte
 			}
 
 			klog.Infof("Writing secret manifest %q ...", fullFilename)
-			if err := staticpod.WriteFileAtomic(content, 0644, fullFilename); err != nil {
+			if err := staticpod.WriteFileAtomic(content, 0600, fullFilename); err != nil {
 				c.eventRecorder.Warningf("CertificateUpdateFailed", "Failed writing file for secret: %s/%s: %v", secret.Namespace, secret.Name, err)
 				errors = append(errors, err)
 				continue

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20210915142033-188c3c82f817
+# github.com/openshift/library-go v0.0.0-20211013205920-86426cb40139
 ## explicit
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
This is the needed piece bumping library go version with the cert change vendoring for 4.9 branch.
Here is the library-go commit: openshift/library-go#1229