### PR TITLE
Revert "Enable DynamicResourceAllocation API in kube-apiserver"

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -16,7 +16,6 @@ import (
 
 var DefaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]schema.GroupVersion{
 	"ValidatingAdmissionPolicy": {{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}},
-	"DynamicResourceAllocation": {{Group: "resource.k8s.io", Version: "v1alpha2"}},
 }
 
 var (


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1538; tracked by OCPBUGS-17967

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

We believe this PR broke the techpreview "[sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial]" test which is now failing on nightly payloads.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run techpreview jobs on the unrevert:

`/payload-job periodic-ci-openshift-release-master-ci-4.14-e2e-gcp-sdn-techpreview-serial`

CC: @bertinatto, @benluddy 