### PR TITLE
[release-4.14] OCPBUGS-31354: Create separate SNO alert for control plane high cpu usage

### DIFF
--- a/bindata/assets/alerts/cpu-utilization-sno.yaml
+++ b/bindata/assets/alerts/cpu-utilization-sno.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cpu-utilization-sno
+  namespace: openshift-kube-apiserver
+spec:
+  groups:
+    - name: control-plane-cpu-utilization
+      rules:
+        - alert: HighOverallControlPlaneCPU
+          annotations:
+            summary: >-
+              CPU utilization across control plane pods is more than 60% of {{ . }} CPU. High CPU usage usually means that something goes wrong.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            description: >-    
+              This level of CPU utlization of an control plane is probably not a problem under most circumstances, but high levels of utilization may indicate
+              problems with cluster or control plane pods. To manage this alert or modify threshold it in case of false positives see the following link:
+              https://docs.openshift.com/container-platform/latest/monitoring/managing-alerts.html
+          expr: |
+            sum(rate(container_cpu_usage_seconds_total{namespace=~"openshift-.*",image!=""}[5m])) / {{ . }} * 100 > 60
+          for: 10m
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: warning
+        - alert: ExtremelyHighIndividualControlPlaneCPU
+          annotations:
+            summary: >-
+              CPU utilization across control plane pods is more than 90% of {{ . }} CPU. High CPU usage usually means that something goes wrong.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-apiserver-operator/ExtremelyHighIndividualControlPlaneCPU.md
+            description: >-
+              This level of CPU utlization of an control plane is probably not a problem under most circumstances, but high levels of utilization may indicate
+              problems with cluster or control plane pods. When workload partitioning is enabled,
+              Extreme CPU pressure can cause slow serialization and poor performance from the kube-apiserver and etcd.
+              When this happens, there is a risk of clients seeing non-responsive API requests which are issued again
+              causing even more CPU pressure.
+              It can also cause failing liveness probes due to slow etcd responsiveness on the backend.
+              If one kube-apiserver fails under this condition, chances are you will experience a cascade as the remaining
+              kube-apiservers are also under-provisioned.
+              To fix this, increase the CPU and memory on your control plane nodes.
+              To manage this alert or modify threshold it in case of false positives see the following link: 
+              https://docs.openshift.com/container-platform/latest/monitoring/managing-alerts.html
+          expr: |
+            sum(rate(container_cpu_usage_seconds_total{namespace=~"openshift-.*",image!=""}[5m])) / {{ . }} * 100 > 90
+          for: 1h
+          labels:
+            namespace: openshift-kube-apiserver
+            severity: critical

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/targetconfigcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/terminationobserver"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/webhooksupportabilitycontroller"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/workloadpartitioning"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/apiserver/controller/auditpolicy"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
@@ -169,6 +170,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+
 	var notOnSingleReplicaTopology resourceapply.ConditionalFunction = func() bool {
 		return infrastructure.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode
 	}
@@ -199,7 +201,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
 			"assets/alerts/api-usage.yaml",
 			"assets/alerts/audit-errors.yaml",
-			"assets/alerts/cpu-utilization.yaml",
 			"assets/alerts/kube-apiserver-requests.yaml",
 			"assets/alerts/kube-apiserver-slos-basic.yaml",
 			"assets/alerts/podsecurity-violations.yaml",
@@ -212,9 +213,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorClient,
 		controllerContext.EventRecorder,
 	).
-		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml"}, notOnSingleReplicaTopology, nil).
+		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml", "assets/alerts/cpu-utilization.yaml"}, notOnSingleReplicaTopology, nil).
 		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos.yaml"}, never, nil). // TODO remove in 4.13
 		AddKubeInformers(kubeInformersForNamespaces)
+
+	err = workloadpartitioning.CreateSNOAlert(ctx, dynamicClient, infrastructure.Status, controllerContext.EventRecorder)
+	if err != nil {
+		klog.Errorln("Failed to create workload partition based sno cpu alert", err)
+	}
 
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),

--- a/pkg/operator/workloadpartitioning/cpuPartitioningAlertRenderer.go
+++ b/pkg/operator/workloadpartitioning/cpuPartitioningAlertRenderer.go
@@ -1,0 +1,114 @@
+package workloadpartitioning
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"text/template"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/bindata"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/cpuset"
+)
+
+// default and taken from the docs
+const defaultCoresNum = 8
+
+var performanceGroup = schema.GroupVersionResource{Group: "performance.openshift.io", Version: "v2", Resource: "performanceprofiles"}
+
+type performanceProfileList struct {
+	Items []performanceProfile `json:"items"`
+}
+
+type performanceProfile struct {
+	Spec struct {
+		CPU *struct {
+			Reserved *string `json:"reserved"`
+		} `json:"cpu"`
+		NodeSelector map[string]string `json:"nodeSelector"`
+	} `json:"spec"`
+}
+
+func CreateSNOAlert(ctx context.Context, client dynamic.Interface, infra v1.InfrastructureStatus, recorder events.Recorder) error {
+	if infra.InfrastructureTopology != v1.SingleReplicaTopologyMode {
+		return nil
+	}
+
+	cores := defaultCoresNum
+	if infra.CPUPartitioning == v1.CPUPartitioningAllNodes {
+		wpCores, err := workloadPartitioningCoresNum(ctx, client)
+		if err != nil {
+			return err
+		}
+		cores = wpCores
+	}
+
+	fileData, err := bindata.Asset("assets/alerts/cpu-utilization-sno.yaml")
+	if err != nil {
+		return err
+	}
+	tpl, err := template.New("tpl").Parse(string(fileData))
+	if err != nil {
+		return err
+	}
+
+	buf := &bytes.Buffer{}
+	err = tpl.Execute(buf, cores)
+	if err != nil {
+		return err
+	}
+
+	alert, err := resourceread.ReadGenericWithUnstructured(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	_, _, err = resourceapply.ApplyPrometheusRule(ctx, client, recorder, alert.(*unstructured.Unstructured))
+
+	return err
+}
+
+func workloadPartitioningCoresNum(ctx context.Context, client dynamic.Interface) (int, error) {
+	obj, err := client.Resource(performanceGroup).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return defaultCoresNum, nil
+		}
+		return 0, err
+	}
+
+	objRaw, err := obj.MarshalJSON()
+	if err != nil {
+		return 0, err
+	}
+
+	res := &performanceProfileList{}
+	err = json.Unmarshal(objRaw, &res)
+	if err != nil {
+		return 0, err
+	}
+	for _, pf := range res.Items {
+		if _, ok := pf.Spec.NodeSelector["node-role.kubernetes.io/master"]; !ok {
+			continue
+		}
+		if pf.Spec.CPU == nil || pf.Spec.CPU.Reserved == nil {
+			continue
+		}
+		return coresInCPUSet(*pf.Spec.CPU.Reserved)
+	}
+
+	return defaultCoresNum, nil
+}
+
+func coresInCPUSet(set string) (int, error) {
+	cpuMap, err := cpuset.Parse(set)
+	return cpuMap.Size(), err
+}

--- a/vendor/k8s.io/utils/cpuset/OWNERS
+++ b/vendor/k8s.io/utils/cpuset/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - dchen1107
+  - derekwaynecarr
+  - ffromani
+  - klueska
+  - SergeyKanzhelev

--- a/vendor/k8s.io/utils/cpuset/cpuset.go
+++ b/vendor/k8s.io/utils/cpuset/cpuset.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cpuset represents a collection of CPUs in a 'set' data structure.
+//
+// It can be used to represent core IDs, hyper thread siblings, CPU nodes, or processor IDs.
+//
+// The only special thing about this package is that
+// methods are provided to convert back and forth from Linux 'list' syntax.
+// See http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS for details.
+//
+// Future work can migrate this to use a 'set' library, and relax the dubious 'immutable' property.
+//
+// This package was originally developed in the 'kubernetes' repository.
+package cpuset
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// CPUSet is a thread-safe, immutable set-like data structure for CPU IDs.
+type CPUSet struct {
+	elems map[int]struct{}
+}
+
+// New returns a new CPUSet containing the supplied elements.
+func New(cpus ...int) CPUSet {
+	s := CPUSet{
+		elems: map[int]struct{}{},
+	}
+	for _, c := range cpus {
+		s.add(c)
+	}
+	return s
+}
+
+// add adds the supplied elements to the CPUSet.
+// It is intended for internal use only, since it mutates the CPUSet.
+func (s CPUSet) add(elems ...int) {
+	for _, elem := range elems {
+		s.elems[elem] = struct{}{}
+	}
+}
+
+// Size returns the number of elements in this set.
+func (s CPUSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s CPUSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s CPUSet) Contains(cpu int) bool {
+	_, found := s.elems[cpu]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s CPUSet) Equals(s2 CPUSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// filter returns a new CPU set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s CPUSet) filter(predicate func(int) bool) CPUSet {
+	r := New()
+	for cpu := range s.elems {
+		if predicate(cpu) {
+			r.add(cpu)
+		}
+	}
+	return r
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s CPUSet) IsSubsetOf(s2 CPUSet) bool {
+	result := true
+	for cpu := range s.elems {
+		if !s2.Contains(cpu) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied sets, without mutating
+// either source set.
+func (s CPUSet) Union(s2 ...CPUSet) CPUSet {
+	r := New()
+	for cpu := range s.elems {
+		r.add(cpu)
+	}
+	for _, cs := range s2 {
+		for cpu := range cs.elems {
+			r.add(cpu)
+		}
+	}
+	return r
+}
+
+// Intersection returns a new CPU set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s CPUSet) Intersection(s2 CPUSet) CPUSet {
+	return s.filter(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// Difference returns a new CPU set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s CPUSet) Difference(s2 CPUSet) CPUSet {
+	return s.filter(func(cpu int) bool { return !s2.Contains(cpu) })
+}
+
+// List returns a slice of integers that contains all elements from
+// this set. The list is sorted.
+func (s CPUSet) List() []int {
+	result := s.UnsortedList()
+	sort.Ints(result)
+	return result
+}
+
+// UnsortedList returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) UnsortedList() []int {
+	result := make([]int, 0, len(s.elems))
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	return result
+}
+
+// String returns a new string representation of the elements in this CPU set
+// in canonical linux CPU list format.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func (s CPUSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	elems := s.List()
+
+	type rng struct {
+		start int
+		end   int
+	}
+
+	ranges := []rng{{elems[0], elems[0]}}
+
+	for i := 1; i < len(elems); i++ {
+		lastRange := &ranges[len(ranges)-1]
+		// if this element is adjacent to the high end of the last range
+		if elems[i] == lastRange.end+1 {
+			// then extend the last range to include this element
+			lastRange.end = elems[i]
+			continue
+		}
+		// otherwise, start a new range beginning with this element
+		ranges = append(ranges, rng{elems[i], elems[i]})
+	}
+
+	// construct string from ranges
+	var result bytes.Buffer
+	for _, r := range ranges {
+		if r.start == r.end {
+			result.WriteString(strconv.Itoa(r.start))
+		} else {
+			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+		}
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// Parse CPUSet constructs a new CPU set from a Linux CPU list formatted string.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func Parse(s string) (CPUSet, error) {
+	// Handle empty string.
+	if s == "" {
+		return New(), nil
+	}
+
+	result := New()
+
+	// Split CPU list string:
+	// "0-5,34,46-48" => ["0-5", "34", "46-48"]
+	ranges := strings.Split(s, ",")
+
+	for _, r := range ranges {
+		boundaries := strings.SplitN(r, "-", 2)
+		if len(boundaries) == 1 {
+			// Handle ranges that consist of only one element like "34".
+			elem, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return New(), err
+			}
+			result.add(elem)
+		} else if len(boundaries) == 2 {
+			// Handle multi-element ranges like "0-5".
+			start, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return New(), err
+			}
+			end, err := strconv.Atoi(boundaries[1])
+			if err != nil {
+				return New(), err
+			}
+			if start > end {
+				return New(), fmt.Errorf("invalid range %q (%d > %d)", r, start, end)
+			}
+			// start == end is acceptable (1-1 -> 1)
+
+			// Add all elements to the result.
+			// e.g. "0-5", "46-48" => [0, 1, 2, 3, 4, 5, 46, 47, 48].
+			for e := start; e <= end; e++ {
+				result.add(e)
+			}
+		}
+	}
+	return result, nil
+}
+
+// Clone returns a copy of this CPU set.
+func (s CPUSet) Clone() CPUSet {
+	r := New()
+	for elem := range s.elems {
+		r.add(elem)
+	}
+	return r
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1390,6 +1390,7 @@ k8s.io/pod-security-admission/api
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/clock/testing
+k8s.io/utils/cpuset
 k8s.io/utils/integer
 k8s.io/utils/internal/third_party/forked/golang/golang-lru
 k8s.io/utils/internal/third_party/forked/golang/net


### PR DESCRIPTION
Create separate SNO alert for control plane high cpu usage. This alert is also aware of workload partitioning and adjusts threshold if workload partitioning is enabled.

(cherry picked from commit d92b46166259ef43918e9f7cd6bc62f09a806d1f)