### PR TITLE
serviceaccountissuer: fix case when default value is being used and not trusted after change

### DIFF
--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -29,14 +29,14 @@ func TestServiceAccountIssuer(t *testing.T) {
 
 	t.Run("serviceaccountissuer set in authentication config results in apiserver config", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "https://first.foo.bar")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar"}); err != nil {
+		if err := pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
 			t.Errorf(err.Error())
 		}
 	})
 
 	t.Run("second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "https://second.foo.bar")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar"}); err != nil {
+		if err := pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
 			t.Errorf(err.Error())
 		}
 	})


### PR DESCRIPTION
As documented in https://github.com/openshift/cluster-kube-apiserver-operator/blob/005a95607cf9f8db490e962b549811d8bc0c5eaf/bindata/assets/config/config-overrides.yaml#L8 we set the default value for service account issuer if one is not specified in authentication config. This was missed in the original controller design, and we have to account for this default value. When the user specifies a custom issuer in auth config, we must preserve the default value previously used and keep it as a trusted value.