### PR TITLE
Drop flags removed in k8s 1.26

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -44,8 +44,6 @@ spec:
     - >
       hyperkube kube-apiserver
       --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }}
-      --logtostderr=false
-      --alsologtostderr
       --v=2
       --log-file=/var/log/bootstrap-control-plane/kube-apiserver.log
       --advertise-address=${HOST_IP}


### PR DESCRIPTION
These flags were removed in https://github.com/kubernetes/kubernetes/pull/112120, based on [the defaults](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md#logging-defaults)  we should be good with just dropping these flags. 