### PR TITLE
OCPBUGS-15489: manifests: add new PrometheusRule for recording rules

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -153,118 +153,118 @@ spec:
   - name: api-performance
     rules:
     - record: resource_verb:apiserver_request_duration_seconds_bucket:rate:1m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[1m])) by (apiserver, resource, verb, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[1m])) by (apiserver, resource, verb, le)
     - record: resource_verb:apiserver_request_duration_seconds_bucket:rate:5m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[5m])) by (apiserver, resource, verb, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[5m])) by (apiserver, resource, verb, le)
     - record: list:apiserver_request_duration_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"LIST|GET"}[1m])) by (apiserver, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"LIST|GET"}[1m])) by (apiserver, le)
     - record: list:apiserver_request_duration_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"LIST|GET"}[5m])) by (apiserver, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"LIST|GET"}[5m])) by (apiserver, le)
     - record: write:apiserver_request_duration_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[1m])) by (apiserver, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[1m])) by (apiserver, le)
     - record: write:apiserver_request_duration_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[5m])) by (apiserver, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[5m])) by (apiserver, le)
     - record: verb:apiserver_request_duration_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[1m])) by (apiserver, verb, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[1m])) by (apiserver, verb, le)
     - record: verb:apiserver_request_duration_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[5m])) by (apiserver, verb, le)
+      expr: sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",subresource!~"proxy|attach|log|exec|portforward",verb!~"WATCH|WATCHLIST|PROXY"}[5m])) by (apiserver, verb, le)
     - record: operation:etcd_request_duration_seconds_bucket:rate1m
       expr: sum(rate(etcd_request_duration_seconds_bucket[1m])) by (operation, le)
     - record: operation:etcd_request_duration_seconds_bucket:rate5m
       expr: sum(rate(etcd_request_duration_seconds_bucket[5m])) by (operation, le)
     - record: resource_verb:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, resource, verb)
     - record: resource_verb:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, resource, verb)
     - record: read:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"LIST|GET"}[1m])) by (apiserver)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"LIST|GET"}[1m])) by (apiserver)
     - record: read:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"LIST|GET"}[5m])) by (apiserver)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"LIST|GET"}[5m])) by (apiserver)
     - record: write:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[1m])) by (apiserver)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[1m])) by (apiserver)
     - record: write:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[5m])) by (apiserver)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[5m])) by (apiserver)
     - record: group_resource:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",code="429"}[1m])) by (apiserver, group, resource)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",code="429"}[1m])) by (apiserver, group, resource)
     - record: group_resource:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver",code="429"}[5m])) by (apiserver, group, resource)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver",code="429"}[5m])) by (apiserver, group, resource)
     - record: component_resource:apiserver_request_terminations_total:rate:1m
-      expr: sum(rate(apiserver_request_terminations_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, component, resource)
+      expr: sum(rate(apiserver_request_terminations_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, component, resource)
     - record: component_resource:apiserver_request_terminations_total:rate:5m
-      expr: sum(rate(apiserver_request_terminations_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, component, resource)
+      expr: sum(rate(apiserver_request_terminations_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, component, resource)
     - record: code:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, code)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, code)
     - record: code:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, code)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, code)
     - record: instance:apiserver_request_total:rate1m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, instance)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, instance)
     - record: instance:apiserver_request_total:rate5m
-      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, instance)
+      expr: sum(rate(apiserver_request_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, instance)
     - record: resource:apiserver_longrunning_requests:sum
-      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, resource)
+      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, resource)
     - record: instance:apiserver_longrunning_requests:sum
-      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, instance)
+      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, instance)
     - record: instance_request_kind:apiserver_current_inflight_requests:sum
-      expr: sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, instance, request_kind)
+      expr: sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, instance, request_kind)
     - record: instance:apiserver_response_sizes_sum:rate1m
-      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, instance)
+      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, instance)
     - record: instance:apiserver_response_sizes_sum:rate5m
-      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, instance)
+      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, instance)
     - record: resource_verb:apiserver_response_sizes_sum:rate1m
-      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, resource, verb)
     - record: resource_verb:apiserver_response_sizes_sum:rate5m
-      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_response_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, resource, verb)
     - record: flow_schema_priority_reason:apiserver_flowcontrol_request_queue_length_after_enqueue_bucket:rate1m
-      expr: sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, reason, le)
+      expr: sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, reason, le)
     - record: flow_schema_priority_reason:apiserver_flowcontrol_request_queue_length_after_enqueue_bucket:rate5m
-      expr: sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, reason, le)
+      expr: sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, reason, le)
     - record: flow_schema_priority_level:apiserver_flowcontrol_request_wait_duration_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver", execute="true"}[1m])) by (apiserver, flow_schema, priority_level, le)
+      expr: sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver", execute="true"}[1m])) by (apiserver, flow_schema, priority_level, le)
     - record: flow_schema_priority_level:apiserver_flowcontrol_request_wait_duration_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver", execute="true"}[5m])) by (apiserver, flow_schema, priority_level, le)
+      expr: sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver", execute="true"}[5m])) by (apiserver, flow_schema, priority_level, le)
     - record: flow_schema_priority_level_reason:apiserver_flowcontrol_rejected_requests_total:rate1m
-      expr: sum(rate(apiserver_flowcontrol_rejected_requests_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, reason)
+      expr: sum(rate(apiserver_flowcontrol_rejected_requests_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, reason)
     - record: flow_schema_priority_level_reason:apiserver_flowcontrol_rejected_requests_total:rate5m
-      expr: sum(rate(apiserver_flowcontrol_rejected_requests_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, reason)
+      expr: sum(rate(apiserver_flowcontrol_rejected_requests_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, reason)
     - record: flow_schema_priority_level_le:apiserver_flowcontrol_request_execution_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, le)
+      expr: sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, flow_schema, priority_level, le)
     - record: flow_schema_priority_level_le:apiserver_flowcontrol_request_execution_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, le)
+      expr: sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, flow_schema, priority_level, le)
     - record: flow_schema_priority_level:apiserver_flowcontrol_request_execution_seconds_bucket:rate1m
       expr: sum without (le) (flow_schema_priority_level_le:apiserver_flowcontrol_request_execution_seconds_bucket:rate1m)
     - record: flow_schema_priority_level:apiserver_flowcontrol_request_execution_seconds_bucket:rate5m
       expr: sum without (le) (flow_schema_priority_level_le:apiserver_flowcontrol_request_execution_seconds_bucket:rate5m)
     - record: flow_schema_priority_level:apiserver_flowcontrol_current_executing_requests:sum
-      expr: sum(apiserver_flowcontrol_current_executing_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, flow_schema, priority_level)
+      expr: sum(apiserver_flowcontrol_current_executing_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, flow_schema, priority_level)
     - record: priority_level:apiserver_flowcontrol_request_concurrency_limit:sum
-      expr: sum(apiserver_flowcontrol_request_concurrency_limit{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, priority_level)
+      expr: sum(apiserver_flowcontrol_request_concurrency_limit{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, priority_level)
     - record: flow_schema_priority_level:apiserver_flowcontrol_current_inqueue_requests:sum
-      expr: sum(apiserver_flowcontrol_current_inqueue_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, flow_schema, priority_level)
+      expr: sum(apiserver_flowcontrol_current_inqueue_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, flow_schema, priority_level)
     - record: resource_verb:apiserver_selfrequest_total:rate1m
-      expr: sum(rate(apiserver_selfrequest_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_selfrequest_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, resource, verb)
     - record: resource_verb:apiserver_selfrequest_total:rate5m
-      expr: sum(rate(apiserver_selfrequest_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_selfrequest_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, resource, verb)
     - record: resource_verb:apiserver_request_aborts_total:rate1m
-      expr: sum(rate(apiserver_request_aborts_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_request_aborts_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, resource, verb)
     - record: resource_verb:apiserver_request_aborts_total:rate5m
-      expr: sum(rate(apiserver_request_aborts_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, resource, verb)
+      expr: sum(rate(apiserver_request_aborts_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, resource, verb)
     - record: filter:apiserver_request_filter_duration_seconds_bucket:rate1m
-      expr: sum(rate(apiserver_request_filter_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, filter, le)
+      expr: sum(rate(apiserver_request_filter_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, filter, le)
     - record: filter:apiserver_request_filter_duration_seconds_bucket:rate5m
-      expr: sum(rate(apiserver_request_filter_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, filter, le)
+      expr: sum(rate(apiserver_request_filter_duration_seconds_bucket{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, filter, le)
     - record: group_kind:apiserver_watch_events_total:rate1m
-      expr: sum(rate(apiserver_watch_events_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, group, kind)
+      expr: sum(rate(apiserver_watch_events_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, group, kind)
     - record: group_kind:apiserver_watch_events_total:rate5m
-      expr: sum(rate(apiserver_watch_events_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, group, kind)
+      expr: sum(rate(apiserver_watch_events_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, group, kind)
     - record: group_kind:apiserver_watch_events_sizes_sum:rate1m
-      expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver, group, kind)
+      expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver, group, kind)
     - record: group_kind:apiserver_watch_events_sizes_sum:rate5m
-      expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver, group, kind)
+      expr: sum(rate(apiserver_watch_events_sizes_sum{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver, group, kind)
     - record: group_resource:apiserver_longrunning_requests:sum
-      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, group, resource)
+      expr: sum(apiserver_longrunning_requests{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, group, resource)
     - record: cluster:apiserver_tls_handshake_errors_total:rate1m
-      expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver"}[1m])) by (apiserver)
+      expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[1m])) by (apiserver)
     - record: cluster:apiserver_tls_handshake_errors_total:rate5m
-      expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver"}[5m])) by (apiserver)
+      expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver)
     - record: resource:apiserver_storage_objects:max
-      expr: max(apiserver_storage_objects{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver, resource)
+      expr: max(apiserver_storage_objects{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, resource)

--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -138,6 +138,18 @@ spec:
     - record: cluster:apiserver_current_inflight_requests:sum:max_over_time:2m
       expr: |
         max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,request_kind)[2m:])
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-apiserver-recording-rules
+  namespace: openshift-kube-apiserver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  groups:
   - name: api-performance
     rules:
     - record: resource_verb:apiserver_request_duration_seconds_bucket:rate:1m

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -3323,7 +3323,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "API Performance v2",
+      "title": "API Performance",
       "uid": "X9gzM6XFF",
       "version": 2
     }


### PR DESCRIPTION
In https://github.com/openshift/cluster-kube-apiserver-operator/pull/1484 recording rules were added to the PrometheusRule which was supposed to be removed by CVO (it has `release.openshift.io/delete: "true"` annotation). This PR moves recording rules to a new PrometheusRule - and fixes missing datapoints on apiservers dashboard.

After https://github.com/openshift/cluster-authentication-operator/pull/616 was merged openshift-oauth-apiserver is available on the dashboard, so this PR updates recording rules to include it as well.

This also removes unnecessary v2 suffix in dashboard name