### PR TITLE
manifests: run with OPENSHIFT_PROFILE=web

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_06_deployment.yaml
@@ -71,6 +71,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: OPENSHIFT_PROFILE
+          value: web
         terminationMessagePolicy: FallbackToLogsOnError
       volumes:
       - name: serving-cert


### PR DESCRIPTION
This will enable profiling endpoint running on pod's localhost