### PR TITLE
OCPBUGS-20331: manifests: rename API performance dashboard

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-api-performance
+  name: grafana-dashboard-apiserver-performance
   namespace: openshift-config-managed
   annotations:
     include.release.openshift.io/self-managed-high-availability: 'true'
@@ -3328,3 +3329,14 @@ data:
       "uid": "X9gzM6XFF",
       "version": 2
     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-api-performance
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/delete: "true"
+  labels:
+    console.openshift.io/dashboard: 'true'


### PR DESCRIPTION
In [previous PR](https://github.com/openshift/cluster-kube-apiserver-operator/pull/1542) this manifests was labelled as "available only when Console capability enabled". This causes CVO to force enable Console capability when upgrading from baseline 4.13 cluster - as this manifest is present.

In order to avoid this, the manifest needs to be renamed, so that CVO would treat it as a new one (since its applicability has changed)