### PR TITLE
api_performance_dashboard: show apiserver_request_total instead of apiserver_dropped_requests

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -172,10 +172,10 @@ spec:
       expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[1m])) by (apiserver)
     - record: write:apiserver_request_total:rate5m
       expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[5m])) by (apiserver)
-    - record: request_kind:apiserver_dropped_requests_total:rate1m
-      expr: sum(rate(apiserver_dropped_requests_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, request_kind)
-    - record: request_kind:apiserver_dropped_requests_total:rate5m
-      expr: sum(rate(apiserver_dropped_requests_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, request_kind)
+    - record: group_resource:apiserver_request_total:rate1m
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",code="429"}[1m])) by (apiserver, group, resource)
+    - record: group_resource:apiserver_request_total:rate5m
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",code="429"}[5m])) by (apiserver, group, resource)
     - record: component_resource:apiserver_request_terminations_total:rate:1m
       expr: sum(rate(apiserver_request_terminations_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, component, resource)
     - record: component_resource:apiserver_request_terminations_total:rate:5m

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -718,9 +718,9 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "request_kind:apiserver_dropped_requests_total:rate$period{apiserver=\"$apiserver\"}",
+              "expr": "group_resource:apiserver_request_total:rate$period{apiserver=\"$apiserver\"}",
               "interval": "",
-              "legendFormat": "{{request_kind}}",
+              "legendFormat": "{{group}}:{{resource}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
the prevoius `apiserver_dropped_requests` metric was depreciated in https://github.com/kubernetes/kubernetes/pull/110337

xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1518