### PR TITLE
Revert "OCPBUGS-13946: do not use one second timeout when asserting a webhook connection"

### DIFF
--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
@@ -27,7 +27,6 @@ func (c *webhookSupportabilityController) updateMutatingAdmissionWebhookConfigur
 				Name:                  webhook.Name,
 				CABundle:              webhook.ClientConfig.CABundle,
 				FailurePolicyIsIgnore: webhook.FailurePolicy != nil && *webhook.FailurePolicy == admissionregistrationv1.Ignore,
-				TimeoutSeconds:        webhook.TimeoutSeconds,
 			}
 			if webhook.ClientConfig.Service != nil {
 				info.Service = &serviceReference{
@@ -59,7 +58,6 @@ func (c *webhookSupportabilityController) updateValidatingAdmissionWebhookConfig
 				Name:                  webhook.Name,
 				CABundle:              webhook.ClientConfig.CABundle,
 				FailurePolicyIsIgnore: webhook.FailurePolicy != nil && (*webhook.FailurePolicy == v1.Ignore),
-				TimeoutSeconds:        webhook.TimeoutSeconds,
 			}
 
 			if webhook.ClientConfig.Service != nil {


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1510

This is a test I have no intention of merging. Disruption to kube/openshift/oauth apiservers all IMPROVED massively around when this merged, I want to test if the disruption comes back on this revert.