### PR TITLE
OCPBUGS-3663: Revert "turn PodSecurity admission to enforce restricted globally"

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -14,8 +14,12 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1beta1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
+          audit: "restricted"
+          audit-version: "latest"
+          warn: "restricted"
+          warn-version: "latest"
         exemptions:
           usernames:
           # The build controller creates pods that are likely to be privileged


### PR DESCRIPTION
This reverts commit fe247321ae0f9130ab54b2cf16f6a0b4b5250b54.

