### PR TITLE
Dockerfile: build with debugging enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,113 @@ After doing this you can now change the image of the operator to the desired one
 oc patch pod/kube-apiserver-operator-<rand_digits> -n openshift-kube-apiserver-operator -p '{"spec":{"containers":[{"name":"kube-apiserver-operator","image":"<user>/cluster-kube-apiserver-operator"}]}}'
 ```
 
+## Debugging with delve
+
+1. In order to debug a running container remotely the image needs to contain source code and the binary must have debugging symbols enabled:
+```
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
+ENV GO_BUILD_FLAGS="-gcflags=all='-N -l'"
+RUN make build --warn-undefined-variables
+
+FROM registry.ci.openshift.org/ocp/4.15:base
+COPY . /source
+...
+```
+
+
+2. Run this to allow privileged pods in the namespace:
+```
+oc label ns/openshift-kube-apiserver-operator pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite
+```
+
+3. Stop CVO from reverting changes to deployment:
+```
+oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: apps
+    kind: Deployment
+    name: kube-apiserver-operator
+    namespace: openshift-kube-apiserver-operator
+    unmanaged: true
+EOF
+)"
+```
+
+4. Update permissions for cluster-kube-apiserver-operator SA:
+```
+oc policy add-role-to-user cluster-admin -z kube-apiserver-operator -n openshift-kube-apiserver-operator
+```
+
+5. Patch deployment to make main container copy source from the image to emptyDir for delve:
+```
+oc -n openshift-kube-apiserver-operator patch deployment/kube-apiserver-operator -p "$(cat <<- EOF
+spec:
+  template:
+    spec:
+      volumes:
+      - name: src
+        emptyDir: {}
+      containers:
+      - name: kube-apiserver-operator
+        volumeMounts:
+          - name: src
+            mountPath: /go
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/bash
+                - '-c'
+                - mkdir -p /go/src/github.com/openshift/cluster-kube-apiserver-operator && cp -r /source/* /go/src/github.com/openshift/cluster-kube-apiserver-operator
+```
+
+6. Patch deployment to run delve as sidecar:
+```
+oc -n openshift-kube-apiserver-operator patch deployment/kube-apiserver-operator -p "$(cat <<- EOF
+spec:
+  template:
+    spec:
+      shareProcessNamespace: true
+      containers:
+      - name: delve
+        securityContext:
+          privileged: true
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_PTRACE"]
+        image: quay.io/vrutkovs/ocp:delve
+        ports:
+        - containerPort: 40000
+          name: delve
+          protocol: TCP
+        volumeMounts:
+          - name: src
+            mountPath: /go
+        command:
+        - sh
+        - -c
+        - "echo \"Waiting for cluster-kube-apiserver-operator\" && until [ -n \"\${PID}\" ]; do echo -n \".\" && sleep 1 && export PID=\$(pidof cluster-kube-apiserver-operator); done && echo \"Found operator with PID \${PID}\" && /usr/local/bin/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient=true --allow-non-terminal-interactive=true --continue --log attach \${PID}"
+EOF
+)"
+```
+7. Patch deployment to remove non-root restriction:
+```
+oc -n openshift-kube-apiserver-operator patch deployment/kube-apiserver-operator --type json -p='[{"op": "remove", "path": "/spec/template/spec/securityContext/runAsNonRoot"}]'
+```
+
+8. Patch deployment to point to the new image with debugging symbols and source code:
+```
+oc -n openshift-kube-apiserver-operator patch deployment/kube-apiserver-operator --type json -p='[{"op": "replace", "path": "/spec/template/spec/containers/1/image", "value": "quay.io/vrutkovs/ocp:ckao-debugging-v3"}]'
+```
+
+9. Port forward remote port 40000 locally:
+```
+oc -n openshift-kube-apiserver-operator port-forward deployment/kube-apiserver-operator 40000:40000
+```
+
+10. Run `dlv attach :40000` or use VSCode/GoLand debugger in attach mode (remotePath needs to be set to `/go/src/github.com/openshift/cluster-kube-apiserver-operator`)
 
 ## Developing and debugging the bootkube bootstrap phase
 


### PR DESCRIPTION
Update README with instructions of connecting to remove cluster-kube-apiserver-operator running in the cluster with a locally running `delve` (including via VSCode/GoLand). The instructions are sufficiently generic to be applied to any other container in the cluster