### PR TITLE
add HighAdmissionWebhookLatency alert

### DIFF
--- a/bindata/assets/alerts/kube-apiserver-webhook.yaml
+++ b/bindata/assets/alerts/kube-apiserver-webhook.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: webhooks
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+    - name: webhooks
+      rules:
+        - alert: HighAdmissionWebhookLatency
+          annotations:
+            summary: Webhook Latency is high.
+            description: >-
+              The maximum latency of the {{ $labels.name }} (type="{{ $labels.type }}") webhook 
+              has been over 1s for the past five minutes. Review the logs of the webhook workload to 
+              determine the cause of the high latency.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/HighAdmissionWebhookLatency.md
+          expr: |
+            histogram_quantile(0.99, 
+              sum by (le,name)(
+                rate(apiserver_admission_webhook_admission_duration_seconds_bucket[5m])
+              )
+            ) > 1
+          for: 10m
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: critical

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -153,6 +153,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		"assets/alerts/cpu-utilization.yaml",
 		"assets/alerts/kube-apiserver-requests.yaml",
 		"assets/alerts/kube-apiserver-slos-basic.yaml",
+		"assets/alerts/kube-apiserver-webhook.yaml",
 	}
 	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -24,8 +24,9 @@ func readAllYaml(path string, t *testing.T) {
 			!strings.HasSuffix(info.Name(), "api_performance_dashboard.yaml") &&
 			// there is an alert message containing $labels strings that cause the reader to fail.
 			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml") &&
-			// there is an alert message containing $labels strings that cause the reader to fail.
+			// these are alerts with messages containing $labels strings that cause the reader to fail.
 			!strings.HasSuffix(info.Name(), "api-usage.yaml") &&
+			!strings.HasSuffix(info.Name(), "kube-apiserver-webhook.yaml") &&
 			// the kas's pod manifest contains go template values and fails compilation
 			!strings.HasSuffix(info.Name(), "pod.yaml")
 


### PR DESCRIPTION
Add `critical` alert `HighAdmissionWebhookLatency` that fires when the average duration of an admission webhook is > 1s.