### PR TITLE
Update library-go to enable external provider for OpenStack by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6
+	github.com/openshift/library-go v0.0.0-20220727134723-6802b30e83ba
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6 h1:lmfmsIGq62lmj17qrZh4Gbbb86WvJw6pLhCNwNjB2Yk=
-github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
+github.com/openshift/library-go v0.0.0-20220727134723-6802b30e83ba h1:+xG2MTeBZc1P8Fl+LdNgtfe4yZftRyEYV24PJgClj2Q=
+github.com/openshift/library-go v0.0.0-20220727134723-6802b30e83ba/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -24,8 +24,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	switch platformStatus.Type {
 	case configv1.AWSPlatformType,
 		configv1.GCPPlatformType,
-		configv1.VSpherePlatformType,
-		configv1.OpenStackPlatformType:
+		configv1.VSpherePlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -33,7 +32,10 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 			return true, nil
 		}
 		return isExternalFeatureGateEnabled(featureGate)
-	case configv1.IBMCloudPlatformType, configv1.AlibabaCloudPlatformType, configv1.PowerVSPlatformType:
+	case configv1.AlibabaCloudPlatformType,
+		configv1.IBMCloudPlatformType,
+		configv1.OpenStackPlatformType,
+		configv1.PowerVSPlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/images.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	imagesScheme = runtime.NewScheme()
+	imagesCodecs = serializer.NewCodecFactory(imagesScheme)
+)
+
+func init() {
+	if err := imagev1.AddToScheme(imagesScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadImageStreamV1OrDie(objBytes []byte) *imagev1.ImageStream {
+	requiredObj, err := runtime.Decode(imagesCodecs.UniversalDecoder(imagev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*imagev1.ImageStream)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/status/status_controller.go
@@ -143,7 +143,7 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 			return nil
 		}
 		if createErr != nil {
-			syncCtx.Recorder().Warningf("StatusCreateFailed", "Failed to create operator status: %v", err)
+			syncCtx.Recorder().Warningf("StatusCreateFailed", "Failed to create operator status: %v", createErr)
 			return createErr
 		}
 	}
@@ -210,7 +210,7 @@ func (c StatusSyncer) Sync(ctx context.Context, syncCtx factory.SyncContext) err
 	}
 	klog.V(2).Infof("clusteroperator/%s diff %v", c.clusterOperatorName, resourceapply.JSONPatchNoError(originalClusterOperatorObj, clusterOperatorObj))
 
-	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); err != nil {
+	if _, updateErr := c.clusterOperatorClient.ClusterOperators().UpdateStatus(ctx, clusterOperatorObj, metav1.UpdateOptions{}); updateErr != nil {
 		return updateErr
 	}
 	syncCtx.Recorder().Eventf("OperatorStatusChanged", "Status for clusteroperator/%s changed: %s", c.clusterOperatorName, configv1helpers.GetStatusDiff(originalClusterOperatorObj.Status, clusterOperatorObj.Status))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,7 +273,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6
+# github.com/openshift/library-go v0.0.0-20220727134723-6802b30e83ba
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
This PR bumps the library-go dependency to include the change[1] that
enables external cloud provider for OpenStack by default.

[1] https://github.com/openshift/library-go/pull/1383