### PR TITLE
OCPBUGS-14496: manifests: fix the scope of the TechPreviewNoUpgrade alert

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_03_servicemonitor.yaml
@@ -51,7 +51,7 @@ spec:
           Cluster has enabled Technology Preview features that cannot be undone and will prevent upgrades.
           The TechPreviewNoUpgrade feature set is not recommended on production clusters.
       expr: |
-        cluster_feature_set{name!="", namespace="openshift-kube-apiserver-operator"} == 0
+        cluster_feature_set{name=~"TechPreviewNoUpgrade|CustomNoUpgrade", namespace="openshift-kube-apiserver-operator"} == 0
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
The TechPreviewNoUpgrade alert used to have an expression that was only excluding the default feature set meaning that all other feature set were reported as causing the cluster to be unupgradeable. However, that is not the case for the LatencySensitive feature set. As such, this change limit the list of feature set causing this alert to fire to:

  - TechPreviewNoUpgrade
  - CustomNoUpgrade

Also, since the original name of this alert wasn't generic enough compare to its scope, it was renamed to UnsupportedFeatureSetEnabled.