### PR TITLE
OCPBUGS-3290: routes/status resources can leak sensitive data, exclude it from audit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20221013123534-96eec44e1979
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6
+	github.com/openshift/library-go v0.0.0-20230104152328-aca20b161f79
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6 h1:lmfmsIGq62lmj17qrZh4Gbbb86WvJw6pLhCNwNjB2Yk=
-github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
+github.com/openshift/library-go v0.0.0-20230104152328-aca20b161f79 h1:ghYrjHMsBHZNvvnpTsd0ILuc89kI/YXnq5gYYeJzUoM=
+github.com/openshift/library-go v0.0.0-20230104152328-aca20b161f79/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -2,7 +2,7 @@
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -2,7 +2,7 @@
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes","routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/audit-policies-cm-scenario-1.yaml
@@ -72,7 +72,7 @@ data:
     - level: Metadata
       resources:
       - group: "route.openshift.io"
-        resources: ["routes"]
+        resources: ["routes", "routes/status"]
       - resources: ["secrets"]
     - level: Metadata
       resources:
@@ -121,7 +121,7 @@ data:
     - level: Metadata
       resources:
       - group: "route.openshift.io"
-        resources: ["routes"]
+        resources: ["routes", "routes/status"]
       - resources: ["secrets"]
     - level: Metadata
       resources:

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
@@ -62,7 +62,7 @@ rules:
 - level: Metadata
   resources:
     - group: "route.openshift.io"
-      resources: ["routes"]
+      resources: ["routes", "routes/status"]
     - resources: ["secrets"]
     - group: "authentication.k8s.io"
       resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -32,7 +32,7 @@ rules:
 - level: Metadata
   resources:
   - group: "route.openshift.io"
-    resources: ["routes"]
+    resources: ["routes", "routes/status"]
   - resources: ["secrets"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,7 +285,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220622115547-84d884f4c9f6
+# github.com/openshift/library-go v0.0.0-20230104152328-aca20b161f79
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
re-vendor library-go