### PR TITLE
Bug 2052513: disable webhook supportability during upgrade

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -368,6 +368,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		kubeInformersForNamespaces,
 		apiextensionsInformers,
+		configInformers,
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/operator/webhooksupportabilitycontroller/webhook_supportability_controller.go
+++ b/pkg/operator/webhooksupportabilitycontroller/webhook_supportability_controller.go
@@ -3,6 +3,9 @@ package webhooksupportabilitycontroller
 import (
 	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/management"
@@ -20,6 +23,7 @@ type webhookSupportabilityController struct {
 	validatingWebhookLister admissionregistrationlistersv1.ValidatingWebhookConfigurationLister
 	serviceLister           corev1listers.ServiceLister
 	crdLister               apiextensionslistersv1.CustomResourceDefinitionLister
+	clusterVersionLister    configv1listers.ClusterVersionLister
 }
 
 // NewWebhookSupportabilityController sets Degraded=True conditions when a webhook service either cannot
@@ -28,6 +32,7 @@ func NewWebhookSupportabilityController(
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	apiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
+	configInformers configinformers.SharedInformerFactory,
 	recorder events.Recorder,
 ) *webhookSupportabilityController {
 	kubeInformersForAllNamespaces := kubeInformersForNamespaces.InformersFor("")
@@ -37,6 +42,7 @@ func NewWebhookSupportabilityController(
 		validatingWebhookLister: kubeInformersForAllNamespaces.Admissionregistration().V1().ValidatingWebhookConfigurations().Lister(),
 		serviceLister:           kubeInformersForAllNamespaces.Core().V1().Services().Lister(),
 		crdLister:               apiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Lister(),
+		clusterVersionLister:    configInformers.Config().V1().ClusterVersions().Lister(),
 	}
 	c.Controller = factory.New().
 		WithInformers(
@@ -44,6 +50,7 @@ func NewWebhookSupportabilityController(
 			kubeInformersForAllNamespaces.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer(),
 			kubeInformersForAllNamespaces.Core().V1().Services().Informer(),
 			apiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Informer(),
+			configInformers.Config().V1().ClusterVersions().Informer(),
 		).
 		WithSync(c.sync).
 		ToController("webhookSupportabilityController", recorder)
@@ -56,6 +63,18 @@ func (c *webhookSupportabilityController) sync(ctx context.Context, controllerCo
 		return err
 	}
 	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	// do nothing while an upgrade is in progress
+	clusterVersion, err := c.clusterVersionLister.Get("version")
+	if err != nil {
+		return err
+	}
+	desired := clusterVersion.Status.Desired.Version
+	history := clusterVersion.Status.History
+	// upgrade is in progress if there is no history, or the latest history entry matches the desired version and is not completed
+	if len(history) == 0 || history[0].Version != desired || history[0].State != configv1.CompletedUpdate {
 		return nil
 	}
 


### PR DESCRIPTION
Give customers running mis-configured webhooks before 4.10 a chance to upgrade to 4.10 before they are forced to fix their webhooks. 