### PR TITLE
bindata/assets/alerts/api-usage: Include removed_release in APIRemovedInNext*ReleaseInUse labels

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -13,10 +13,14 @@ spec:
             description: >-
               Deprecated API that will be removed in the next version is being used. Removing the workload that is using
               the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
-              a successful upgrade to the next cluster version.
+              a successful upgrade to the next cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
-          expr: |
-            group(apiserver_requested_deprecated_apis{removed_release="1.26"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
+          expr: >-
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release="1.26"})
+            * on (group,version,resource) group_left ()
+            sum by (group,version,resource) (
+            rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])
+            ) > 0
           for: 1h
           labels:
             namespace: openshift-kube-apiserver
@@ -27,11 +31,14 @@ spec:
             description: >-
               Deprecated API that will be removed in the next EUS version is being used. Removing the workload that is using
               the {{ $labels.group }}.{{ $labels.version }}/{{ $labels.resource }} API might be necessary for
-              a successful upgrade to the next EUS cluster version.
+              a successful upgrade to the next EUS cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
-          expr: |
-            group(apiserver_requested_deprecated_apis{removed_release=~"1\\.2[67]"}) by (group,version,resource) and (sum by(group,version,resource) (rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h]))) > 0
-
+          expr: >-
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release=~"1[.]2[67]"})
+            * on (group,version,resource) group_left ()
+            sum by (group,version,resource) (
+            rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])
+            ) > 0
           for: 1h
           labels:
             namespace: openshift-kube-apiserver


### PR DESCRIPTION
There may be version skew around updates, where an alert gets bumped to consider 1.26 "the next release" while other cluster components are still running 1.25, or vice versa.  This change makes it a bit easier to understand those skew issues by explicitly including in the alert `description` (and Telemetry-uploaded alert labels) the `removed_release` value we're complaining about.