### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -24,10 +24,19 @@ spec:
       labels:
         app: kube-apiserver-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       automountServiceAccountToken: false # here to prevent deadlock, remove in 4.9
       serviceAccountName: kube-apiserver-operator
       containers:
       - name: kube-apiserver-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: docker.io/openshift/origin-cluster-kube-apiserver-operator:v4.0
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-kube-apiserver-operator/deployments/kube-apiserver-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"kube-apiserver-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted ca
pabilities (container \"kube-apiserver-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"kube-apiserver-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or conta
iner \"kube-apiserver-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc @stlaz 