### PR TITLE
OCPBUGS-2765: dont log tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ $ oc adm release new --from-release=registry.svc.ci.openshift.org/openshift/orig
 $ cd ../installer
 $ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/sttts/origin-release:latest bin/openshift-install cluster ...
 ```
+1685115426

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
 	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
-	github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a
+	github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -453,6 +453,8 @@ github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrk
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
 github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a h1:GWDlGsHQUo2QaXG8r4nCAbAMAYNN85HOMt+vZSLBOdQ=
 github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
+github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf h1:ZpFAN2qprgp7jEhGPrOAwP8mmuYC9BRYzvDefg+k4GM=
+github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,6 @@ github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU
 github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrkmcRQMAE9LMbQXPo95aqFnf+12B7SyFVI=
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
-github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a h1:GWDlGsHQUo2QaXG8r4nCAbAMAYNN85HOMt+vZSLBOdQ=
-github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf h1:ZpFAN2qprgp7jEhGPrOAwP8mmuYC9BRYzvDefg+k4GM=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -3,10 +3,10 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -3,11 +3,11 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -33,10 +33,10 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes","routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests
@@ -63,11 +63,11 @@ rules:
   resources:
     - group: "route.openshift.io"
       resources: ["routes", "routes/status"]
-    - resources: ["secrets"]
+    - resources: ["secrets", serviceaccounts/token]
     - group: "authentication.k8s.io"
       resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
-      resources: ["oauthclients"]
+      resources: ["oauthclients", "tokenreviews"]
   userGroups:
     - system:authenticated
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -330,7 +330,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230503173034-95ca3c14e50a
+# github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
# What

Bump library-go as a follow up on https://github.com/openshift/library-go/pull/1500.

# Why

The library-go update doesn't do anything if not used.

FYI: @soltysh, @stlaz 