### PR TITLE
WIP: pkg/operator/certrotationcontroller: roll loadbalancer-serving-signer at 1h

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -322,7 +322,7 @@ func newCertRotationController(
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
 			// it means we effectively do not rotate.
-			Refresh:                8 * 365 * defaultRotationDay,
+			Refresh:                time.Hour,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),


### PR DESCRIPTION
[OCPBUGS-25821][1] is failing to make this rotation in an older cluster where the CA was years old.  Drop `Refresh` to 1h, and see if that allows us to reproduce in a short  CI run.

[1]: https://issues.redhat.com/browse/OCPBUGS-25821