### PR TITLE
OCPBUGS-31807: Use RotatedSigningCASecret in update only mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/api v0.0.0-20231129134630-a782d1c1541c
 	github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642
+	github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95
 	github.com/pkg/profile v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.16.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479 h1:IU
 github.com/openshift/build-machinery-go v0.0.0-20230228230858-4cd708338479/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642 h1:PUNuns2GoKAcIX8PdS0jOUcnq9pIp8miRRJ1M/y8vFc=
-github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
+github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95 h1:7fzNW/fn2vID+h5IWNmueWCmjwNF/obnjIXhI/vHgfY=
+github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -139,6 +139,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -167,6 +171,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -190,6 +198,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -218,6 +230,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -243,6 +259,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -271,6 +291,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -296,6 +320,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -325,6 +353,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -350,6 +382,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -379,6 +415,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -404,6 +444,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -433,6 +477,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -457,6 +505,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -488,6 +540,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -509,6 +565,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -537,6 +597,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -558,6 +622,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -586,6 +654,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -607,6 +679,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -635,6 +711,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -656,6 +736,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -684,6 +768,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},
@@ -707,6 +795,10 @@ func newCertRotationController(
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:                 kubeClient.CoreV1(),
 			EventRecorder:          eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		certrotation.CABundleConfigMap{
 			Namespace: operatorclient.OperatorNamespace,
@@ -742,6 +834,10 @@ func newCertRotationController(
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
 			Client:        kubeClient.CoreV1(),
 			EventRecorder: eventRecorder,
+
+			// we will remove this when we migrate all of the affected secret
+			// objects to their intended type: https://issues.redhat.com/browse/API-1800
+			UseSecretUpdateOnly: true,
 		},
 		eventRecorder,
 		&certrotation.StaticPodConditionStatusReporter{OperatorClient: operatorClient},

--- a/test/e2e/certrotation_test.go
+++ b/test/e2e/certrotation_test.go
@@ -113,7 +113,7 @@ func TestCertRotationStompOnBadType(t *testing.T) {
 		}
 		if _, err := kubeClient.CoreV1().Secrets(operatorclient.OperatorNamespace).Create(context.TODO(), &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: operatorclient.OperatorNamespace, Name: "aggregator-client-signer"},
-			Type:       "Opaque",
+			Type:       "SecretTypeTLS",
 		}, metav1.CreateOptions{}); err != nil {
 			return false, nil
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -52,6 +52,12 @@ type RotatedSigningCASecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*crypto.CA, error) {
@@ -72,10 +78,15 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +101,7 @@ func (c RotatedSigningCASecret) ensureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -68,6 +68,12 @@ type RotatedSelfSignedCertKeySecret struct {
 	Lister        corev1listers.SecretLister
 	Client        corev1client.SecretsGetter
 	EventRecorder events.Recorder
+
+	// Deprecated: DO NOT eanble, it is intended as a short term hack for a very specific use case,
+	// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+	// we will remove this when we migrate all of the affected secret
+	// objects to their intended type: https://issues.redhat.com/browse/API-1800
+	UseSecretUpdateOnly bool
 }
 
 type TargetCertCreator interface {
@@ -107,10 +113,15 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 		}
 	}
 
+	applyFn := resourceapply.ApplySecret
+	if c.UseSecretUpdateOnly {
+		applyFn = resourceapply.ApplySecretDoNotUse
+	}
+
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}
@@ -125,7 +136,7 @@ func (c RotatedSelfSignedCertKeySecret) ensureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := resourceapply.ApplySecret(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -84,7 +84,15 @@ func ApplyConfigMap(ctx context.Context, client coreclientv1.ConfigMapsGetter, r
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecret(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
-	return ApplySecretImproved(ctx, client, recorder, required, noCache)
+	return applySecretImproved(ctx, client, recorder, required, noCache, false)
+}
+
+// ApplySecretDoNotUse is depreated and will be removed
+// Deprecated: DO NOT USE, it is intended as a short term hack for a very specific use case,
+// and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
+// Use ApplySecret instead.
+func ApplySecretDoNotUse(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, required *corev1.Secret) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, required, noCache, true)
 }
 
 // ApplyNamespace merges objectmeta, does not worry about anything else
@@ -347,6 +355,10 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 
 // ApplySecret merges objectmeta, requires data
 func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache) (*corev1.Secret, bool, error) {
+	return applySecretImproved(ctx, client, recorder, requiredInput, cache, false)
+}
+
+func applySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter, recorder events.Recorder, requiredInput *corev1.Secret, cache ResourceCache, updateOnly bool) (*corev1.Secret, bool, error) {
 	// copy the stringData to data.  Error on a data content conflict inside required.  This is usually a bug.
 
 	existing, err := client.Secrets(requiredInput.Namespace).Get(ctx, requiredInput.Name, metav1.GetOptions{})
@@ -426,6 +438,12 @@ func ApplySecretImproved(ctx context.Context, client coreclientv1.SecretsGetter,
 	 * https://github.com/kubernetes/kubernetes/blob/98e65951dccfd40d3b4f31949c2ab8df5912d93e/pkg/apis/core/validation/validation.go#L5048
 	 * We need to explicitly opt for delete+create in that case.
 	 */
+	if updateOnly {
+		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, existingCopy, err)
+		return actual, err == nil, err
+	}
+
 	if existingCopy.Type == existing.Type {
 		actual, err = client.Secrets(required.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 		reportUpdateEvent(recorder, existingCopy, err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -85,16 +85,26 @@ func NewRevisionController(
 // createRevisionIfNeeded takes care of creating content for the static pods to use.
 // returns whether or not requeue and if an error happened when updating status.  Normally it updates status itself.
 func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder events.Recorder, latestAvailableRevision int32, resourceVersion string) (bool, error) {
-	isLatestRevisionCurrent, reason := c.isLatestRevisionCurrent(ctx, latestAvailableRevision)
+	isLatestRevisionCurrent, requiredIsNotFound, reason := c.isLatestRevisionCurrent(ctx, latestAvailableRevision)
 
 	// check to make sure that the latestRevision has the exact content we expect.  No mutation here, so we start creating the next Revision only when it is required
 	if isLatestRevisionCurrent {
+		klog.V(4).Infof("Returning early, %d triggered and up to date", latestAvailableRevision)
 		return false, nil
 	}
 
 	nextRevision := latestAvailableRevision + 1
-	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
-	if err := c.createNewRevision(ctx, recorder, nextRevision, reason); err != nil {
+	var createdNewRevision bool
+	var err error
+	// check to make sure no new revision is created when a required object is missing
+	if requiredIsNotFound {
+		err = fmt.Errorf("%v", reason)
+	} else {
+		recorder.Eventf("StartingNewRevision", "new revision %d triggered by %q", nextRevision, reason)
+		createdNewRevision, err = c.createNewRevision(ctx, recorder, nextRevision, reason)
+	}
+
+	if err != nil {
 		cond := operatorv1.OperatorCondition{
 			Type:    "RevisionControllerDegraded",
 			Status:  operatorv1.ConditionTrue,
@@ -107,6 +117,12 @@ func (c RevisionController) createRevisionIfNeeded(ctx context.Context, recorder
 		}
 		return true, nil
 	}
+
+	if !createdNewRevision {
+		klog.V(4).Infof("Revision %v not created", nextRevision)
+		return false, nil
+	}
+	recorder.Eventf("RevisionTriggered", "new revision %d triggered by %q", nextRevision, reason)
 
 	cond := operatorv1.OperatorCondition{
 		Type:   "RevisionControllerDegraded",
@@ -126,7 +142,7 @@ func nameFor(name string, revision int32) string {
 }
 
 // isLatestRevisionCurrent returns whether the latest revision is up to date and an optional reason
-func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revision int32) (bool, string) {
+func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revision int32) (bool, bool, string) {
 	configChanges := []string{}
 	for _, cm := range c.configMaps {
 		requiredData := map[string]string{}
@@ -134,11 +150,11 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 
 		required, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(ctx, cm.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !cm.Optional {
-			return false, err.Error()
+			return false, true, err.Error()
 		}
 		existing, err := c.configMapGetter.ConfigMaps(c.targetNamespace).Get(ctx, nameFor(cm.Name, revision), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !cm.Optional {
-			return false, err.Error()
+			return false, false, err.Error()
 		}
 		if required != nil {
 			requiredData = required.Data
@@ -171,11 +187,11 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 
 		required, err := c.secretGetter.Secrets(c.targetNamespace).Get(ctx, s.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !s.Optional {
-			return false, err.Error()
+			return false, true, err.Error()
 		}
 		existing, err := c.secretGetter.Secrets(c.targetNamespace).Get(ctx, nameFor(s.Name, revision), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) && !s.Optional {
-			return false, err.Error()
+			return false, false, err.Error()
 		}
 		if required != nil {
 			requiredData = required.Data
@@ -202,61 +218,86 @@ func (c RevisionController) isLatestRevisionCurrent(ctx context.Context, revisio
 	}
 
 	if len(secretChanges) > 0 || len(configChanges) > 0 {
-		return false, strings.Join(append(secretChanges, configChanges...), ",")
+		return false, false, strings.Join(append(secretChanges, configChanges...), ",")
 	}
 
-	return true, ""
+	return true, false, ""
 }
 
-func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) error {
+// returns true if we created a revision
+func (c RevisionController) createNewRevision(ctx context.Context, recorder events.Recorder, revision int32, reason string) (bool, error) {
 	// Create a new InProgress status configmap
-	statusConfigMap := &corev1.ConfigMap{
+	desiredStatusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      nameFor("revision-status", revision),
+			Annotations: map[string]string{
+				"operator.openshift.io/revision-ready": "false",
+			},
 		},
 		Data: map[string]string{
 			"revision": fmt.Sprintf("%d", revision),
 			"reason":   reason,
 		},
 	}
-	statusConfigMap, _, err := resourceapply.ApplyConfigMap(ctx, c.configMapGetter, recorder, statusConfigMap)
-	if err != nil {
-		return err
+	createdStatus, err := c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Create(ctx, desiredStatusConfigMap, metav1.CreateOptions{})
+	switch {
+	case apierrors.IsAlreadyExists(err):
+		if createdStatus == nil || len(createdStatus.UID) == 0 {
+			createdStatus, err = c.configMapGetter.ConfigMaps(desiredStatusConfigMap.Namespace).Get(ctx, desiredStatusConfigMap.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+		}
+		// take a live GET here to get current status to check the annotation
+		if createdStatus.Annotations["operator.openshift.io/revision-ready"] == "true" {
+			// no work to do because our cache is out of date and when we're updated, we will be able to see the result
+			klog.Infof("down the branch indicating that our cache was out of date and we're trying to recreate a revision.")
+			return false, nil
+		}
+		// update the sync and continue
+	case err != nil:
+		return false, err
 	}
 
 	ownerRefs := []metav1.OwnerReference{{
 		APIVersion: "v1",
 		Kind:       "ConfigMap",
-		Name:       statusConfigMap.Name,
-		UID:        statusConfigMap.UID,
+		Name:       createdStatus.Name,
+		UID:        createdStatus.UID,
 	}}
 
 	for _, cm := range c.configMaps {
 		obj, _, err := resourceapply.SyncConfigMap(ctx, c.configMapGetter, recorder, c.targetNamespace, cm.Name, c.targetNamespace, nameFor(cm.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !cm.Optional {
-			return apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("configmaps"), cm.Name)
 		}
 	}
 	for _, s := range c.secrets {
 		obj, _, err := resourceapply.SyncSecret(ctx, c.secretGetter, recorder, c.targetNamespace, s.Name, c.targetNamespace, nameFor(s.Name, revision), ownerRefs)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if obj == nil && !s.Optional {
-			return apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
+			return false, apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
 		}
 	}
 
-	return nil
+	createdStatus.Annotations["operator.openshift.io/revision-ready"] = "true"
+	if _, err := c.configMapGetter.ConfigMaps(createdStatus.Namespace).Update(ctx, createdStatus, metav1.UpdateOptions{}); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // getLatestAvailableRevision returns the latest known revision to the operator
 // This is determined by checking revision status configmaps.
 func (c RevisionController) getLatestAvailableRevision(ctx context.Context) (int32, error) {
+	// this appears to use a cached getter.  I conceded that past-David should have explicitly used Listers
 	configMaps, err := c.configMapGetter.ConfigMaps(c.targetNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, err
@@ -281,7 +322,7 @@ func (c RevisionController) getLatestAvailableRevision(ctx context.Context) (int
 }
 
 func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	operatorSpec, _, latestAvailableRevision, resourceVersion, err := c.operatorClient.GetLatestRevisionState()
+	operatorSpec, _, latestAvailableRevisionSeenByOperator, resourceVersion, err := c.operatorClient.GetLatestRevisionState()
 	if err != nil {
 		return err
 	}
@@ -290,28 +331,22 @@ func (c RevisionController) sync(ctx context.Context, syncCtx factory.SyncContex
 		return nil
 	}
 
-	klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", latestAvailableRevision, resourceVersion)
-
-	// If the operator status has 0 as its latest available revision, this is either the first revision
-	// or possibly the operator resource was deleted and reset back to 0, which is not what we want so check configmaps
-	if latestAvailableRevision == 0 {
-		// Check to see if current revision is accurate and if not, search through configmaps for latest revision
-		latestRevision, err := c.getLatestAvailableRevision(ctx)
+	// If the operator status's latest available revision is not the same as the observed latest revision, update the operator.
+	latestObservedRevision, err := c.getLatestAvailableRevision(ctx)
+	if err != nil {
+		return err
+	}
+	if latestObservedRevision != 0 && latestAvailableRevisionSeenByOperator != latestObservedRevision {
+		// Then make sure that revision number is what's in the operator status
+		_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, latestObservedRevision)
 		if err != nil {
 			return err
 		}
-		if latestRevision != 0 {
-			// Then make sure that revision number is what's in the operator status
-			_, _, err := c.operatorClient.UpdateLatestRevisionOperatorStatus(ctx, latestRevision)
-			if err != nil {
-				return err
-			}
-			// regardless of whether we made a change, requeue to rerun the sync with updated status
-			return factory.SyntheticRequeueError
-		}
+		// regardless of whether we made a change, requeue to rerun the sync with updated status
+		return factory.SyntheticRequeueError
 	}
 
-	requeue, syncErr := c.createRevisionIfNeeded(ctx, syncCtx.Recorder(), latestAvailableRevision, resourceVersion)
+	requeue, syncErr := c.createRevisionIfNeeded(ctx, syncCtx.Recorder(), latestAvailableRevisionSeenByOperator, resourceVersion)
 	if requeue && syncErr == nil {
 		return factory.SyntheticRequeueError
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/i
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane
 github.com/openshift/client-go/operatorcontrolplane/informers/externalversions/operatorcontrolplane/v1alpha1
 github.com/openshift/client-go/operatorcontrolplane/listers/operatorcontrolplane/v1alpha1
-# github.com/openshift/library-go v0.0.0-20240306175506-206f66c55642
+# github.com/openshift/library-go v0.0.0-20240409080036-0ebfe3e52a95
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
UseSecretUpdateOnly is intended as a short term hack for a very specific use case,
and it works in tandem with a particular carry patch applied to the openshift kube-apiserver.
(https://github.com/openshift/kubernetes/pull/1924)

we will remove this when we migrate all of the affected secret
objects to their intended type: https://issues.redhat.com/browse/API-1800

in short tls secrets used by this operator are reconciled
by multiple controllers ([the cert controller run by the operator](https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/pkg/operator/certrotationcontroller/certrotationcontroller.go#L85) and [the same controller run by the recovery pod](https://github.com/openshift/cluster-kube-controller-manager-operator/blob/master/pkg/cmd/recoverycontroller/cmd.go#L92)) at the same time without any coordination.

the issue is that the secret's crypto material
can be regenerated, which has serious consequences for the platform
as it can break external clients and the cluster itself.

xref: https://github.com/openshift/library-go/pull/1710
xref: https://github.com/openshift/kubernetes/pull/1939