### PR TITLE
OCPBUGS-13946: degraded_webhook.go x509: certificate signed by unknown authority

### DIFF
--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
@@ -49,7 +49,7 @@ func (c *webhookSupportabilityController) updateWebhookConfigurationDegraded(ctx
 				serviceMsgs = append(serviceMsgs, msg)
 				continue
 			}
-			err = c.assertConnect(ctx, webhook.Service, webhook.CABundle)
+			err = c.assertConnect(ctx, webhook.Name, webhook.Service, webhook.CABundle)
 			if err != nil {
 				msg := fmt.Sprintf("%s: %s", webhook.Name, err)
 				if webhook.FailurePolicyIsIgnore {
@@ -94,7 +94,7 @@ func (c *webhookSupportabilityController) assertService(reference *serviceRefere
 }
 
 // assertConnect performs a dns lookup of service, opens a tcp connection, and performs a tls handshake.
-func (c *webhookSupportabilityController) assertConnect(ctx context.Context, reference *serviceReference, caBundle []byte) error {
+func (c *webhookSupportabilityController) assertConnect(ctx context.Context, webhookName string, reference *serviceReference, caBundle []byte) error {
 	host := reference.Name + "." + reference.Namespace + ".svc"
 	port := "443"
 	if reference.Port != nil {
@@ -125,7 +125,7 @@ func (c *webhookSupportabilityController) assertConnect(ctx context.Context, ref
 		if err != nil {
 			if i != 2 {
 				// log err since only last one is reported
-				runtime.HandleError(err)
+				runtime.HandleError(fmt.Errorf("%s: %v", webhookName, err))
 			}
 			continue
 		}


### PR DESCRIPTION
This PR puts the name of the webook into the log file which makes debugging easier.

In addition to that I have realised that the controller reacts to changes made to any CRD which increases the frequency of running checks. I changed the controller to react only to changes made to CRDs that have webhook configuration defined.

On my local cluster (4.14) I have noticed frequent changes to `egressqoses.k8s.ovn.org` and `egressfirewalls.k8s.ovn.org` CRDs

```
oc get crds egressqoses.k8s.ovn.org -w
oc get crds egressfirewalls.k8s.ovn.org -w
```


![Screenshot 2023-05-30 at 11 31 34](https://github.com/openshift/cluster-kube-apiserver-operator/assets/21304151/2573b8d5-d626-4d57-9807-d28dec00556c)

Perhaps only changes to the `managedField` but still worth further investigation.
@oarribas would you be interested in taking a closer look at ^ ?

TODO: (separate PRs)

[X] I found out that the `Controller %q resync interval is set to %s which might lead to client request throttling` event is misleading when the `resync` interval is set to `0` - in such case resyncing is disabled. (addressed in https://github.com/openshift/library-go/pull/1535)

[ ] I found out that the dial timeout to a webook is set to `1` second which seems to be very aggressive. We could read the timeout for a webhook from the spec (or the default value of 10 second if not specified) and perhaps use only X% of the total timeout when running the check.
