### PR TITLE
fix label for max-in-flight-recorder

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -137,4 +137,4 @@ spec:
       # The following query gives us maximum peak of the apiserver concurrency over a 2-minute window.
     - record: cluster:apiserver_current_inflight_requests:sum:max_over_time:2m
       expr: |
-        max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,requestKind)[2m:])
+        max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,request_kind)[2m:])


### PR DESCRIPTION
The label has been renamed from `requestKind` to `request_kind` for the `apiserver_current_inflight_requests` metric.
https://github.com/kubernetes/kubernetes/pull/91177 in 1.19

The recording rule needs to be updated.
