### PR TITLE
OCPBUGS-15504: manifest: remove kube-apiserver PrometheusRule

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -119,29 +119,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: kube-apiserver
-  namespace: openshift-kube-apiserver
-  annotations:
-    release.openshift.io/delete: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-spec:
-  groups:
-  - name: apiserver-requests-in-flight
-    rules:
-      # We want to capture requests in-flight metrics for kube-apiserver and openshift-apiserver.
-      # apiserver='kube-apiserver' indicates that the source is kubernetes apiserver.
-      # apiserver='openshift-apiserver' indicates that the source is openshift apiserver.
-      # The subquery aggregates by apiserver and request kind. requestKind is {mutating|readOnly}
-      # The following query gives us maximum peak of the apiserver concurrency over a 2-minute window.
-    - record: cluster:apiserver_current_inflight_requests:sum:max_over_time:2m
-      expr: |
-        max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,request_kind)[2m:])
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
   name: kube-apiserver-recording-rules
   namespace: openshift-kube-apiserver
   annotations:


### PR DESCRIPTION
The kube-apiserver PrometheusRule was marked to be deleted by CVO in 4.13, so it is now safe to remove the manifest in 4.14.