### PR TITLE
Update required GV for ValidatingAdmissionPolicy gate.

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -15,7 +15,7 @@ import (
 )
 
 var DefaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]schema.GroupVersion{
-	"ValidatingAdmissionPolicy": {{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}},
+	"ValidatingAdmissionPolicy": {{Group: "admissionregistration.k8s.io", Version: "v1beta1"}},
 	"DynamicResourceAllocation": {{Group: "resource.k8s.io", Version: "v1alpha2"}},
 }
 


### PR DESCRIPTION
In 1.29, ValidatingAdmissionPolicy requires admissionregistration.k8s.io/v1beta1, not admissionregistration.k8s.io/v1alpha1.