### PR TITLE
Bug 2100155: Add new alert on Pod Security violations

### DIFF
--- a/bindata/assets/alerts/podsecurity-violations.yaml
+++ b/bindata/assets/alerts/podsecurity-violations.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: podsecurity
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+  - name: pod-security-violation
+    rules:
+    - alert: PodSecurityViolation
+      annotations:
+        summary: One or more workloads users created in the cluster don't match their Pod Security profile
+        description: >-
+          A workload (pod, deployment, deamonset, ...) was created somewhere in the cluster but it
+          did not match the PodSecurity "{{ $labels.policy_level }}" profile defined by its namespace either via the cluster-wide
+          configuration (which triggers on a "restricted" profile violations) or by the namespace
+          local Pod Security labels.
+          Refer to Kubernetes documentation on Pod Security Admission to learn more about these
+          violations.
+      expr: |
+        sum(increase(pod_security_evaluations_total{decision="deny",mode="audit"}[1d])) by (policy_level) > 0
+      labels:
+        namespace: openshift-kube-apiserver
+        severity: info

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -155,6 +155,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		"assets/alerts/cpu-utilization.yaml",
 		"assets/alerts/kube-apiserver-requests.yaml",
 		"assets/alerts/kube-apiserver-slos-basic.yaml",
+		"assets/alerts/podsecurity-violations.yaml",
 	}
 	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {

--- a/pkg/test/assets_test.go
+++ b/pkg/test/assets_test.go
@@ -26,6 +26,8 @@ func readAllYaml(path string, t *testing.T) {
 			!strings.HasSuffix(info.Name(), "servicemonitor-apiserver.yaml") &&
 			// there is an alert message containing $labels strings that cause the reader to fail.
 			!strings.HasSuffix(info.Name(), "api-usage.yaml") &&
+			// there is an alert message containing $labels strings that cause the reader to fail.
+			!strings.HasSuffix(info.Name(), "podsecurity-violations.yaml") &&
 			// the kas's pod manifest contains go template values and fails compilation
 			!strings.HasSuffix(info.Name(), "pod.yaml")
 


### PR DESCRIPTION
Cluster administrators should be aware when a Pod Security violation
occurs as that might cause workloads to break in the next .y OpenShift
version.

/cc @ibihim @s-urbaniak 