### PR TITLE
OCPCLOUD-2514: External CCM should no longer rely on feature gate access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20231219140051-ddc590a81acb
 	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20231218155125-ff7d9f9bf415
-	github.com/openshift/library-go v0.0.0-20240110142250-07ee1a48ec84
+	github.com/openshift/library-go v0.0.0-20240229145526-d26b0b6227e4
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.16.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU
 github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20231218155125-ff7d9f9bf415 h1:wfnn3E0Z62bB3wYM5eO1AZ9EYZpFd7M1p4PclcIyVv0=
 github.com/openshift/client-go v0.0.0-20231218155125-ff7d9f9bf415/go.mod h1:5W+xoimHjRdZ0dI/yeQR0ANRNLK9mPmXMzUWPAIPADo=
-github.com/openshift/library-go v0.0.0-20240110142250-07ee1a48ec84 h1:fMYn2oCNBkVHyvo3Bp4Yju5BhXH1GvetukIaTC01oxg=
-github.com/openshift/library-go v0.0.0-20240110142250-07ee1a48ec84/go.mod h1:82B0gt8XawdXWRtKMrm3jSMTeRsiOSYKCi4F0fvPjG0=
+github.com/openshift/library-go v0.0.0-20240229145526-d26b0b6227e4 h1:hq03auh9Y8Q7ejKOUhfVG0pDTDFRVuj8DuqOolIXiBs=
+github.com/openshift/library-go v0.0.0-20240229145526-d26b0b6227e4/go.mod h1:ePlaOqUiPplRc++6aYdMe+2FmXb2xTNS9Nz5laG2YmI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -131,9 +131,11 @@ func newCertRotationController(
 	certRotator := certrotation.NewCertRotationController(
 		"AggregatorProxyClientCert",
 		certrotation.RotatedSigningCASecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "aggregator-client-signer",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "aggregator-client-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -143,18 +145,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			Name:          "kube-apiserver-aggregator-client-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Name:      "kube-apiserver-aggregator-client-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "aggregator-client",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "aggregator-client",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -174,10 +180,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"KubeAPIServerToKubeletClientCert",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-apiserver-to-kubelet-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      1 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-apiserver-to-kubelet-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 1 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			Refresh:                292 * defaultRotationDay,
@@ -188,18 +196,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-apiserver-to-kubelet-client-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-apiserver-to-kubelet-client-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "kubelet-client",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "kubelet-client",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -219,10 +231,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"LocalhostServing",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "localhost-serving-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "localhost-serving-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -235,18 +249,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "localhost-serving-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "localhost-serving-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "localhost-serving-cert-certkey",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "localhost-serving-cert-certkey",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -266,10 +284,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"ServiceNetworkServing",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "service-network-serving-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "service-network-serving-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -282,18 +302,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "service-network-serving-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "service-network-serving-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "service-network-serving-certkey",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "service-network-serving-certkey",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -314,10 +338,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"ExternalLoadBalancerServing",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "loadbalancer-serving-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "loadbalancer-serving-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -330,18 +356,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "loadbalancer-serving-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "loadbalancer-serving-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "external-loadbalancer-serving-certkey",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "external-loadbalancer-serving-certkey",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -362,10 +392,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"InternalLoadBalancerServing",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "loadbalancer-serving-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "loadbalancer-serving-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -378,18 +410,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "loadbalancer-serving-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "loadbalancer-serving-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "internal-loadbalancer-serving-certkey",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "internal-loadbalancer-serving-certkey",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -410,10 +446,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"LocalhostRecoveryServing",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "localhost-recovery-serving-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay, // this comes from the installer
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "localhost-recovery-serving-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -425,19 +463,23 @@ func newCertRotationController(
 			EventRecorder: eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "localhost-recovery-serving-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "localhost-recovery-serving-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:     operatorclient.TargetNamespace,
-			Name:          "localhost-recovery-serving-certkey",
-			JiraComponent: "kube-apiserver",
-			Validity:      10 * 365 * defaultRotationDay,
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "localhost-recovery-serving-certkey",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 10 * 365 * defaultRotationDay,
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			// Given that in this case rotation will be after 8y,
@@ -459,9 +501,11 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"KubeControllerManagerClient",
 		certrotation.RotatedSigningCASecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "kube-control-plane-signer",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -471,18 +515,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-control-plane-signer-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			Name:                   "kube-controller-manager-client-cert-key",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Name:      "kube-controller-manager-client-cert-key",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -502,9 +550,11 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"KubeSchedulerClient",
 		certrotation.RotatedSigningCASecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "kube-control-plane-signer",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -514,18 +564,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-control-plane-signer-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			Name:                   "kube-scheduler-client-cert-key",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			Name:      "kube-scheduler-client-cert-key",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -545,9 +599,11 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"ControlPlaneNodeAdminClient",
 		certrotation.RotatedSigningCASecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "kube-control-plane-signer",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -557,18 +613,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-control-plane-signer-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "control-plane-node-admin-client-cert-key",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "control-plane-node-admin-client-cert-key",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -588,9 +648,11 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"CheckEndpointsClient",
 		certrotation.RotatedSigningCASecret{
-			Namespace:              operatorclient.OperatorNamespace,
-			Name:                   "kube-control-plane-signer",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -600,18 +662,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "kube-control-plane-signer-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "kube-control-plane-signer-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:              operatorclient.TargetNamespace,
-			Name:                   "check-endpoints-client-cert-key",
-			JiraComponent:          "kube-apiserver",
+			Namespace: operatorclient.TargetNamespace,
+			Name:      "check-endpoints-client-cert-key",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
@@ -631,10 +697,12 @@ func newCertRotationController(
 	certRotator = certrotation.NewCertRotationController(
 		"NodeSystemAdminClient",
 		certrotation.RotatedSigningCASecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "node-system-admin-signer",
-			JiraComponent: "kube-apiserver",
-			Validity:      1 * 365 * defaultRotationDay,
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "node-system-admin-signer",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
+			Validity: 1 * 365 * defaultRotationDay,
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
 			Refresh:                292 * defaultRotationDay,
@@ -645,18 +713,22 @@ func newCertRotationController(
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "node-system-admin-ca",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "node-system-admin-ca",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
-			Namespace:     operatorclient.OperatorNamespace,
-			Name:          "node-system-admin-client",
-			JiraComponent: "kube-apiserver",
+			Namespace: operatorclient.OperatorNamespace,
+			Name:      "node-system-admin-client",
+			AdditionalAnnotations: certrotation.AdditionalAnnotations{
+				JiraComponent: "kube-apiserver",
+			},
 			// This needs to live longer then control plane certs so there is high chance that if a cluster breaks
 			// because of expired certs these are still valid to use for collecting data using localhost-recovery
 			// endpoint with long lived serving certs for localhost.

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -144,7 +144,6 @@ func NewConfigObserver(
 				"openshift-kube-apiserver", true,
 				[]string{"apiServerArguments", "cloud-provider"},
 				[]string{"apiServerArguments", "cloud-config"},
-				featureGateAccessor,
 			),
 			apienablement.NewFeatureGateObserverWithRuntimeConfig(
 				nil,

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -284,8 +285,9 @@ func ManageClientCABundle(ctx context.Context, lister corev1listers.ConfigMapLis
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
 		lister,
-		"kube-apiserver",
-		"",
+		certrotation.AdditionalAnnotations{
+			JiraComponent: "kube-apiserver",
+		},
 		// this is from the installer and contains the value to verify the admin.kubeconfig user
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
 		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images
@@ -317,8 +319,9 @@ func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.Confi
 	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-apiserver-server-ca"},
 		lister,
-		"kube-apiserver",
-		"",
+		certrotation.AdditionalAnnotations{
+			JiraComponent: "kube-apiserver",
+		},
 		// this bundle is what this operator uses to mint loadbalancers certs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "loadbalancer-serving-ca"},
 		// this bundle is what this operator uses to mint localhost certs

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -3,8 +3,6 @@ package cloudprovider
 import (
 	"fmt"
 
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-
 	configv1 "github.com/openshift/api/config/v1"
 )
 
@@ -27,24 +25,15 @@ var (
 // IsCloudProviderExternal is used to check whether external cloud provider settings should be used in a component.
 // It checks whether the ExternalCloudProvider feature gate is enabled and whether the ExternalCloudProvider feature
 // has been implemented for the platform.
-func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return false, fmt.Errorf("featureGates have not been read yet")
-	}
+func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil {
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.GCPPlatformType:
-		// Platforms that are external based on feature gate presence
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureGCP)
-	case configv1.AzurePlatformType:
-		if isAzureStackHub(platformStatus) {
-			return true, nil
-		}
-		return isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureAzure)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
+		configv1.GCPPlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -53,23 +42,14 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		configv1.VSpherePlatformType:
 		return true, nil
 	case configv1.ExternalPlatformType:
-		return isExternalPlatformCCMEnabled(platformStatus, featureGateAccessor)
+		return isExternalPlatformCCMEnabled(platformStatus)
 	default:
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
 }
 
-func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
-	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
-}
-
-func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featureGateAccessor featuregates.FeatureGateAccess) (bool, error) {
-	featureEnabled, err := isExternalFeatureGateEnabled(featureGateAccessor, ExternalCloudProviderFeature, ExternalCloudProviderFeatureExternal)
-	if err != nil || !featureEnabled {
-		return featureEnabled, err
-	}
-
+func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus) (bool, error) {
 	if platformStatus == nil || platformStatus.External == nil {
 		return false, nil
 	}
@@ -78,24 +58,5 @@ func isExternalPlatformCCMEnabled(platformStatus *configv1.PlatformStatus, featu
 		return true, nil
 	}
 
-	return false, nil
-}
-
-// isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current
-// feature set.
-func isExternalFeatureGateEnabled(featureGateAccess featuregates.FeatureGateAccess, featureGateNames ...configv1.FeatureGateName) (bool, error) {
-	featureGates, err := featureGateAccess.CurrentFeatureGates()
-	if err != nil {
-		return false, fmt.Errorf("unable to read current featuregates: %w", err)
-	}
-
-	// If any of the desired feature gates are enabled, then the external cloud provider should be used.
-	for _, featureGateName := range featureGateNames {
-		if featureGates.Enabled(featureGateName) {
-			return true, nil
-		}
-	}
-
-	// No explicit opinion on the feature gate, assume it's not enabled.
 	return false, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -5,30 +5,45 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTLSArtifactObjectMeta(name, namespace, jiraComponent, description string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Annotations: map[string]string{
-			annotations.OpenShiftComponent:   jiraComponent,
-			annotations.OpenShiftDescription: description,
-		},
-	}
+const (
+	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+)
+
+type AdditionalAnnotations struct {
+	// JiraComponent annotates tls artifacts so that owner could be easily found
+	JiraComponent string
+	// Description is a human-readable one sentence description of certificate purpose
+	Description string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
+	// that TLS artifact is correctly regenerated after it has expired
+	AutoRegenerateAfterOfflineExpiry string
 }
 
-// EnsureTLSMetadataUpdate mutates objectMeta setting necessary annotations if unset
-func EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta, jiraComponent, description string) bool {
+func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
 	modified := false
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
 	}
-	if len(jiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != jiraComponent {
-		meta.Annotations[annotations.OpenShiftComponent] = jiraComponent
+	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
 		modified = true
 	}
-	if len(description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != description {
-		meta.Annotations[annotations.OpenShiftDescription] = description
+	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		meta.Annotations[annotations.OpenShiftDescription] = a.Description
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.Description
 		modified = true
 	}
 	return modified
+}
+
+func NewTLSArtifactObjectMeta(name, namespace string, annotations AdditionalAnnotations) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+	_ = annotations.EnsureTLSMetadataUpdate(&meta)
+	return meta
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -1,10 +1,12 @@
 package certrotation
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"fmt"
 	"reflect"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -30,11 +32,8 @@ type CABundleConfigMap struct {
 	Name string
 	// Owner is an optional reference to add to the secret that this rotator creates.
 	Owner *metav1.OwnerReference
-	// JiraComponent annotates tls artifacts so that owner could be easily found
-	JiraComponent string
-	// Description is a human-readable one sentence description of certificate purpose
-	Description string
-
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
 	// Plumbing:
 	Informer      corev1informers.ConfigMapInformer
 	Lister        corev1listers.ConfigMapLister
@@ -42,7 +41,7 @@ type CABundleConfigMap struct {
 	EventRecorder events.Recorder
 }
 
-func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
+func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA) ([]*x509.Certificate, error) {
 	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
 	// doesn't have any expired certs
 	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
@@ -55,8 +54,7 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
-			c.JiraComponent,
-			c.Description,
+			c.AdditionalAnnotations,
 		)}
 	}
 
@@ -64,9 +62,7 @@ func (c CABundleConfigMap) ensureConfigMapCABundle(ctx context.Context, signingC
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
 	}
-	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
-		needsMetadataUpdate = EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
-	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
 		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
@@ -139,6 +135,10 @@ func manageCABundleConfigMap(caBundleConfigMap *corev1.ConfigMap, currentSigner 
 		}
 	}
 
+	// sorting ensures we don't continuously swap the certificates in the bundle, which might cause revision rollouts
+	sort.SliceStable(finalCertificates, func(i, j int) bool {
+		return bytes.Compare(finalCertificates[i].Raw, finalCertificates[j].Raw) < 0
+	})
 	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/api/annotations"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,11 +57,8 @@ type RotatedSelfSignedCertKeySecret struct {
 	// certificate is used, early deletion will be catastrophic.
 	Owner *metav1.OwnerReference
 
-	// JiraComponent annotates tls artifacts so that owner could be easily found
-	JiraComponent string
-
-	// Description is a human-readable one sentence description of certificate purpose
-	Description string
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
 
 	// CertCreator does the actual cert generation.
 	CertCreator TargetCertCreator
@@ -89,14 +85,14 @@ type TargetCertRechecker interface {
 	RecheckChannel() <-chan struct{}
 }
 
-func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) error {
+func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) (*corev1.Secret, error) {
 	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
 	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
 	// and need to mint one
 	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
 	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+		return nil, err
 	}
 	targetCertKeyPairSecret := originalTargetCertKeyPairSecret.DeepCopy()
 	if apierrors.IsNotFound(err) {
@@ -104,8 +100,7 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 		targetCertKeyPairSecret = &corev1.Secret{ObjectMeta: NewTLSArtifactObjectMeta(
 			c.Name,
 			c.Namespace,
-			c.JiraComponent,
-			c.Description,
+			c.AdditionalAnnotations,
 		)}
 	}
 	targetCertKeyPairSecret.Type = corev1.SecretTypeTLS
@@ -114,32 +109,30 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 	if c.Owner != nil {
 		needsMetadataUpdate = ensureOwnerReference(&targetCertKeyPairSecret.ObjectMeta, c.Owner)
 	}
-	if len(c.JiraComponent) > 0 || len(c.Description) > 0 {
-		needsMetadataUpdate = EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta, c.JiraComponent, c.Description) || needsMetadataUpdate
-	}
+	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(targetCertKeyPairSecret.ResourceVersion) > 0 {
 		_, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	if reason := needNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret.Annotations, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired); len(reason) > 0 {
 		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
-		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.JiraComponent, c.Description); err != nil {
-			return err
+		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+			return nil, err
 		}
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
 		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	}
 
-	return nil
+	return targetCertKeyPairSecret, nil
 }
 
 func needNewTargetCertKeyPair(annotations map[string]string, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired bool) string {
@@ -217,7 +210,7 @@ func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *cryp
 
 // setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
 // TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
-func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, jiraComponent, description string) error {
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, annotations AdditionalAnnotations) error {
 	if targetCertKeyPairSecret.Annotations == nil {
 		targetCertKeyPairSecret.Annotations = map[string]string{}
 	}
@@ -244,12 +237,8 @@ func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity
 	targetCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
 	targetCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
 	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
-	if len(jiraComponent) > 0 {
-		targetCertKeyPairSecret.Annotations[annotations.OpenShiftComponent] = jiraComponent
-	}
-	if len(description) > 0 {
-		targetCertKeyPairSecret.Annotations[annotations.OpenShiftDescription] = description
-	}
+
+	_ = annotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
 	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
 
 	return nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
@@ -16,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 )
 
 // GenericOptions contains the generic render command options.

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/config.go
@@ -1,0 +1,58 @@
+package resourceread
+
+import (
+	"encoding/json"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func init() {
+	utilruntime.Must(configv1.AddToScheme(configScheme))
+}
+
+func ReadFeatureGateV1(objBytes []byte) (*configv1.FeatureGate, error) {
+	requiredObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return requiredObj.(*configv1.FeatureGate), nil
+}
+
+func ReadFeatureGateV1OrDie(objBytes []byte) *configv1.FeatureGate {
+	requiredObj, err := ReadFeatureGateV1(objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj
+}
+func WriteFeatureGateV1(obj *configv1.FeatureGate) (string, error) {
+	// done for pretty printing of JSON (technically also yaml)
+	asMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return "", err
+	}
+	ret, err := json.MarshalIndent(asMap, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(ret) + "\n", nil
+}
+
+func WriteFeatureGateV1OrDie(obj *configv1.FeatureGate) string {
+	ret, err := WriteFeatureGateV1(obj)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 )
 
-func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, jiraComponent, description string, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
 	certificates := []*x509.Certificate{}
 	for _, input := range inputConfigMaps {
 		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
@@ -62,8 +62,7 @@ func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister cor
 		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
 			destinationConfigMap.Name,
 			destinationConfigMap.Namespace,
-			jiraComponent,
-			description,
+			additionalAnnotations,
 		),
 		Data: map[string]string{
 			"ca-bundle.crt": string(caBytes),

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -585,9 +585,14 @@ func setAvailableProgressingNodeInstallerFailingConditions(newStatus *operatorv1
 	}
 
 	revisionStrings := []string{}
+	var nodesStr string
 	for _, currentRevision := range Int32KeySet(counts).List() {
 		count := counts[currentRevision]
-		revisionStrings = append(revisionStrings, fmt.Sprintf("%d nodes are at revision %d", count, currentRevision))
+		nodesStr = "node is"
+		if count > 1 {
+			nodesStr = "nodes are"
+		}
+		revisionStrings = append(revisionStrings, fmt.Sprintf("%d %s at revision %d", count, nodesStr, currentRevision))
 	}
 	// if we are progressing and no nodes have achieved that level, we should indicate
 	if numProgressing > 0 && counts[newStatus.LatestAvailableRevision] == 0 {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,11 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
-
-	"github.com/ghodss/yaml"
-
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // SetOperandVersion sets the new version and returns the previous value.
@@ -160,6 +160,7 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -168,15 +169,21 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -190,6 +197,9 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", operatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -197,6 +207,17 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func operatorStatusJSONPatchNoError(original, modified *operatorv1.OperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+
+	return cmp.Diff(original, modified)
 }
 
 // UpdateConditionFn returns a func to update a condition.
@@ -215,6 +236,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -223,15 +245,21 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -245,6 +273,9 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", staticPodOperatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -252,6 +283,16 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func staticPodOperatorStatusJSONPatchNoError(original, modified *operatorv1.StaticPodOperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+	return cmp.Diff(original, modified)
 }
 
 // UpdateStaticPodConditionFn returns a func to update a condition.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -334,7 +334,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20240110142250-07ee1a48ec84
+# github.com/openshift/library-go v0.0.0-20240229145526-d26b0b6227e4
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
As of 4.15, all feature gates for external cloud providers were promoted to GA. We therefore no longer need to have conditional logic to determine if the CCMs should be out of tree or not.
This has been updated in library-go but also needs to be updated here before we can remove the feature gates.