### PR TITLE
defaultconfig: set restricted as default pod security

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -14,7 +14,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1beta1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"


### PR DESCRIPTION
This is enabling the restricted pod security as default.

Note: This is a WIP PR until all workloads are successfully switched to handle restricted pod security level.