### PR TITLE
OCPBUGS-24005: when skipping a webhook check because of missing CA log the name of the webhook

### DIFF
--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook.go
@@ -116,7 +116,7 @@ func (c *webhookSupportabilityController) assertConnect(ctx context.Context, web
 	if len(caBundle) > 0 {
 		rootCAs.AppendCertsFromPEM(caBundle)
 	} else if caBundleProvidedByServiceCA {
-		err := fmt.Errorf("skipping checking the webhook via %q service because the caBundle (provided by the service-ca-operator) is empty. Please check the service-ca's logs if the issue persists", net.JoinHostPort(host, port))
+		err := fmt.Errorf("skipping checking the webhook %q via %q service because the caBundle (provided by the service-ca-operator) is empty. Please check the service-ca's logs if the issue persists", webhookName, net.JoinHostPort(host, port))
 		return err
 	}
 	timeout := 10 * time.Second

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission_test.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_admission_test.go
@@ -197,7 +197,7 @@ func TestUpdateMutatingAdmissionWebhookConfigurationDegraded(t *testing.T) {
 				Type:    MutatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
-				Message: `mw10: skipping checking the webhook via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
+				Message: `mw10: skipping checking the webhook \"mw10\" via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
 			},
 		},
 	}
@@ -424,7 +424,7 @@ func TestUpdateValidatingAdmissionWebhookConfigurationDegradedStatus(t *testing.
 				Type:    ValidatingAdmissionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
-				Message: `mw10: skipping checking the webhook via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
+				Message: `mw10: skipping checking the webhook \"mw10\" via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
 			},
 		},
 	}

--- a/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion_test.go
+++ b/pkg/operator/webhooksupportabilitycontroller/degraded_webhook_conversion_test.go
@@ -165,7 +165,7 @@ func TestUpdateCRDConversionWebhookConfigurationDegraded(t *testing.T) {
 				Type:    CRDConversionWebhookConfigurationErrorType,
 				Status:  operatorv1.ConditionTrue,
 				Reason:  WebhookServiceConnectionErrorReason,
-				Message: `crd10: skipping checking the webhook via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
+				Message: `crd10: skipping checking the webhook \"crd10\" via \"([^"]+)\" service because the caBundle \(provided by the service-ca-operator\) is empty. Please check the service-ca's logs if the issue persists`,
 			},
 		},
 	}


### PR DESCRIPTION
for easier troubleshooting when a check is skipped because `service-ca` hasn't provided a CA for the webook we should also log the name of the webhook.