### PR TITLE
[rebase v1.24]: remove insecure-port

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -183,7 +183,6 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "insecure-readyz"]
     args:
-    - --insecure-port=6080
     - --delegate-url=https://localhost:6443/readyz
     ports:
     - containerPort: 6080

--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -88,7 +88,6 @@ spec:
     terminationMessagePolicy: FallbackToLogsOnError
     command: ["cluster-kube-apiserver-operator", "insecure-readyz"]
     args:
-    - --insecure-port=6080
     - --delegate-url=https://localhost:6443/readyz
     ports:
     - containerPort: 6080


### PR DESCRIPTION
`insecure-port` server option has been removed in 1.24 - https://github.com/kubernetes/kubernetes/blob/v1.23.7-rc.0/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go

This is causing cluster bootstrap to fail in rebase PR with the following error:
```
E0426 04:06:12.761688       1 run.go:74] "command failed" err="unknown flag: --insecure-port"
```
