### PR TITLE
Fix aggregator-client-signer got inconsistent cert validity period #1292

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -133,8 +133,8 @@ func newCertRotationController(
 		certrotation.RotatedSigningCASecret{
 			Namespace:              operatorclient.OperatorNamespace,
 			Name:                   "aggregator-client-signer",
-			Validity:               30 * rotationDay,
-			Refresh:                15 * rotationDay,
+			Validity:               60 * rotationDay,
+			Refresh:                30 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),


### PR DESCRIPTION
Previouly the aggregator-client-signer got the 30 validity / 15 refesh days, now it's 60 / 30 days