### PR TITLE
api_performance_dashboard: show apiserver_longrunning_requests metric

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -248,8 +248,8 @@ spec:
       expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, group, kind)
     - record: group_kind:apiserver_watch_events_sizes_sum:rate5m
       expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, group, kind)
-    - record: group_kind:apiserver_registered_watchers:sum
-      expr: sum(apiserver_registered_watchers{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, group, kind)
+    - record: group_resource:apiserver_longrunning_requests:sum
+      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, group, resource)
     - record: cluster:apiserver_tls_handshake_errors_total:rate1m
       expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver)
     - record: cluster:apiserver_tls_handshake_errors_total:rate5m

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -2939,10 +2939,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(25, group_kind:apiserver_registered_watchers:sum{apiserver=\"$apiserver\"})",
+              "expr": "topk(25, group_resource:apiserver_longrunning_requests:sum{apiserver=\"$apiserver\"})",
               "format": "time_series",
               "interval": "",
-              "legendFormat": "{{group}}:{{kind}}",
+              "legendFormat": "{{group}}:{{resource}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
the `prevoius apiserver_registered_watchers` metric was depreciated in https://github.com/kubernetes/kubernetes/pull/110337

grouping by `group` and `resource` gives us:
![Screenshot 2023-06-22 at 12 14 57](https://github.com/openshift/cluster-kube-apiserver-operator/assets/21304151/b1e019d1-05cd-45f4-9cf0-491f779de5f8)

grouping by `group` only gives us:
![Screenshot 2023-06-22 at 12 15 12](https://github.com/openshift/cluster-kube-apiserver-operator/assets/21304151/501ce64c-90a0-4d20-8648-0ec76f07399d)

an empty `group` indicates the `core` group, not sure if it could be shown somehow. 
