### PR TITLE
Bug 2094362: Duplicate prometheus rules for API SLOs after upgrade

### DIFF
--- a/bindata/assets/alerts/kube-apiserver-slos.yaml
+++ b/bindata/assets/alerts/kube-apiserver-slos.yaml
@@ -1,0 +1,6 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-apiserver-slos
+  namespace: openshift-kube-apiserver
+spec: {}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -136,6 +136,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	var notOnSingleReplicaTopology resourceapply.ConditionalFunction = func() bool {
 		return infrastructure.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode
 	}
+	var never resourceapply.ConditionalFunction = func() bool { return false }
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
 		"KubeAPIServerStaticResources",
 		bindata.Asset,
@@ -176,6 +177,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	).
 		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml"}, notOnSingleReplicaTopology, nil).
+		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos.yaml"}, never, nil). // TODO remove in 4.13
 		AddKubeInformers(kubeInformersForNamespaces)
 
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -129,45 +129,44 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		WithEventHandler(operatorclient.TargetNamespace, "LateConnections", terminationobserver.ProcessLateConnectionEvents).
 		ToController(kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace), kubeClient.CoreV1(), controllerContext.EventRecorder)
 
-	staticResourceFiles := []string{
-		"assets/kube-apiserver/ns.yaml",
-		"assets/kube-apiserver/svc.yaml",
-		"assets/kube-apiserver/kubeconfig-cm.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrole.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrole-node-reader.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrole-crd-reader.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrolebinding-auth-delegator.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrolebinding-node-reader.yaml",
-		"assets/kube-apiserver/check-endpoints-clusterrolebinding-crd-reader.yaml",
-		"assets/kube-apiserver/check-endpoints-kubeconfig-cm.yaml",
-		"assets/kube-apiserver/check-endpoints-rolebinding-kube-system.yaml",
-		"assets/kube-apiserver/check-endpoints-rolebinding.yaml",
-		"assets/kube-apiserver/control-plane-node-kubeconfig-cm.yaml",
-		"assets/kube-apiserver/delegated-incluster-authentication-rolebinding.yaml",
-		"assets/kube-apiserver/localhost-recovery-client-crb.yaml",
-		"assets/kube-apiserver/localhost-recovery-sa.yaml",
-		"assets/kube-apiserver/localhost-recovery-token.yaml",
-		"assets/kube-apiserver/apiserver.openshift.io_apirequestcount.yaml",
-		"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
-		"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
-		"assets/alerts/api-usage.yaml",
-		"assets/alerts/audit-errors.yaml",
-		"assets/alerts/cpu-utilization.yaml",
-		"assets/alerts/kube-apiserver-requests.yaml",
-		"assets/alerts/kube-apiserver-slos-basic.yaml",
-		"assets/alerts/podsecurity-violations.yaml",
-	}
 	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	if infrastructure.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
-		staticResourceFiles = append(staticResourceFiles, "assets/alerts/kube-apiserver-slos-extended.yaml")
+	var notOnSingleReplicaTopology resourceapply.ConditionalFunction = func() bool {
+		return infrastructure.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode
 	}
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
 		"KubeAPIServerStaticResources",
 		bindata.Asset,
-		staticResourceFiles,
+		[]string{
+			"assets/kube-apiserver/ns.yaml",
+			"assets/kube-apiserver/svc.yaml",
+			"assets/kube-apiserver/kubeconfig-cm.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrole.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrole-node-reader.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrole-crd-reader.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrolebinding-auth-delegator.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrolebinding-node-reader.yaml",
+			"assets/kube-apiserver/check-endpoints-clusterrolebinding-crd-reader.yaml",
+			"assets/kube-apiserver/check-endpoints-kubeconfig-cm.yaml",
+			"assets/kube-apiserver/check-endpoints-rolebinding-kube-system.yaml",
+			"assets/kube-apiserver/check-endpoints-rolebinding.yaml",
+			"assets/kube-apiserver/control-plane-node-kubeconfig-cm.yaml",
+			"assets/kube-apiserver/delegated-incluster-authentication-rolebinding.yaml",
+			"assets/kube-apiserver/localhost-recovery-client-crb.yaml",
+			"assets/kube-apiserver/localhost-recovery-sa.yaml",
+			"assets/kube-apiserver/localhost-recovery-token.yaml",
+			"assets/kube-apiserver/apiserver.openshift.io_apirequestcount.yaml",
+			"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
+			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
+			"assets/alerts/api-usage.yaml",
+			"assets/alerts/audit-errors.yaml",
+			"assets/alerts/cpu-utilization.yaml",
+			"assets/alerts/kube-apiserver-requests.yaml",
+			"assets/alerts/kube-apiserver-slos-basic.yaml",
+			"assets/alerts/podsecurity-violations.yaml",
+		},
 		(&resourceapply.ClientHolder{}).
 			WithKubernetes(kubeClient).
 			WithAPIExtensionsClient(apiextensionsClient).
@@ -175,7 +174,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			WithMigrationClient(migrationClient),
 		operatorClient,
 		controllerContext.EventRecorder,
-	).AddKubeInformers(kubeInformersForNamespaces)
+	).
+		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml"}, notOnSingleReplicaTopology, nil).
+		AddKubeInformers(kubeInformersForNamespaces)
 
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),


### PR DESCRIPTION
- use conditional static resource functionality
- delete prometheusrules/kube-apiserver-slos
