### PR TITLE
set goaway-chance to 1 in 1000

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -121,7 +121,7 @@ apiServerArguments:
   event-ttl:
     - 3h
   goaway-chance:
-    - "0"
+    - "0.001"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-certificate-authority:


### PR DESCRIPTION
A mirror of this hypershift PR
https://github.com/openshift/hypershift/pull/3178

Opened to get feedback on this approach from KAS team.

We would want this to merge before we did it in hypershift.

The point is a to be an added mitigation against HTTP2 DoS.