### PR TITLE
OCPBUGS-8404: pkg/operator/configobserver: check that the serving certificate refer…

### DIFF
--- a/test/e2e/user_certs_test.go
+++ b/test/e2e/user_certs_test.go
@@ -56,13 +56,16 @@ func TestNamedCertificates(t *testing.T) {
 
 	// create secrets for named serving certificates
 	for _, info := range testCertInfoById {
-		defer func(info *testCertInfo) {
-			err := deleteSecret(kubeClient, "openshift-config", info.secretName)
-			require.NoError(t, err)
-		}(info)
 		_, err := createTLSSecret(kubeClient, "openshift-config", info.secretName, info.crypto.PrivateKey, info.crypto.Certificate)
 		require.NoError(t, err)
 	}
+
+	defer func() {
+		for _, info := range testCertInfoById {
+			err := deleteSecret(kubeClient, "openshift-config", info.secretName)
+			require.NoError(t, err)
+		}
+	}()
 
 	// configure named certificates
 	defer func() {


### PR DESCRIPTION
…ence exists before applying

Ensure that .spec.servingCerts.namedCertificates[*].servingCertificate.Name exists before applying. This prevents a typo or a missing/inaccessible certificate from being referenced in kube-apiserver pod and prevents crashlooping and recovery operation.

Tested this manually and now when invalid secretref is set, no rollouts occur and the operator sets Degraded message "ConfigObservationDegraded: secret "foobar" not found", but Degraded=False