### PR TITLE
Disable webhooks during bootstrap-in-place

### DIFF
--- a/bindata/bootkube/config/bootstrap-config-overrides.yaml
+++ b/bindata/bootkube/config/bootstrap-config-overrides.yaml
@@ -41,6 +41,57 @@ apiServerArguments:
   - {{ or .ServiceAccountIssuer "https://kubernetes.default.svc" }}
   client-ca-file:
     - /etc/kubernetes/secrets/kube-apiserver-complete-client-ca-bundle.crt
+{{- if .BootstrapInPlace}}
+  disable-admission-plugins:
+    - ValidatingAdmissionWebhook
+  enable-admission-plugins:
+    - CertificateApproval
+    - CertificateSigning
+    - CertificateSubjectRestriction
+    - DefaultIngressClass
+    - DefaultStorageClass
+    - DefaultTolerationSeconds
+    - LimitRanger
+    - MutatingAdmissionWebhook
+    - NamespaceLifecycle
+    - NodeRestriction
+    - OwnerReferencesPermissionEnforcement
+    - PersistentVolumeClaimResize
+    - PersistentVolumeLabel
+    - PodNodeSelector
+    - PodTolerationRestriction
+    - Priority
+    - ResourceQuota
+    - RuntimeClass
+    - ServiceAccount
+    - StorageObjectInUseProtection
+    - TaintNodesByCondition
+    # - ValidatingAdmissionWebhook
+    - ValidatingAdmissionPolicy
+    - authorization.openshift.io/RestrictSubjectBindings
+    - authorization.openshift.io/ValidateRoleBindingRestriction
+    - config.openshift.io/DenyDeleteClusterConfiguration
+    - config.openshift.io/ValidateAPIServer
+    - config.openshift.io/ValidateAuthentication
+    - config.openshift.io/ValidateConsole
+    - config.openshift.io/ValidateFeatureGate
+    - config.openshift.io/ValidateImage
+    - config.openshift.io/ValidateOAuth
+    - config.openshift.io/ValidateProject
+    - config.openshift.io/ValidateScheduler
+    - image.openshift.io/ImagePolicy
+    - network.openshift.io/ExternalIPRanger
+    - network.openshift.io/RestrictedEndpointsAdmission
+    - quota.openshift.io/ClusterResourceQuota
+    - quota.openshift.io/ValidateClusterResourceQuota
+    - route.openshift.io/IngressAdmission
+    - scheduling.openshift.io/OriginPodNodeEnvironment
+    - security.openshift.io/DefaultSecurityContextConstraints
+    - security.openshift.io/SCCExecRestrictions
+    - security.openshift.io/SecurityContextConstraint
+    - security.openshift.io/ValidateSecurityContextConstraints
+    - storage.openshift.io/CSIInlineVolumeSecurity
+{{end}}
   etcd-cafile:
     - /etc/kubernetes/secrets/{{.EtcdServingCA}}
   etcd-certfile:

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -181,6 +181,8 @@ type TemplateData struct {
 	ShutdownDelayDuration string
 
 	ServiceAccountIssuer string
+
+	BootstrapInPlace bool
 }
 
 // Run contains the logic of the render command.
@@ -283,6 +285,7 @@ func (r *renderOpts) Run() error {
 		case configv1.SingleReplicaTopologyMode:
 			renderConfig.TerminationGracePeriodSeconds = 15
 			renderConfig.ShutdownDelayDuration = "0s"
+			renderConfig.BootstrapInPlace = true
 		}
 	}
 

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -582,6 +582,20 @@ spec:
 				if got, expected := cfg.APIServerArguments["shutdown-delay-duration"][0], "0s"; got != expected {
 					return fmt.Errorf("expected shutdown-delay-duration=%q, but found %s", expected, got)
 				}
+				for _, plugin := range cfg.APIServerArguments["enable-admission-plugins"] {
+					if strings.Compare(plugin, "ValidatingAdmissionWebhook") == 0 {
+						return fmt.Errorf("expected %s to not be enabled for bootstrap in place", plugin)
+					}
+				}
+				var disableValidatingWebhookPlugin bool
+				for _, plugin := range cfg.APIServerArguments["disable-admission-plugins"] {
+					if strings.Compare(plugin, "ValidatingAdmissionWebhook") == 0 {
+						disableValidatingWebhookPlugin = true
+					}
+				}
+				if !disableValidatingWebhookPlugin {
+					return fmt.Errorf("expected ValidatingAdmissionWebhook to be disabled for bootstrap in place")
+				}
 				return nil
 			},
 			podTestFunction: func(pod *corev1.Pod) error {


### PR DESCRIPTION
This commit disables validating webhook
admission controller plugin during bootstrap in place.
Webhooks don't work when bootstrapping-in-place, because
most of the cluster operators don't have running pods.
Mutating webhook plugin remains enabled. If someone relies on
mutating webhook during bootstrap in place, this will still fail.
