### PR TITLE
WIP certrotation: update secret type only when its created

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -76,12 +76,21 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 	}
 
 	needsMetadataUpdate := false
+	// no ownerReference set
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&signingCertKeyPairSecret.ObjectMeta, c.Owner)
 	}
+	// ownership annotations not set
 	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
 		needsMetadataUpdate = EnsureTLSMetadataUpdate(&signingCertKeyPairSecret.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
 	}
+	// convert outdated secret type (set pre 4.7)
+	if signingCertKeyPairSecret.Type != corev1.SecretTypeTLS {
+		signingCertKeyPairSecret.Type = corev1.SecretTypeTLS
+		needsMetadataUpdate = true
+	}
+	// apply changes (possibly via delete+recreate) if secret exists and requires metadata update
+	// this is done before content update to prevent unexpected rollouts
 	if needsMetadataUpdate && len(signingCertKeyPairSecret.ResourceVersion) > 0 {
 		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {


### PR DESCRIPTION
Pre-4.7 clusters have LB signer key created by installer with `SecretTypeTLS` instead of `kubernetes.io/tls`, so this function should avoid changing its type so that it wouldn't be recreated by library-go's `ApplySecret`