### PR TITLE
Bug 2100429: Allow ephemeral volumes in all SCCs

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
@@ -37,6 +37,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
@@ -41,6 +41,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - hostPath
 - persistentVolumeClaim
 - projected

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
@@ -40,6 +40,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - hostPath
 - nfs
 - persistentVolumeClaim

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork-v2.yaml
@@ -42,6 +42,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
@@ -40,6 +40,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot-v2.yaml
@@ -43,6 +43,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
@@ -40,6 +40,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml
@@ -42,6 +42,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
@@ -39,6 +39,7 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret


### PR DESCRIPTION
"`ephemeral`" volumes, called as [Generic Ephemeral Volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) in upstream docs, are volumes represented by a [PersistentVolumeClaim template in a Pod](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes).

`ephemeral` is already part of upstream `restricted` policy: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

Using these volumes is safe for any user, as users with the capability to use "`ephemeral`" volumes can only fool Kubernetes to create PVCs, in the same fashion as users that can create StatefulSets can fool Kubernetes to create PVCs.

In both cases, the created PVC is subject of namespace's PVC quota. From Kubernetes/OCP point of view, it's just a regular PVC. Users won't get ability to create PVs (except for dynamic provisioning) nor ability to refer to an existing volume.

There were multiple discussions on Slack about this:
* https://coreos.slack.com/archives/CB48XQ4KZ/p1655465586780419
* @deads2k's semi-approval: https://coreos.slack.com/archives/CE4L0F143/p1663272051841919

**Note: this is a different feature than "CSI In-line Ephemeral Volumes", which *could* be unsafe and we're working on a way how to fix it in https://github.com/openshift/enhancements/pull/1240**