### PR TITLE
OCPBUGS-8477: e2e: disable issuer revocation test

### DIFF
--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -28,6 +28,7 @@ func TestServiceAccountIssuer(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("serviceaccountissuer set in authentication config results in apiserver config", func(t *testing.T) {
+		t.Skip()
 		setServiceAccountIssuer(t, authConfigClient, "https://first.foo.bar")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
 			t.Errorf(err.Error())
@@ -35,6 +36,7 @@ func TestServiceAccountIssuer(t *testing.T) {
 	})
 
 	t.Run("second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func(t *testing.T) {
+		t.Skip()
 		setServiceAccountIssuer(t, authConfigClient, "https://second.foo.bar")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
 			t.Errorf(err.Error())
@@ -42,6 +44,7 @@ func TestServiceAccountIssuer(t *testing.T) {
 	})
 
 	t.Run("no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func(t *testing.T) {
+		t.Skip()
 		setServiceAccountIssuer(t, authConfigClient, "")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc"}); err != nil {
 			t.Errorf(err.Error())


### PR DESCRIPTION
The service account issuer mechanism has a special revocation procedure. When the issuer is set to an empty string, the service account token issuer is **immediately** revoked, and existing tokens with the previous issuer are invalid.
This is to support a case when the cluster is compromised. Unfortunately, when we try to do this in an e2e test, the immediate revocation causes some components to use tokens with invalid issuers and therefore, the tokens fail authentication. This manifests as an "Unauthorized" error.