### PR TITLE
bindata/assets/alerts/podsecurity-violations: Set a runbook URI

### DIFF
--- a/bindata/assets/alerts/podsecurity-violations.yaml
+++ b/bindata/assets/alerts/podsecurity-violations.yaml
@@ -17,6 +17,7 @@ spec:
           local Pod Security labels.
           Refer to Kubernetes documentation on Pod Security Admission to learn more about these
           violations.
+        runbook_url: https://access.redhat.com/solutions/6976583
       expr: |
         sum(increase(pod_security_evaluations_total{decision="deny",mode="audit",resource="pod"}[1d])) by (policy_level) > 0
       labels:


### PR DESCRIPTION
To make it easier for admins to figure out what to do when this alert is firing.