### PR TITLE
Revert "drop log-file flag removed in 1.26"

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -45,8 +45,8 @@ spec:
       hyperkube kube-apiserver
       --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }}
       --v=2
+      --log-file=/var/log/bootstrap-control-plane/kube-apiserver.log
       --advertise-address=${HOST_IP}
-      &> /var/log/bootstrap-control-plane/kube-apiserver.log
     resources:
       requests:
         memory: 1Gi


### PR DESCRIPTION
This reverts commit 6d1def163cf897b6ca54da16bdc1f444bbae5607.

This results in log files getting wiped on restart, I'm also investigating some CI failures and would like to rule
this out as a cause. 