### PR TITLE
make PodSecurity admission enforce restricted globally

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -14,12 +14,8 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1beta1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
-          audit: "restricted"
-          audit-version: "latest"
-          warn: "restricted"
-          warn-version: "latest"
         exemptions:
           usernames:
           # The build controller creates pods that are likely to be privileged


### PR DESCRIPTION
Also removes the warn and audit levels as these are driven
by the enforcement policy.

/assign @ibihim 
/assign @deads2k 