### PR TITLE
Move node CPU alerts to MCO

### DIFF
--- a/bindata/assets/alerts/cpu-utilization.yaml
+++ b/bindata/assets/alerts/cpu-utilization.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: cpu-utilization
   namespace: openshift-kube-apiserver
+  annotations:
+    release.openshift.io/delete: "true"
 spec:
   groups:
     - name: control-plane-cpu-utilization


### PR DESCRIPTION
Move the node CPU alerts to the machine config operator which is their
rightful owner.

Add the release.openshift.io/delete: "true" annotation to the manifest
in order to have it cleaned up in 4.11. After 4.11 is released, we will
be able to remove the manifest for 4.12.

/cc @tkashem @wking 