### PR TITLE
Cover featuregate access errors in PSA configobserver unit tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20230424202542-f7a9b7696bc2
 	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
-	github.com/openshift/library-go v0.0.0-20230425132011-00923e044766
+	github.com/openshift/library-go v0.0.0-20230425205800-ab66adbd0bb5
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU
 github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/library-go v0.0.0-20230425132011-00923e044766 h1:pENkmo53xgk2+QsTdoClC50Vnb92wJ4rq+LWiNgujX4=
-github.com/openshift/library-go v0.0.0-20230425132011-00923e044766/go.mod h1:tUWJLc0m8/1GyMKXFKZMWWfaGtFhX1T6kdcGtiGtZIE=
+github.com/openshift/library-go v0.0.0-20230425205800-ab66adbd0bb5 h1:U+Cdda576x6c0s9PlTFf+JXSHUkPjg1u3Smb/piRTyc=
+github.com/openshift/library-go v0.0.0-20230425205800-ab66adbd0bb5/go.mod h1:tUWJLc0m8/1GyMKXFKZMWWfaGtFhX1T6kdcGtiGtZIE=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
@@ -38,9 +38,10 @@ type FeatureGateAccess interface {
 
 	// Run starts a go func that continously watches the set of featuregates enabled in the cluster.
 	Run(ctx context.Context)
-	// InitialFeatureGatesObserved returns a channel that is closed once the featuregates have been observed.
-	// Once closed, the CurrentFeatureGates method can be called successfully.
-	InitialFeatureGatesObserved() chan struct{}
+	// InitialFeatureGatesObserved returns a channel that is closed once the featuregates have
+	// been observed. Once closed, the CurrentFeatureGates method will return the current set of
+	// featuregates and will never return a non-nil error.
+	InitialFeatureGatesObserved() <-chan struct{}
 	// CurrentFeatureGates returns the list of enabled and disabled featuregates.
 	// It returns an error if the current set of featuregates is not known.
 	CurrentFeatureGates() (enabled []configv1.FeatureGateName, disabled []configv1.FeatureGateName, err error)
@@ -254,7 +255,7 @@ func (c *defaultFeatureGateAccess) setFeatureGates(features Features) {
 	}
 }
 
-func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() chan struct{} {
+func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
 	return c.initialFeatureGatesObserved
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,7 +324,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230425132011-00923e044766
+# github.com/openshift/library-go v0.0.0-20230425205800-ab66adbd0bb5
 ## explicit; go 1.19
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Minor follow-up for https://github.com/openshift/cluster-kube-apiserver-operator/pull/1485#pullrequestreview-1400370715.