### PR TITLE
NO-JIRA: extend node-system-admin-client validity to 2 years

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -660,7 +660,7 @@ func newCertRotationController(
 			// This needs to live longer then control plane certs so there is high chance that if a cluster breaks
 			// because of expired certs these are still valid to use for collecting data using localhost-recovery
 			// endpoint with long lived serving certs for localhost.
-			Validity: 120 * defaultRotationDay,
+			Validity: 2 * 365 * defaultRotationDay,
 			// We rotate sooner so certs are always valid for 90 days (30 days more then kube-control-plane-signer)
 			Refresh:                30 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,


### PR DESCRIPTION
This is necessary to test multi year time skew, so that CSRs could be approved using localhost-recovery kubeconfig