### PR TITLE
OCPBUGS-5933: Fixed clusterrole for hostmount-anyuid scc

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount-anyuid.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount-anyuid.yaml
@@ -6,12 +6,12 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
-  name: system:openshift:scc:hostmount
+  name: system:openshift:scc:hostmount-anyuid
 rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - hostmount
+  - hostmount-anyuid
   resources:
   - securitycontextconstraints
   verbs:


### PR DESCRIPTION
Fixed the bootkube manifest file for `hostmount-anyuid` SCC, which was wrongly referring to `hostmount` SCC.