### PR TITLE
OCPBUGS-5873: dashboard: use apiserver_storage_objects metric

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -3170,7 +3170,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(25, max(etcd_object_counts) by (resource))",
+              "expr": "topk(25, max(apiserver_storage_objects) by (resource))",
               "interval": "",
               "legendFormat": "{{resource}}",
               "refId": "A"


### PR DESCRIPTION
The etcd_object_counts metric is deprecated and was replaced by the stable apiserver_storage_objects metric.