### PR TITLE
Bug 2067384: OCP 4.10 should be firing APIRemovedInNextEUSReleaseInUse for APIs removed in 1.25

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -16,7 +16,7 @@ spec:
               a successful upgrade to the next cluster version.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.23"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release="1.24"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
             namespace: openshift-kube-apiserver
@@ -30,7 +30,7 @@ spec:
               a successful upgrade to the next EUS cluster version.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[123]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[45]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
 
           for: 1h
           labels:

--- a/test/e2e/deprecated_api_test.go
+++ b/test/e2e/deprecated_api_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,47 +11,100 @@ import (
 
 	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 )
 
 func TestAPIRemovedInNextReleaseInUse(t *testing.T) {
-	t.Run("RemovedRelease", func(t *testing.T) {
-		kubeConfig, err := test.NewClientConfigForTest()
-		require.NoError(t, err)
+	kubeConfig, err := test.NewClientConfigForTest()
+	require.NoError(t, err)
 
-		// get current major.minor version
-		discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
-		require.NoError(t, err)
-		version, err := discoveryClient.ServerVersion()
-		require.NoError(t, err)
-		currentMajor, err := strconv.Atoi(version.Major)
-		require.NoError(t, err)
-		currentMinor, err := strconv.Atoi(regexp.MustCompile(`^\d*`).FindString(version.Minor))
+	// get current major.minor version
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	require.NoError(t, err)
+	version, err := discoveryClient.ServerVersion()
+	require.NoError(t, err)
+	currentMajor, err := strconv.Atoi(version.Major)
+	require.NoError(t, err)
+	currentMinor, err := strconv.Atoi(regexp.MustCompile(`^\d*`).FindString(version.Minor))
 
-		// get deprecated major.minor version from alert expression
-		// NOTE: the alert major and minor version is hardcoded
-		// this test will fail in each version bump until the alert is updated
-		// xref: /home/aojea/go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/assets/alerts/api-usage.yaml
-		monitoringClient, err := monitoringclient.NewForConfig(kubeConfig)
-		require.NoError(t, err)
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		rule, err := monitoringClient.MonitoringV1().PrometheusRules("openshift-kube-apiserver").Get(ctx, "api-usage", v1.GetOptions{})
-		require.NoError(t, err)
-		expr := func() string {
-			for _, group := range rule.Spec.Groups {
-				for _, rule := range group.Rules {
-					if rule.Alert == "APIRemovedInNextReleaseInUse" {
-						return strings.TrimSpace(rule.Expr.StrVal)
-					}
+	// get deprecated major.minor version from alert expression
+	// NOTE: the alert major and minor version is hardcoded
+	// this test will fail in each version bump until the alert is updated
+	// xref: https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/assets/alerts/api-usage.yaml
+	monitoringClient, err := monitoringclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	rule, err := monitoringClient.MonitoringV1().PrometheusRules("openshift-kube-apiserver").Get(ctx, "api-usage", v1.GetOptions{})
+	require.NoError(t, err)
+	expr := func() string {
+		for _, group := range rule.Spec.Groups {
+			for _, rule := range group.Rules {
+				if rule.Alert == "APIRemovedInNextReleaseInUse" {
+					return strings.TrimSpace(rule.Expr.StrVal)
 				}
 			}
-			return ""
-		}()
-		require.NotEmpty(t, expr, "Unable to find the alert expression.")
-		removedRelease := strings.Split(regexp.MustCompile(`.*removed_release="(\d+\.\d+)".*`).ReplaceAllString(expr, "$1"), ".")
+		}
+		return ""
+	}()
+	require.NotEmpty(t, expr, "Unable to find the alert expression.")
+	removedRelease := strings.Split(regexp.MustCompile(`.*removed_release="(\d+\.\d+)".*`).ReplaceAllString(expr, "$1"), ".")
+	require.Len(t, removedRelease, 2, "Unable to parse the removed release version from the alert expression.")
+	major, err := strconv.Atoi(removedRelease[0])
+	require.NoError(t, err)
+	minor, err := strconv.Atoi(removedRelease[1])
+	require.NoError(t, err)
+
+	// rewrite this test if the major version ever changes
+	require.Equal(t, currentMajor, major)
+	require.Equal(t, currentMinor+1, minor)
+}
+
+func TestAPIRemovedInNextEUSReleaseInUse(t *testing.T) {
+	kubeConfig, err := test.NewClientConfigForTest()
+	require.NoError(t, err)
+
+	// get current major.minor version
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	require.NoError(t, err)
+	version, err := discoveryClient.ServerVersion()
+	require.NoError(t, err)
+	currentMajor, err := strconv.Atoi(version.Major)
+	require.NoError(t, err)
+	currentMinor, err := strconv.Atoi(regexp.MustCompile(`^\d*`).FindString(version.Minor))
+
+	// get deprecated major.minor version from alert expression
+	// NOTE: the alert major and minor version is hardcoded
+	// this test will fail in each version bump until the alert is updated
+	// xref: https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/assets/alerts/api-usage.yaml
+	monitoringClient, err := monitoringclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	rule, err := monitoringClient.MonitoringV1().PrometheusRules("openshift-kube-apiserver").Get(ctx, "api-usage", v1.GetOptions{})
+	require.NoError(t, err)
+	expr := func() string {
+		for _, group := range rule.Spec.Groups {
+			for _, rule := range group.Rules {
+				if rule.Alert == "APIRemovedInNextEUSReleaseInUse" {
+					return strings.TrimSpace(rule.Expr.StrVal)
+				}
+			}
+		}
+		return ""
+	}()
+	require.NotEmpty(t, expr, "Unable to find the alert expression.")
+	rx := regexp.MustCompile(`.*removed_release="(\d+\.\d+)".*`)
+	if rx.FindStringIndex(expr) != nil {
+		// kubernetes minor version must be even, otherwise this is an even numbered
+		// OpenShift EUS release and the alert can't match 2 versions using the label
+		// matching operator `=` and must instead use `~=` instead.
+		require.Equal(t, 0, currentMinor%2, "Alert expression should match more than one release.")
+
+		removedRelease := strings.Split(rx.ReplaceAllString(expr, "$1"), ".")
 		require.Len(t, removedRelease, 2, "Unable to parse the removed release version from the alert expression.")
 		major, err := strconv.Atoi(removedRelease[0])
 		require.NoError(t, err)
@@ -60,5 +114,23 @@ func TestAPIRemovedInNextReleaseInUse(t *testing.T) {
 		// rewrite this test if the major version ever changes
 		require.Equal(t, currentMajor, major)
 		require.Equal(t, currentMinor+1, minor)
-	})
+		return
+	}
+	rx = regexp.MustCompile(`.*removed_release=~"([^"]+)".*`)
+	require.Regexp(t, rx, expr, "Unable to parse the removed release version from the alert expression.")
+	removedRelease := strings.ReplaceAll(rx.ReplaceAllString(expr, "$1"), `\\`, `\`)
+
+	// rewrite this test if the major version ever changes
+
+	// if Kubernetes minor version is even, this is an odd numbered OpenShift non-EUS
+	// release and the next EUS release is one minor versions away; otherwise, we still
+	// alert on the next version to forewarn EUS customers.
+	assert.Regexp(t, removedRelease, fmt.Sprintf("%d.%d", currentMajor, currentMinor+1))
+
+	// if Kubernetes minor version is odd, this is an even numbered OpenShift
+	// EUS release and the next EUS release is two minor versions away.
+	if currentMinor%2 == 1 {
+		assert.Regexp(t, removedRelease, fmt.Sprintf("%d.%d", currentMajor, currentMinor+2))
+	}
+
 }


### PR DESCRIPTION
* `APIRemovedInNextEUSReleaseInUse` should alert on use of APIs removed in OpenShift 4.11 & 4.12 (kube api server versions 1.24 and 1.25).
* `APIRemovedInNextReleaseInUse` should alert on use of APIs removed in OpenShift v4.11 (kube api server version 1.24).
* Added `TestAPIRemovedInNextEUSReleaseInUse` e2e test.

Once OpenShift 4.11 has been rebased onto kube apiserver 1.24, this will need to be updated again.