### PR TITLE
OCPBUGS-497: Change service used to collect metrics

### DIFF
--- a/bindata/assets/kube-apiserver/svc.yaml
+++ b/bindata/assets/kube-apiserver/svc.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   namespace: openshift-kube-apiserver
   name: apiserver
+  labels:
+    app: kube-apiserver
 spec:
   type: ClusterIP
   selector:

--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -110,11 +110,10 @@ spec:
   jobLabel: component
   namespaceSelector:
     matchNames:
-    - default
+    - openshift-kube-apiserver
   selector:
     matchLabels:
-      component: apiserver
-      provider: kubernetes
+      app: kube-apiserver
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
Instead of using the default kubernetes service for kube-apiserver metrics' collection, we should use the service in the openshift-kube-apiserver which provide more accurate endpoint availability.

This solves an issue where only two endpoints were reported in the default service instead of three.