### PR TITLE
[rebase v1.24]: remove insecure-port from kas args

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -108,8 +108,6 @@ apiServerArguments:
     - "0"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
-  insecure-port:
-    - "0"
   kubelet-certificate-authority:
     - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
   kubelet-client-certificate:


### PR DESCRIPTION
`insecure-port` server option has been removed in 1.24 - https://github.com/kubernetes/kubernetes/blob/v1.23.7-rc.0/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go

This is causing cluster bootstrap to fail in rebase PR with the following error:
```
E0426 04:06:12.761688       1 run.go:74] "command failed" err="unknown flag: --insecure-port"
```
