### PR TITLE
prometheus rules for client-go

### DIFF
--- a/bindata/assets/alerts/client-go-requests.yaml
+++ b/bindata/assets/alerts/client-go-requests.yaml
@@ -16,13 +16,13 @@ spec:
                 label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url=~"https?://api-int.*"},
                   "host","$1","url","https?://([^/\\s]+).*")[5m:30s]
                 )) by (le,host,service,namespace,node)
-        - record: service:rest_client_request_duration_seconds:sum:rate
+        - record: service:rest_client_request_duration_seconds:rate5m
           expr: |
               sum(rate(
                 label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url!~"https?://(api-int|\\[::1\\]|127\\.0\\.0\\.1|localhost).*"},
                   "host","$1","url","https?://([^/\\s]+).*")[5m:30s]
                 )) by (le,host,service,namespace)
-        - record: pod:rest_client_request_duration_seconds:sum:rate
+        - record: pod:rest_client_request_duration_seconds:rate5m
           expr: |
               sum(rate(
                 label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url=~"https?://(\\[::1\\]|127\\.0\\.0\\.1|localhost).*"},
@@ -33,17 +33,17 @@ spec:
           labels:
             quantile: "0.99"
           expr: |
-            histogram_quantile(0.99, sum by (le) (internal_load_balancer:rest_client_request_duration_seconds:sum:rate))
+            histogram_quantile(0.99, sum by (le) (internal_load_balancer:rest_client_request_duration_seconds:rate5m))
         - record: service:rest_client_request_duration_seconds:histogram_quantile
           labels:
             quantile: "0.99"
           expr: |
-            histogram_quantile(0.99, sum by (le) (service:rest_client_request_duration_seconds:sum:rate))
+            histogram_quantile(0.99, sum by (le) (service:rest_client_request_duration_seconds:rate5m))
         - record: pod:rest_client_request_duration_seconds:histogram_quantile
           labels:
             quantile: "0.99"
           expr: |
-            histogram_quantile(0.99, sum by (le) (pod:rest_client_request_duration_seconds:sum:rate))
+            histogram_quantile(0.99, sum by (le) (pod:rest_client_request_duration_seconds:rate5m))
         # error by host and job, the rest_client metrics use the code "<error>" to aggregate
         # any non-http error and avoid cardinality problems.
         # xref: https://github.com/kubernetes/kubernetes/blob/66931c9b8f11a3f223ba1890e4f390cff74ce1a6/staging/src/k8s.io/client-go/rest/request.go#L785-L799
@@ -63,12 +63,12 @@ spec:
             / ignoring (host,service,namespace) group_left
             sum(rate(rest_client_requests_total{host=~"(\\[::1\\]|127\\.0\\.0\\.1|localhost).*"}[5m]))
         # errors by destination
-        - record: internal_load_balancer:rest_client_requests_errors:sum
+        - record: internal_load_balancer:rest_client_requests_errors:rate5m:sum
           expr: |
             sum(internal_load_balancer:rest_client_requests_errors:ratio_rate5m)
-        - record: service:rest_client_requests:errors:sum
+        - record: service:rest_client_requests:errors:rate5m:sum
           expr: |
             sum(service:rest_client_requests:errors:ratio_rate5m)
-        - record: pod:rest_client_requests:errors:sum
+        - record: pod:rest_client_requests:errors:rate5m:sum
           expr: |
             sum(pod:rest_client_requests:errors:ratio_rate5m)

--- a/bindata/assets/alerts/client-go-requests.yaml
+++ b/bindata/assets/alerts/client-go-requests.yaml
@@ -1,0 +1,74 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: client-go
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+    - name: control-plane-client-go
+      rules:
+        # record request duration rate by:
+        # - job (kubelet, apiserver. controller-manager, ...)
+        # - destination host: internal-lb, services, localhost
+        - record: internal_load_balancer:rest_client_request_duration_seconds:rate5m
+          expr: |
+              sum(rate(
+                label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url=~"https?://api-int.*"},
+                  "host","$1","url","https?://([^/\\s]+).*")[5m:30s]
+                )) by (le,host,service,namespace,node)
+        - record: service:rest_client_request_duration_seconds:sum:rate
+          expr: |
+              sum(rate(
+                label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url!~"https?://(api-int|\\[::1\\]|127\\.0\\.0\\.1|localhost).*"},
+                  "host","$1","url","https?://([^/\\s]+).*")[5m:30s]
+                )) by (le,host,service,namespace)
+        - record: pod:rest_client_request_duration_seconds:sum:rate
+          expr: |
+              sum(rate(
+                label_replace(rest_client_request_duration_seconds_bucket{verb="GET",url=~"https?://(\\[::1\\]|127\\.0\\.0\\.1|localhost).*"},
+                  "host","$1","url","https?://([^/\\s]+).*")[5m:30s]
+                )) by (le,host,service,namespace)
+        # latency by destination: internal-lb, services, localhost
+        - record: internal_load_balancer:rest_client_request_duration_seconds:histogram_quantile
+          labels:
+            quantile: "0.99"
+          expr: |
+            histogram_quantile(0.99, sum by (le) (internal_load_balancer:rest_client_request_duration_seconds:sum:rate))
+        - record: service:rest_client_request_duration_seconds:histogram_quantile
+          labels:
+            quantile: "0.99"
+          expr: |
+            histogram_quantile(0.99, sum by (le) (service:rest_client_request_duration_seconds:sum:rate))
+        - record: pod:rest_client_request_duration_seconds:histogram_quantile
+          labels:
+            quantile: "0.99"
+          expr: |
+            histogram_quantile(0.99, sum by (le) (pod:rest_client_request_duration_seconds:sum:rate))
+        # error by host and job, the rest_client metrics use the code "<error>" to aggregate
+        # any non-http error and avoid cardinality problems.
+        # xref: https://github.com/kubernetes/kubernetes/blob/66931c9b8f11a3f223ba1890e4f390cff74ce1a6/staging/src/k8s.io/client-go/rest/request.go#L785-L799
+        - record: internal_load_balancer:rest_client_requests_errors:ratio_rate5m
+          expr: |
+            sum(rate(rest_client_requests_total{code="<error>",host=~"api-int.*"}[5m])) by (host,service,namespace)
+            / ignoring (host,service,namespace) group_left
+            sum(rate(rest_client_requests_total{host=~"api-int.*"}[5m]))
+        - record: service:rest_client_requests:errors:ratio_rate5m
+          expr: |
+            sum(rate(rest_client_requests_total{code="<error>",host!~"(api-int|\\[::1\\]|127\\.0\\.0\\.1|localhost).*"}[5m])) by (host,service,namespace)
+            / ignoring (host,service,namespace) group_left
+            sum(rate(rest_client_requests_total{host!~"(api-int|\\[::1\\]|127\\.0\\.0\\.1|localhost).*"}[5m]))
+        - record: pod:rest_client_requests:errors:ratio_rate5m
+          expr: |
+            sum(rate(rest_client_requests_total{code="<error>",host=~"(\\[::1\\]|127\\.0\\.0\\.1|localhost).*"}[5m])) by (host,service,namespace)
+            / ignoring (host,service,namespace) group_left
+            sum(rate(rest_client_requests_total{host=~"(\\[::1\\]|127\\.0\\.0\\.1|localhost).*"}[5m]))
+        # errors by destination
+        - record: internal_load_balancer:rest_client_requests_errors:sum
+          expr: |
+            sum(internal_load_balancer:rest_client_requests_errors:ratio_rate5m)
+        - record: service:rest_client_requests:errors:sum
+          expr: |
+            sum(service:rest_client_requests:errors:ratio_rate5m)
+        - record: pod:rest_client_requests:errors:sum
+          expr: |
+            sum(pod:rest_client_requests:errors:ratio_rate5m)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -149,6 +149,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
 		"assets/alerts/api-usage.yaml",
 		"assets/alerts/audit-errors.yaml",
+		"assets/alerts/client-go-requests.yaml",
 		"assets/alerts/cpu-utilization.yaml",
 		"assets/alerts/kube-apiserver-requests.yaml",
 		"assets/alerts/kube-apiserver-slos-basic.yaml",


### PR DESCRIPTION
Kubernetes is a distributed system, so network is a fundamental part
of the system.

At the heart of the system we can find the apiservers and the etcd
cluster, both have a good instrumentation that allow users and
developers to diagnose and troubleshoot networking problems.

However, there are other components like the kube-scheduler,
kube-controller-manager and kubelets that depend on its connectivity
against the apiserver to work.

These communication can be achieved via a direct network connection,
and intermeadiate load balancer or via the Kubernetes Services
implementation (CNI, ...)

Recording the latency and the error rate of these components against
the apiserver will allow users and developers to understand and
troubleshoot the networking problem caused by external factors.

Also, before adding SLOs we need a better understanding on how these
SLIs behave, since they depend a lot of the environment, per example,
cloud providers load balancers vs BareMetal keepalived+haproxy or
customer load balancer, ...


Add 4 rules to store the latency against the internal apiserver, localhost and loopback connections

