### PR TITLE
[release-4.10] Bug 2052339: degraded webhook conditions to errors

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -353,6 +353,11 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// the static pod operator used to directly set these. this removes those conditions since the static pod operator was updated.
 			// these can be removed in 4.5
 			"Available", "Progressing",
+			// webhook supportability controller used to set these but are now renamed
+			"MutatingAdmissionWebhookConfigurationDegraded",
+			"ValidatingAdmissionWebhookConfigurationDegraded",
+			"CRDConversionWebhookConfigurationDegraded",
+			"VirtualResourceAdmissionDegraded",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,

--- a/pkg/operator/webhooksupportabilitycontroller/conditions.go
+++ b/pkg/operator/webhooksupportabilitycontroller/conditions.go
@@ -3,19 +3,19 @@ package webhooksupportabilitycontroller
 const (
 	// MutatingAdmissionWebhookConfigurationDegradedType is true when there
 	// is a problem with a mutating admission webhook service.
-	MutatingAdmissionWebhookConfigurationDegradedType = "MutatingAdmissionWebhookConfigurationDegraded"
+	MutatingAdmissionWebhookConfigurationDegradedType = "MutatingAdmissionWebhookConfigurationError"
 
 	// ValidatingAdmissionWebhookConfigurationDegradedType is true when there
 	// is a problem with a validating admission webhook service.
-	ValidatingAdmissionWebhookConfigurationDegradedType = "ValidatingAdmissionWebhookConfigurationDegraded"
+	ValidatingAdmissionWebhookConfigurationDegradedType = "ValidatingAdmissionWebhookConfigurationError"
 
 	// CRDConversionWebhookConfigurationDegradedType is true when there
 	// is a problem with a custom resource definition conversion webhook service.
-	CRDConversionWebhookConfigurationDegradedType = "CRDConversionWebhookConfigurationDegraded"
+	CRDConversionWebhookConfigurationDegradedType = "CRDConversionWebhookConfigurationError"
 
 	// VirtualResourceAdmissionDegradedType is true when a dynamic admission webhook matches
 	// a virtual resource.
-	VirtualResourceAdmissionDegradedType = "VirtualResourceAdmissionDegraded"
+	VirtualResourceAdmissionDegradedType = "VirtualResourceAdmissionError"
 )
 
 const (


### PR DESCRIPTION
Rename the following conditions so that they do not get rolled up into the overall Degraded status:

-MutatingAdmissionWebhookConfigurationDegraded
-ValidatingAdmissionWebhookConfigurationDegraded
-CRDConversionWebhookConfigurationDegraded
-VirtualResourceAdmissionDegraded

We will gather insights from connected customers in the future to determine if we can re-add these conditions to the overall Degraded status without impacting customer clusters.

cherry pick from https://github.com/openshift/cluster-kube-apiserver-operator/pull/1313