### PR TITLE
OCPBUGS-31865: bump(library-go)=release-4.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20231129134630-a782d1c1541c
 	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642
+	github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.16.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU
 github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642 h1:PUNuns2GoKAcIX8PdS0jOUcnq9pIp8miRRJ1M/y8vFc=
-github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
+github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4 h1:1iObai4zzg+ZZYFJcyz68DSqezMZvCPg8YR71kPkYsQ=
+github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -85,16 +85,26 @@ func NewRevisionController(
 // createRevisionIfNeeded takes care of creating content for the static pods to use.
 // returns whether or not requeue and if an error happened when updating status.  Normally it updates status itself.
 func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder events.Recorder, latestAvailableRevision int32, resourceVersion string) (bool, error) {
-	isLatestRevisionCurrent, reason := c.isLatestRevisionCurrent(ctx, latestAvailableRevision)
+	isLatestRevisionCurrent, requiredIsNotFound, reason := c.isLatestRevisionCurrent(ctx, latestAvailableRevision)
 
 	// check to make sure that the latestRevision has the exact content we expect.  No mutation here, so we start creating the next Revision only when it is required
 	if isLatestRevisionCurrent {
+		klog.V(4).Infof("Returning early, %d triggered and up to date", latestAvailableRevision)
 		return false, nil
 	}
 
 	nextRevision := latestAvailableRevision + 1
-	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
-	if err := c.createNewRevision(ctx, recorder, nextRevision, reason); err != nil {
+	var createdNewRevision bool
+	var err error
+	// check to make sure no new revision is created when a required object is missing
+	if requiredIsNotFound {
+		err = fmt.Errorf("%v", reason)
+	} else {
+		recorder.Eventf("StartingNewRevision", "new revision %d triggered by %q", nextRevision, reason)
+		createdNewRevision, err = c.createNewRevision(ctx, recorder, nextRevision, reason)
+	}
+
+	if err != nil {
 		cond := operatorv1.OperatorCondition{
 			Type:    "RevisionControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -107,6 +117,12 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 		}
 		return true, nil
 	}
+
+	if !createdNewRevision {
+		klog.V(4).Infof("Revision %v not created", nextRevision)
+		return false, nil
+	}
+	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
 
 	cond := operatorv1.OperatorCondition{
 		Type:   "RevisionControllerDegraded",
@@ -126,7 +142,7 @@ func nameFor(name string, revision int32) string {
 }
 
 // isLatestRevisionCurrent returns whether the latest revision is up to date and an optional reason
-func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revision int32) (bool, string) {
+func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revision int32) (bool, bool, string) {
 	configChanges := []string{}
 	for _, cm := range c.configMaps {
 		requiredData := map[string]string{}
@@ -134,11 +150,11 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 
 		required, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(ctx, cm.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !cm.Optional {
-			return false, err.Error()
+			return false, true, err.Error()
 		}
 		existing, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(ctx, nameFor(cm.Name, revision), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !cm.Optional {
-			return false, err.Error()
+			return false, false, err.Error()
 		}
 		if required != nil {
 			requiredData = required.Data
@@ -171,11 +187,11 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 
 		required, err := c.secretGetter.Secrets(c.targetNamespace).Get(ctx, s.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !s.Optional {
-			return false, err.Error()
+			return false, true, err.Error()
 		}
 		existing, err := c.secretGetter.Secrets(c.targetNamespace).Get(ctx, nameFor(s.Name, revision), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !s.Optional {
-			return false, err.Error()
+			return false, false, err.Error()
 		}
 		if required != nil {
 			requiredData = required.Data
@@ -202,61 +218,86 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 	}
 
 	if len(secretChanges) > 0 || len(configChanges) > 0 {
-		return false, strings.Join(append(secretChanges, configChanges...), ",")
+		return false, false, strings.Join(append(secretChanges, configChanges...), ",")
 	}
 
-	return true, ""
+	return true, false, ""
 }
 
-func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) error {
+// returns true if we created a revision
+func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) (bool, error) {
 	// Create a new InProgress status configmap
-	statusConfigMap := &corev1.ConfigMap{
+	desiredStatusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      nameFor("revision-status", revision),
+			Annotations: map[string]string{
+				"operator.openshift.io/revision-ready": "false",
+			},
 		},
 		Data: map[string]string{
 			"revision": fmt.Sprintf("%d", revision),
 			"reason":   reason,
 		},
 	}
-	statusConfigMap, _, err := resourceapply.ApplyConfigMap(ctx, c.configMapGetter, recorder, statusConfigMap)
-	if err != nil {
-		return err
+	createdStatus, err := c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Create(ctx, desiredStatusConfigMap, metav1.CreateOptions{})
+	switch {
+	case apierrors.IsAlreadyExists(err):
+		if createdStatus == nil || len(createdStatus.UID) == 0 {
+			createdStatus, err = c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Get(ctx, desiredStatusConfigMap.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+		}
+		// take a live GET here to get current status to check the annotation
+		if createdStatus.Annotations["operator.openshift.io/revision-ready"] == "true" {
+			// no work to do because our cache is out of date and when we're updated, we will be able to see the result
+			klog.Infof("down the branch indicating that our cache was out of date and we're trying to recreate a revision.")
+			return false, nil
+		}
+		// update the sync and continue
+	case err != nil:
+		return false, err
 	}
 
 	ownerRefs := []metav1.OwnerReference{{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",
-		Name:       statusConfigMap.Name,
-		UID:        statusConfigMap.UID,
+		Name:       createdStatus.Name,
+		UID:        createdStatus.UID,
 	}}
 
 	for _, cm := range c.configMaps {
 		obj, _, err := resourceapply.SyncConfigMap(ctx, c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !cm.Optional {
-			return apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
 		}
 	}
 	for _, s := range c.secrets {
 		obj, _, err := resourceapply.SyncSecret(ctx, c.secretGetter, recorder, c.targetNamespace, s.Name, c.targetNamespace, nameFor(s.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !s.Optional {
-			return apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
 		}
 	}
 
-	return nil
+	createdStatus.Annotations["operator.openshift.io/revision-ready"] = "true"
+	if _, err := c.configMapGetter.ConfigMaps(createdStatus.Namespace).Update(ctx, createdStatus, metav1.UpdateOptions{}); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // getLatestAvailableRevision returns the latest known revision to the operator
 // This is determined by checking revision status configmaps.
 func (c RevisionController) getLatestAvailableRevision(ctx context.Context) (int32, error) {
+	// this appears to use a cached getter.  I conceded that past-David should have explicitly used Listers
 	configMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, err
@@ -281,7 +322,7 @@ func (c RevisionController) getLatestAvailableRevision(ctx context.Context) (int
 }
 
 func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	operatorSpec, _, latestAvailableRevision, resourceVersion, err := c.operatorClient.GetLatestRevisionState()
+	operatorSpec, _, latestAvailableRevisionSeenByOperator, resourceVersion, err := c.operatorClient.GetLatestRevisionState()
 	if err != nil {
 		return err
 	}
@@ -290,28 +331,22 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return nil
 	}
 
-	klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", latestAvailableRevision, resourceVersion)
-
-	// If the operator status has 0 as its latest available revision, this is either the first revision
-	// or possibly the operator resource was deleted and reset back to 0, which is not what we want so check configmaps
-	if latestAvailableRevision == 0 {
-		// Check to see if current revision is accurate and if not, search through configmaps for latest revision
-		latestRevision, err := c.getLatestAvailableRevision(ctx)
+	// If the operator status's latest available revision is not the same as the observed latest revision, update the operator.
+	latestObservedRevision, err := c.getLatestAvailableRevision(ctx)
+	if err != nil {
+		return err
+	}
+	if latestObservedRevision != 0 && latestAvailableRevisionSeenByOperator != latestObservedRevision {
+		// Then make sure that revision number is what's in the operator status
+		_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, latestObservedRevision)
 		if err != nil {
 			return err
 		}
-		if latestRevision != 0 {
-			// Then make sure that revision number is what's in the operator status
-			_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, latestRevision)
-			if err != nil {
-				return err
-			}
-			// regardless of whether we made a change, requeue to rerun the sync with updated status
-			return factory.SyntheticRequeueError
-		}
+		// regardless of whether we made a change, requeue to rerun the sync with updated status
+		return factory.SyntheticRequeueError
 	}
 
-	requeue, syncErr := c.createRevisionIfNeeded(ctx, syncCtx.Recorder(), latestAvailableRevision, resourceVersion)
+	requeue, syncErr := c.createRevisionIfNeeded(ctx, syncCtx.Recorder(), latestAvailableRevisionSeenByOperator, resourceVersion)
 	if requeue && syncErr == nil {
 		return factory.SyntheticRequeueError
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642
+# github.com/openshift/library-go v0.0.0-20240403193518-3e3d5f9cf7a4
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
Evidence for https://github.com/openshift/library-go/pull/1683

/hold