### PR TITLE
certrotation: rotate faster in test infrastructure

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -103,6 +103,7 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	kubeAPIServerCertRotationController, err := certrotationcontroller.NewCertRotationControllerOnlyWhenExpired(
+		ctx,
 		kubeClient,
 		operatorClient,
 		configInformers,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -274,6 +274,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	}
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
+		ctx,
 		kubeClient,
 		operatorClient,
 		configInformers,


### PR DESCRIPTION
This is kind of dirty, but it gets the job done. With this change, we no longer have to open Jira issues to remind us to revert short rotations before we ship. This way is also not doable in openshift.next when we ship much faster. 