### PR TITLE
Bug 2078901: raise alerts for what will be removed on 1.25

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -16,7 +16,7 @@ spec:
               a successful upgrade to the next cluster version.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.24"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+            group(apiserver_requested_deprecated_apis{removed_release="1.25"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
           for: 1h
           labels:
             namespace: openshift-kube-apiserver


### PR DESCRIPTION
**Description**
OCP 4.11 should be raising the alerts when removed apis on 1.25 are found. 

Closes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2078901