### PR TITLE
OCPBUGS-18247: manifests: don't include recording rules when Console capability is not enabled

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -146,8 +146,7 @@ metadata:
   namespace: openshift-kube-apiserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    capability.openshift.io/name: Console
 spec:
   groups:
   - name: api-performance

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-managed
   annotations:
     include.release.openshift.io/self-managed-high-availability: 'true'
+    capability.openshift.io/name: Console
   labels:
     console.openshift.io/dashboard: 'true'
 data:


### PR DESCRIPTION
In order to avoid additional load on Prometheus the recording rules for kube-apiserver dashboard are not included when Console capability is not enablked . These are not used anywhere else, so it should not affect any other components.