### PR TITLE
OCPBUGS-10577: update apf configuration to use v1beta3

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_08_flowschema.yaml
@@ -1,4 +1,4 @@
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 kind: PriorityLevelConfiguration
 metadata:
   name: openshift-control-plane-operators
@@ -8,7 +8,8 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 spec:
   limited:
-    assuredConcurrencyShares: 10
+    nominalConcurrencyShares: 10
+    lendablePercent: 33
     limitResponse:
       queuing:
         handSize: 6
@@ -17,7 +18,7 @@ spec:
       type: Queue
   type: Limited
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 kind: FlowSchema
 metadata:
   name: openshift-monitoring-metrics
@@ -43,7 +44,7 @@ spec:
         name: prometheus-k8s
         namespace: openshift-monitoring
 ---
-apiVersion: flowcontrol.apiserver.k8s.io/v1beta2
+apiVersion: flowcontrol.apiserver.k8s.io/v1beta3
 kind: FlowSchema
 metadata:
   name: openshift-kube-apiserver-operator


### PR DESCRIPTION
- `assuredConcurrencyShares` has been rename to `nominalConcurrencyShares`
- two new field `lendablePercent` and `borrowingLimitPercent` have been added for borrowing

https://github.com/kubernetes/kubernetes/blob/172431ebf15b9d85406202365c697a7b925e0efe/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go#L476-L503

we have a dedicated PriorityLevel for our control plane operators, and we are saying that 33% of its capacity can be borrowed by other priority levels if need be.
