### PR TITLE
OCPBUGS-8478: Disable TestBoundTokenSignerController

### DIFF
--- a/test/e2e/bound_sa_token_test.go
+++ b/test/e2e/bound_sa_token_test.go
@@ -51,7 +51,7 @@ func TestBoundTokenSignerController(t *testing.T) {
 
 	// The operand secret should be recreated after deletion.
 	t.Run("operand-secret-deletion", func(t *testing.T) {
-
+		t.Skip()
 		err := kubeClient.Secrets(targetNamespace).Delete(context.TODO(), tokenctl.SigningKeySecretName, metav1.DeleteOptions{})
 		require.NoError(t, err)
 		checkBoundTokenOperandSecret(t, kubeClient, regularTimeout, operatorSecret.Data)
@@ -60,6 +60,7 @@ func TestBoundTokenSignerController(t *testing.T) {
 	// The operand config map should be recreated after deletion.
 	// Note: it will roll out a new version
 	t.Run("configmap-deletion", func(t *testing.T) {
+		t.Skip()
 		err := kubeClient.ConfigMaps(targetNamespace).Delete(context.TODO(), tokenctl.PublicKeyConfigMapName, metav1.DeleteOptions{})
 		require.NoError(t, err)
 		checkCertConfigMap(t, kubeClient, map[string]string{
@@ -76,6 +77,7 @@ func TestBoundTokenSignerController(t *testing.T) {
 	//
 	// Note: it will roll out a new version
 	t.Run("operator-secret-deletion", func(t *testing.T) {
+		t.Skip()
 		// Delete the operator secret
 		err := kubeClient.Secrets(operatorNamespace).Delete(context.TODO(), tokenctl.NextSigningKeySecretName, metav1.DeleteOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
We need to disable this test for now because it puts the CI cluster in an unstable state.

https://issues.redhat.com/browse/OCPBUGS-8529 is a blocker bug against OpenShift 4.13 that tracks the effort of fixing this behavior.