### PR TITLE
make the bootstrap kube-apiserver honor cluster-wide featuregates

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -49,13 +49,8 @@ apiServerArguments:
     - /etc/kubernetes/secrets/etcd-client.key
   etcd-servers: {{range .EtcdServerURLs}}
     - {{.}}{{end}}
-  feature-gates:
-    - "APIPriorityAndFairness=true"
-    - "RotateKubeletServerCertificate=true"
-    - "DownwardAPIHugePages=true"
-{{- if .ServiceCIDR | len | eq 2}}
-    - "IPv6DualStack=true"
-{{- end}}
+  feature-gates: {{range .FeatureGates}}
+    - {{.}}{{end}}
   kubelet-certificate-authority:
     - /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
   kubelet-client-certificate:


### PR DESCRIPTION
This is a precursor to a future update that will enable the new discovery API once we update to 1.26.  We want the *only* form of discovery ever available to be aggregated so that we can flush out problems in our new install clusters instead of having clients coast on caches.

/assign @tkashem
/cc @soltysh 