### PR TITLE
OCPBUGS-13635: make webhook connection failure a warning in log

### DIFF
--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
@@ -131,8 +131,8 @@ func (c *webhookSupportabilityController) assertConnect(ctx context.Context, web
 		conn, err = dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 		if err != nil {
 			if i != 2 {
-				// log err since only last one is reported
-				runtime.HandleError(fmt.Errorf("%s: %v", webhookName, err))
+				// log warning since only last one is reported
+				klog.Warningf("failed to connect to webhook %q via service %q: %v", webhookName, net.JoinHostPort(host, port), err)
 			}
 			continue
 		}


### PR DESCRIPTION
Since these logs are only for debugging and are informational, they should not be errors but just warnings.