### PR TITLE
[4.12] OCPBUGS-6789: make the bootstrap kube-apiserver honor cluster-wide featuregates

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -49,15 +49,8 @@ apiServerArguments:
     - /etc/kubernetes/secrets/etcd-client.key
   etcd-servers: {{range .EtcdServerURLs}}
     - {{.}}{{end}}
-  feature-gates:
-    - "APIPriorityAndFairness=true"
-    - "RotateKubeletServerCertificate=true"
-    - "DownwardAPIHugePages=true"
-    - "CSIMigrationAzureFile=false"
-    - "CSIMigrationvSphere=false"
-{{- if .ServiceCIDR | len | eq 2}}
-    - "IPv6DualStack=true"
-{{- end}}
+  feature-gates: {{range .FeatureGates}}
+    - {{.}}{{end}}
   kubelet-certificate-authority:
     - /etc/kubernetes/secrets/kubelet-client-ca-bundle.crt # this is wired to the KCM CSR, which signs serving and client certs for kubelet
   kubelet-client-certificate:


### PR DESCRIPTION
this is a backport of https://github.com/openshift/cluster-kube-apiserver-operator/pull/1419

/cc @deads2k @ibihim 