### PR TITLE
NO-JIRA: Add ownership for the admin kubeconfig

### DIFF
--- a/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: admin-kubeconfig-client-ca
   namespace: openshift-config
+  annotations:
+    "openshift.io/owning-component": "kube-apiserver"
 data:
   ca-bundle.crt: |
     {{ .Assets | load "admin-kubeconfig-ca-bundle.crt" | indent 4 }}


### PR DESCRIPTION
This comes from the installer, but it's not user provided. It is logically owned by the kube-apiserver and something must manage the equivalent when the admin.kubeconfig expires.  We're close to that point.