### PR TITLE
OCPBUGS-14940: api_performance_dashboard: show apiserver_longrunning_requests metric

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -1109,7 +1109,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(20, sum(apiserver_longrunning_gauge{apiserver=\"$apiserver\"}) by(resource))",
+              "expr": "topk(20, sum(apiserver_longrunning_requests{apiserver=\"$apiserver\"}) by(resource))",
               "interval": "",
               "legendFormat": "{{resource}}",
               "refId": "A"
@@ -1206,7 +1206,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(apiserver_longrunning_gauge{apiserver=\"$apiserver\"}) by(instance)",
+              "expr": "sum(apiserver_longrunning_requests{apiserver=\"$apiserver\"}) by(instance)",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"


### PR DESCRIPTION
It looks like the previous metric used in the dashboard (`apiserver_longrunning_gauge`) metric was depreciated in `1.23` (upstream) - https://github.com/kubernetes/kubernetes/issues/103441

The new metric is `apiserver_longrunning_requests`(used in this PR)  - https://github.com/kubernetes/kubernetes/pull/103799/files

The old metric was removed in https://github.com/kubernetes/kubernetes/commit/731397086b763b9a951a414d37018f7e4f03b99c
and at the same time the new metrics was promoted to "STABLE" level.
