### PR TITLE
OCPBUGS-25922: [release-4.14] dashboard: use recording rules for most metrics

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -119,30 +119,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: kube-apiserver
-  namespace: openshift-kube-apiserver
-  annotations:
-    release.openshift.io/delete: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-spec:
-  groups:
-  - name: apiserver-requests-in-flight
-    rules:
-      # We want to capture requests in-flight metrics for kube-apiserver and openshift-apiserver.
-      # apiserver='kube-apiserver' indicates that the source is kubernetes apiserver.
-      # apiserver='openshift-apiserver' indicates that the source is openshift apiserver.
-      # The subquery aggregates by apiserver and request kind. requestKind is {mutating|readOnly}
-      # The following query gives us maximum peak of the apiserver concurrency over a 2-minute window.
-    - record: cluster:apiserver_current_inflight_requests:sum:max_over_time:2m
-      expr: |
-        max_over_time(sum(apiserver_current_inflight_requests{apiserver=~"openshift-apiserver|kube-apiserver"}) by (apiserver,request_kind)[2m:])
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kube-apiserver-recording-rules
+  name: kube-apiserver-performance-recording-rules
   namespace: openshift-kube-apiserver
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -267,3 +244,12 @@ spec:
       expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver)
     - record: resource:apiserver_storage_objects:max
       expr: max(apiserver_storage_objects{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, resource)
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-apiserver-recording-rules
+  namespace: openshift-kube-apiserver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/delete: "true"

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -720,7 +720,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "group_resource:apiserver_request_total:rate$period{apiserver=\"$apiserver\"}",
+              "expr": "request_kind:apiserver_dropped_requests_total:rate$period{apiserver=\"$apiserver\"}",
               "interval": "",
               "legendFormat": "{{group}}:{{resource}}",
               "refId": "A"
@@ -2941,7 +2941,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(25, group_resource:apiserver_longrunning_requests:sum{apiserver=\"$apiserver\"})",
+              "expr": "topk(25, group_kind:apiserver_registered_watchers:sum{apiserver=\"$apiserver\"})",
               "format": "time_series",
               "interval": "",
               "legendFormat": "{{group}}:{{resource}}",


### PR DESCRIPTION
Add more recording rules to reduce the load on Thanos querier and Prometheus. This removes "auto" interval as it can't be cached via recording rules

Recording rules are no applied if cluster is configured with no console enabled to avoid straining Prometheus