### PR TITLE
remove use of deprecated klog flags

### DIFF
--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -45,7 +45,6 @@ spec:
       hyperkube kube-apiserver
       --openshift-config=/etc/kubernetes/config/{{ .ConfigFileName }}
       --v=2
-      --log-file=/var/log/bootstrap-control-plane/kube-apiserver.log
       --advertise-address=${HOST_IP}
     resources:
       requests:


### PR DESCRIPTION
Previously deprecated klog flags will be removed completely in kube 1.26.
Logs of bootstrap pods were previously using the --log-file flag, will be available in the cri-o container logs instead.