### PR TITLE
OCPBUGS-24005: webhookcontroller: report when a webhook resource is missing a caBundle provided by the service-ca-operator

### DIFF
--- a/pkg/operator/webhooksupportabilitycontroller/conditions.go
+++ b/pkg/operator/webhooksupportabilitycontroller/conditions.go
@@ -1,21 +1,21 @@
 package webhooksupportabilitycontroller
 
 const (
-	// MutatingAdmissionWebhookConfigurationDegradedType is true when there
+	// MutatingAdmissionWebhookConfigurationErrorType is true when there
 	// is a problem with a mutating admission webhook service.
-	MutatingAdmissionWebhookConfigurationDegradedType = "MutatingAdmissionWebhookConfigurationError"
+	MutatingAdmissionWebhookConfigurationErrorType = "MutatingAdmissionWebhookConfigurationError"
 
-	// ValidatingAdmissionWebhookConfigurationDegradedType is true when there
+	// ValidatingAdmissionWebhookConfigurationErrorType is true when there
 	// is a problem with a validating admission webhook service.
-	ValidatingAdmissionWebhookConfigurationDegradedType = "ValidatingAdmissionWebhookConfigurationError"
+	ValidatingAdmissionWebhookConfigurationErrorType = "ValidatingAdmissionWebhookConfigurationError"
 
-	// CRDConversionWebhookConfigurationDegradedType is true when there
+	// CRDConversionWebhookConfigurationErrorType is true when there
 	// is a problem with a custom resource definition conversion webhook service.
-	CRDConversionWebhookConfigurationDegradedType = "CRDConversionWebhookConfigurationError"
+	CRDConversionWebhookConfigurationErrorType = "CRDConversionWebhookConfigurationError"
 
-	// VirtualResourceAdmissionDegradedType is true when a dynamic admission webhook matches
+	// VirtualResourceAdmissionErrorType is true when a dynamic admission webhook matches
 	// a virtual resource.
-	VirtualResourceAdmissionDegradedType = "VirtualResourceAdmissionError"
+	VirtualResourceAdmissionErrorType = "VirtualResourceAdmissionError"
 )
 
 const (

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
@@ -24,10 +24,11 @@ func (c *webhookSupportabilityController) updateMutatingAdmissionWebhookConfigur
 	for _, webhookConfiguration := range webhookConfigurations {
 		for _, webhook := range webhookConfiguration.Webhooks {
 			info := webhookInfo{
-				Name:                  webhook.Name,
-				CABundle:              webhook.ClientConfig.CABundle,
-				FailurePolicyIsIgnore: webhook.FailurePolicy != nil && *webhook.FailurePolicy == admissionregistrationv1.Ignore,
-				TimeoutSeconds:        webhook.TimeoutSeconds,
+				Name:                   webhook.Name,
+				CABundle:               webhook.ClientConfig.CABundle,
+				HasServiceCaAnnotation: hasServiceCaAnnotation(webhookConfiguration.Annotations),
+				FailurePolicyIsIgnore:  webhook.FailurePolicy != nil && *webhook.FailurePolicy == admissionregistrationv1.Ignore,
+				TimeoutSeconds:         webhook.TimeoutSeconds,
 			}
 			if webhook.ClientConfig.Service != nil {
 				info.Service = &serviceReference{
@@ -56,10 +57,11 @@ func (c *webhookSupportabilityController) updateValidatingAdmissionWebhookConfig
 	for _, webhookConfiguration := range webhookConfigurations {
 		for _, webhook := range webhookConfiguration.Webhooks {
 			info := webhookInfo{
-				Name:                  webhook.Name,
-				CABundle:              webhook.ClientConfig.CABundle,
-				FailurePolicyIsIgnore: webhook.FailurePolicy != nil && (*webhook.FailurePolicy == v1.Ignore),
-				TimeoutSeconds:        webhook.TimeoutSeconds,
+				Name:                   webhook.Name,
+				CABundle:               webhook.ClientConfig.CABundle,
+				HasServiceCaAnnotation: hasServiceCaAnnotation(webhookConfiguration.Annotations),
+				FailurePolicyIsIgnore:  webhook.FailurePolicy != nil && (*webhook.FailurePolicy == v1.Ignore),
+				TimeoutSeconds:         webhook.TimeoutSeconds,
 			}
 
 			if webhook.ClientConfig.Service != nil {

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission.go
@@ -12,7 +12,7 @@ import (
 
 func (c *webhookSupportabilityController) updateMutatingAdmissionWebhookConfigurationDegraded(ctx context.Context) v1helpers.UpdateStatusFunc {
 	condition := operatorv1.OperatorCondition{
-		Type:   MutatingAdmissionWebhookConfigurationDegradedType,
+		Type:   MutatingAdmissionWebhookConfigurationErrorType,
 		Status: operatorv1.ConditionUnknown,
 	}
 	webhookConfigurations, err := c.mutatingWebhookLister.List(labels.Everything())
@@ -44,7 +44,7 @@ func (c *webhookSupportabilityController) updateMutatingAdmissionWebhookConfigur
 
 func (c *webhookSupportabilityController) updateValidatingAdmissionWebhookConfigurationDegradedStatus(ctx context.Context) v1helpers.UpdateStatusFunc {
 	condition := operatorv1.OperatorCondition{
-		Type:   ValidatingAdmissionWebhookConfigurationDegradedType,
+		Type:   ValidatingAdmissionWebhookConfigurationErrorType,
 		Status: operatorv1.ConditionUnknown,
 	}
 	webhookConfigurations, err := c.validatingWebhookLister.List(labels.Everything())

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission_test.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission_test.go
@@ -31,7 +31,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 		{
 			name: "None",
 			expected: operatorv1.OperatorCondition{
-				Type:   MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:   MutatingAdmissionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -65,7 +65,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("mwc30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:   MutatingAdmissionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -90,7 +90,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 			},
 			webhookServers: []*mockWebhookServer{},
 			expected: operatorv1.OperatorCondition{
-				Type:   MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:   MutatingAdmissionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -115,7 +115,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("mwc30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:    MutatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceNotReadyReason,
 				Message: `mw10: unable to find service svc10.ns10: service "svc10" not found\nmw20: (?:.*)?dial tcp: lookup svc20.ns20.svc on .+: no such host`,
@@ -133,7 +133,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 			},
 			webhookServers: nil,
 			expected: operatorv1.OperatorCondition{
-				Type:    MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:    MutatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?dial tcp: lookup svc10.ns10.svc on .+: no such host`,
@@ -153,7 +153,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("mwc10", "ns10", "svc10", doNotStart()),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:    MutatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?dial tcp 127.0.0.1:[0-9]+: connect: connection refused`,
@@ -173,7 +173,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("mwc10", "ns10", "svc10", withWrongCABundle(t)),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    MutatingAdmissionWebhookConfigurationDegradedType,
+				Type:    MutatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?x509: certificate signed by unknown authority`,
@@ -262,7 +262,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 		{
 			name: "None",
 			expected: operatorv1.OperatorCondition{
-				Type:   ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:   ValidatingAdmissionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -296,7 +296,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 				webhookServer("mwc30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:   ValidatingAdmissionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -321,7 +321,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 				webhookServer("mwc30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:    ValidatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceNotReadyReason,
 				Message: `mw10: unable to find service svc10.ns10: service \"svc10\" not found\nmw20: (?:.*)?dial tcp: lookup svc20.ns20.svc on .+: no such host`,
@@ -339,7 +339,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 			},
 			webhookServers: nil,
 			expected: operatorv1.OperatorCondition{
-				Type:    ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:    ValidatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?dial tcp: lookup svc10.ns10.svc on .+: no such host`,
@@ -359,7 +359,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 				webhookServer("mwc10", "ns10", "svc10", doNotStart()),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:    ValidatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?dial tcp 127.0.0.1:[0-9]+: connect: connection refused`,
@@ -379,7 +379,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 				webhookServer("mwc10", "ns10", "svc10", withWrongCABundle(t)),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    ValidatingAdmissionWebhookConfigurationDegradedType,
+				Type:    ValidatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `mw10: (?:.*)?x509: certificate signed by unknown authority`,

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion.go
@@ -12,7 +12,7 @@ import (
 
 func (c *webhookSupportabilityController) updateCRDConversionWebhookConfigurationDegraded(ctx context.Context) v1helpers.UpdateStatusFunc {
 	condition := operatorv1.OperatorCondition{
-		Type:   CRDConversionWebhookConfigurationDegradedType,
+		Type:   CRDConversionWebhookConfigurationErrorType,
 		Status: operatorv1.ConditionUnknown,
 	}
 	crds, err := c.crdLister.List(labels.Everything())

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion.go
@@ -26,8 +26,9 @@ func (c *webhookSupportabilityController) updateCRDConversionWebhookConfiguratio
 			continue
 		}
 		info := webhookInfo{
-			Name:     crd.Name,
-			CABundle: crd.Spec.Conversion.Webhook.ClientConfig.CABundle,
+			Name:                   crd.Name,
+			CABundle:               crd.Spec.Conversion.Webhook.ClientConfig.CABundle,
+			HasServiceCaAnnotation: hasServiceCaAnnotation(crd.Annotations),
 			Service: &serviceReference{
 				Namespace: crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace,
 				Name:      crd.Spec.Conversion.Webhook.ClientConfig.Service.Name,

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion_test.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion_test.go
@@ -30,7 +30,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 		{
 			name: "None",
 			expected: operatorv1.OperatorCondition{
-				Type:   CRDConversionWebhookConfigurationDegradedType,
+				Type:   CRDConversionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -58,7 +58,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("crd30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   CRDConversionWebhookConfigurationDegradedType,
+				Type:   CRDConversionWebhookConfigurationErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -83,7 +83,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("crd30", "ns30", "svc30"),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    CRDConversionWebhookConfigurationDegradedType,
+				Type:    CRDConversionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceNotReadyReason,
 				Message: `crd10: unable to find service svc10.ns10: service "svc10" not found\ncrd20: (?:.*)?dial tcp: lookup svc20.ns20.svc on .+: no such host`,
@@ -101,7 +101,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 			},
 			webhookServers: nil,
 			expected: operatorv1.OperatorCondition{
-				Type:    CRDConversionWebhookConfigurationDegradedType,
+				Type:    CRDConversionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `crd10: (?:.*)?dial tcp: lookup svc10.ns10.svc on .+: no such host`,
@@ -121,7 +121,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("crd10", "ns10", "svc10", doNotStart()),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    CRDConversionWebhookConfigurationDegradedType,
+				Type:    CRDConversionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `crd10: (?:.*)?dial tcp 127.0.0.1:[0-9]+: connect: connection refused`,
@@ -141,7 +141,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 				webhookServer("crd10", "ns10", "svc10", withWrongCABundle(t)),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:    CRDConversionWebhookConfigurationDegradedType,
+				Type:    CRDConversionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
 				Message: `crd10: (?:.*)?x509: certificate signed by unknown authority`,

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_on_virtual_resource.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_on_virtual_resource.go
@@ -15,7 +15,7 @@ import (
 
 func (c *webhookSupportabilityController) updateVirtualResourceAdmissionDegraded(ctx context.Context) v1helpers.UpdateStatusFunc {
 	condition := operatorv1.OperatorCondition{
-		Type:   VirtualResourceAdmissionDegradedType,
+		Type:   VirtualResourceAdmissionErrorType,
 		Status: operatorv1.ConditionUnknown,
 	}
 	mutatingWebhookConfigurations, err := c.mutatingWebhookLister.List(labels.Everything())

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_on_virtual_resource_test.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_on_virtual_resource_test.go
@@ -21,7 +21,7 @@ func TestUpdateVirtualResourceAdmissionDegraded(t *testing.T) {
 		{
 			name: "NoHooks",
 			expected: operatorv1.OperatorCondition{
-				Type:   VirtualResourceAdmissionDegradedType,
+				Type:   VirtualResourceAdmissionErrorType,
 				Status: operatorv1.ConditionFalse,
 			},
 		},
@@ -38,7 +38,7 @@ func TestUpdateVirtualResourceAdmissionDegraded(t *testing.T) {
 				),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   VirtualResourceAdmissionDegradedType,
+				Type:   VirtualResourceAdmissionErrorType,
 				Status: operatorv1.ConditionTrue,
 				Reason: AdmissionWebhookMatchesVirtualResourceReason,
 				Message: "Mutating webhook mw10 matches multiple virtual resources: " +
@@ -80,7 +80,7 @@ func TestUpdateVirtualResourceAdmissionDegraded(t *testing.T) {
 				),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   VirtualResourceAdmissionDegradedType,
+				Type:   VirtualResourceAdmissionErrorType,
 				Status: operatorv1.ConditionTrue,
 				Reason: AdmissionWebhookMatchesVirtualResourceReason,
 				Message: "Mutating webhook mw10 matches a virtual resource subjectaccessreviews.authorization.openshift.io/v1.\n" +
@@ -95,7 +95,7 @@ func TestUpdateVirtualResourceAdmissionDegraded(t *testing.T) {
 				),
 			},
 			expected: operatorv1.OperatorCondition{
-				Type:   VirtualResourceAdmissionDegradedType,
+				Type:   VirtualResourceAdmissionErrorType,
 				Status: operatorv1.ConditionTrue,
 				Reason: AdmissionWebhookMatchesVirtualResourceReason,
 				Message: "Mutating webhook mw10 matches multiple virtual resources: " +


### PR DESCRIPTION
This is clearly a gap in the platform. Perhaps the best way would be to introduce a readiness condition `kas` would honour. On the other hand the issue is not that severe since most of the time it will appear during a webhook installation. I've checked and the cert-manager works exactly in the same way.

Initially I was thinking about waiting for a caBundle to be populated but realised it would hide the issue. I've changed the PR to report the issue instead.