### PR TITLE
render apirequest count to reduce startup errors

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -9,6 +9,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/scc-manifests /usr/share/bootkube/manifests/manifests/
+COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/vendor/github.com/openshift/api/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml /usr/share/bootkube/manifests/manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/cluster-kube-apiserver-operator /usr/bin/
 COPY manifests /manifests
 COPY bindata/bootkube/scc-manifests /manifests


### PR DESCRIPTION
these appear consistently in the bootstrap kube-apiserver log and are not valuable.

> E0404 19:03:15.520793       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:16.933062       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:17.578002       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:20.997276       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:23.063800       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:23.487180       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:23.715648       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:26.718209       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:27.003275       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:27.134657       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:29.873523       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:30.966422       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)
E0404 19:03:31.432466       1 apiaccess_count_controller.go:161] the server could not find the requested resource (post apirequestcounts.apiserver.openshift.io)

This PR renders the apirequestcount to reduce bootstrap kube-apiserver noise.

See install-gather from https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere/1511046135223947264