### PR TITLE
[v1.24] remove enable-swagger-ui from default config

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -92,8 +92,6 @@ apiServerArguments:
     - "true"
   enable-logs-handler:
     - "false"
-  enable-swagger-ui:
-    - "true"
   endpoint-reconciler-type:
     - "lease"
   etcd-cafile:


### PR DESCRIPTION
starting with 1.24 `enable-swagger-ui` server option has been removed. See https://github.com/kubernetes/kubernetes/commit/206f3aeec2748ef149a36a9c69329b5be2953ecb

The rebase PR is seeing this error from bootstrap:
```
E0425 13:41:01.547406       1 run.go:74] "command failed" err="unknown flag: --enable-swagger-ui"
```

