### PR TITLE
OCPBUGS-20331: manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver: Rename to kube-apiserver-performance-recording-rules

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -119,7 +119,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: kube-apiserver-recording-rules
+  name: kube-apiserver-performance-recording-rules
   namespace: openshift-kube-apiserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -244,3 +244,12 @@ spec:
       expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver)
     - record: resource:apiserver_storage_objects:max
       expr: max(apiserver_storage_objects{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, resource)
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-apiserver-recording-rules
+  namespace: openshift-kube-apiserver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
Exactly like 7457da4fc0 (#1565), this pivot:

* Turns the original (group, namepspace, name) into a delete manifest, with no capability annotation (all clusters should delete this resource).
* Creates a (group, namespace, newName) manifest with the original spec content and capability annotation (only clusters with the cap enabled should have this resource).

which allows updates like:

1. Old release with the old (kind, group, namepspace, name) not annotated for a capability.
2. Request update to new release.
3. Outgoing cluster-version operator compares the outgoing manifests with the incoming manifests to decide if any capabilities need to be implicitly enabled:
    1. It sees that the old (kind, group, namepspace, name) isn't labeled with any capabilities, so no need to implicitly enable anything there.
    2. It sees that the new (kind, group, namespace, newName) is annotated for the capability, but it doesn't see anything with that k,g,n,n getting reconciled in the outgoing manifest set, so it thinks "just some new manifest for a capability I do not care about", and does not enable the annotated capability.

In a separate pull request than 7457da4fc0, because this one doesn't need to go back to 4.14.  The RecordingRule is from 04f36e7309 (#1521), which landed in 4.14, so 4.13 clusters do not have a matching (kind, group, namespace, name) manifest to worry about matching.