### PR TITLE
OCPBUGS-33184: Fix incorrect name for hostmount-anyuid SCC ClusterRole

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount.yaml
@@ -6,12 +6,13 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     rbac.authorization.kubernetes.io/autoupdate: "true"
-  name: system:openshift:scc:hostmount-anyuid
+    openshift.io/description: "This ClusterRole was is created by default, but refers to an SCC that doesn't exist. This ClusterRole will likely be removed in a future release."
+  name: system:openshift:scc:hostmount
 rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - hostmount-anyuid
+  - hostmount
   resources:
   - securitycontextconstraints
   verbs:


### PR DESCRIPTION
The SCC is named "hostmount-anyuid", and not just "hostmount", so I'm not sure this cluster role ever worked correctly.