### PR TITLE
OCPBUGS-13346: dont log jwt tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20230213134911-7ba313770556
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea
-	github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26
+	github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.45.0
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q7
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
 github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26 h1:vXYT3dX03Fm5FCX1284aTGoa5qBZFp3zMnIVaV9WOdg=
 github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
+github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a h1:TYvVEQEh7vRooVZcsCetgaT9JW8eNjsvEEhtkV13WjA=
+github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,6 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
-github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26 h1:vXYT3dX03Fm5FCX1284aTGoa5qBZFp3zMnIVaV9WOdg=
-github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a h1:TYvVEQEh7vRooVZcsCetgaT9JW8eNjsvEEhtkV13WjA=
 github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/allrequestbodies-rules.yaml
@@ -3,10 +3,10 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/manifests/writerequestbodies-rules.yaml
@@ -3,11 +3,11 @@
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/allrequestbodies.yaml
@@ -33,10 +33,10 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes","routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # catch-all rule to log all other requests with request and response payloads
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/multipleCr.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests
@@ -63,11 +63,11 @@ rules:
   resources:
     - group: "route.openshift.io"
       resources: ["routes", "routes/status"]
-    - resources: ["secrets"]
+    - resources: ["secrets", serviceaccounts/token]
     - group: "authentication.k8s.io"
       resources: ["tokenreviews", "tokenrequests"]
     - group: "oauth.openshift.io"
-      resources: ["oauthclients"]
+      resources: ["oauthclients", "tokenreviews"]
   userGroups:
     - system:authenticated
 - level: RequestResponse

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/oauth.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
   userGroups:
   - system:authenticated:oauth
 # log request and response payloads for all write requests

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/audit/testdata/writerequestbodies.yaml
@@ -33,11 +33,11 @@ rules:
   resources:
   - group: "route.openshift.io"
     resources: ["routes", "routes/status"]
-  - resources: ["secrets"]
+  - resources: ["secrets", "serviceaccounts/token"]
   - group: "authentication.k8s.io"
     resources: ["tokenreviews", "tokenrequests"]
   - group: "oauth.openshift.io"
-    resources: ["oauthclients"]
+    resources: ["oauthclients", "tokenreviews"]
 # log request and response payloads for all write requests
 - level: RequestResponse
   verbs:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230301092340-c13b89190a26
+# github.com/openshift/library-go v0.0.0-20230707145856-7efc9e03154a
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
# What

- Bump library-go

# Why

- Contains updated audit policies to not log tokens.