### PR TITLE
Bug 2074031: Support tuning GOGC within a limited range.

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -127,6 +127,8 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
+      - name: GOGC
+        value: "{{ .GOGC }}"
     securityContext:
       privileged: true
   - name: kube-apiserver-cert-syncer

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -172,6 +172,49 @@ func TestManageTemplate(t *testing.T) {
 				UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(configWithOverriddenWatchTerminationDuration)},
 			}},
 		},
+		{
+			name:     "default value provided for gogc",
+			template: "{{.GOGC}}",
+			golden:   "100",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{
+				OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig: runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+		},
+		{
+			name:     "gogc from unsupportedConfigOverrides",
+			template: "{{.GOGC}}",
+			golden:   "76",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{
+				OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig:             runtime.RawExtension{Raw: []byte(`{}`)},
+					UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(`{"garbageCollectionTargetPercentage":"76"}`)},
+				},
+			},
+		},
+		{
+			name:     "gogc from unsupportedConfigOverrides clamped to lower bound",
+			template: "{{.GOGC}}",
+			golden:   "63",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{
+				OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig:             runtime.RawExtension{Raw: []byte(`{}`)},
+					UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(`{"garbageCollectionTargetPercentage":"62"}`)},
+				},
+			},
+		},
+		{
+			name:     "gogc from unsupportedConfigOverrides clamped to upper bound",
+			template: "{{.GOGC}}",
+			golden:   "100",
+			operatorSpec: &operatorv1.StaticPodOperatorSpec{
+				OperatorSpec: operatorv1.OperatorSpec{
+					ObservedConfig:             runtime.RawExtension{Raw: []byte(`{}`)},
+					UnsupportedConfigOverrides: runtime.RawExtension{Raw: []byte(`{"garbageCollectionTargetPercentage":"101"}`)},
+				},
+			},
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
From the upstream release notes:

> Kubernetes 1.24 bumped version of golang it is compiled with to go1.18, which introduced significant changes to its garbage collection algorithm. As a result, we observed an increase in memory usage for kube-apiserver in larger an heavily loaded clusters up to ~25% (with the benefit of API call latencies drop by up to 10x on 99th percentiles). If the memory increase is not acceptable for you you can mitigate by setting GOGC env variable (for our tests using GOGC=63 brings memory usage back to original value, although the exact value may depend on usage patterns on your cluster).

Since kube-apiserver is managed by an operator on OpenShift, they'll need a configuration knob to tune this value if desired.