### PR TITLE
remove the StorageVersionMigration which is useless

### DIFF
--- a/bindata/assets/kube-apiserver/storage-version-migration-flowschema.yaml
+++ b/bindata/assets/kube-apiserver/storage-version-migration-flowschema.yaml
@@ -1,9 +1,0 @@
-apiVersion: migration.k8s.io/v1alpha1
-kind: StorageVersionMigration
-metadata:
-  name: flowcontrol-flowschema-storage-version-migration
-spec:
-  resource:
-    group: flowcontrol.apiserver.k8s.io
-    version: v1beta1
-    resource: flowschemas

--- a/bindata/assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml
+++ b/bindata/assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml
@@ -1,9 +1,0 @@
-apiVersion: migration.k8s.io/v1alpha1
-kind: StorageVersionMigration
-metadata:
-  name: flowcontrol-prioritylevel-storage-version-migration
-spec:
-  resource:
-    group: flowcontrol.apiserver.k8s.io
-    version: v1beta1
-    resource: prioritylevelconfigurations

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -204,8 +204,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"assets/kube-apiserver/localhost-recovery-sa.yaml",
 			"assets/kube-apiserver/localhost-recovery-token.yaml",
 			"assets/kube-apiserver/apiserver.openshift.io_apirequestcount.yaml",
-			"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
-			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
 			"assets/alerts/api-usage.yaml",
 			"assets/alerts/audit-errors.yaml",
 			"assets/alerts/cpu-utilization.yaml",


### PR DESCRIPTION
address https://github.com/openshift/cluster-kube-apiserver-operator/issues/1682


found the related JIRA https://issues.redhat.com/browse/OCPBUGS-22336 which has been closed