### PR TITLE
AUTH-521: add disabled syncer as reason to CFE for PSA

### DIFF
--- a/pkg/operator/podsecurityreadinesscontroller/conditions_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/conditions_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCondition(t *testing.T) {
@@ -62,8 +64,184 @@ func TestCondition(t *testing.T) {
 		}
 	})
 
-	t.Run("without anything", func(t *testing.T) {
-		cond := podSecurityOperatorConditions{}
-		cond.addViolation("hello world")
-	})
+}
+
+func TestOperatorStatus(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		namespace []*corev1.Namespace
+		expected  map[string]operatorv1.ConditionStatus
+	}{
+		{
+			name: "with default namespace",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "syncer-by-default",
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionTrue,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionFalse,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionFalse,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "with customer disabled syncer",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "syncer-no-thx",
+						Labels: map[string]string{
+							"security.openshift.io/scc.podSecurityLabelSync": "false",
+						},
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionFalse,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionFalse,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionFalse,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionTrue,
+			},
+		},
+		{
+			name: "with customer re-enabled syncer",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "syncer-yes-plz",
+						Labels: map[string]string{
+							"security.openshift.io/scc.podSecurityLabelSync": "true",
+						},
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionTrue,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionFalse,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionFalse,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "with openshift namespace",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-fail",
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionFalse,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionTrue,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionFalse,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "with run-level 0 namespace",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kube-system",
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionFalse,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionFalse,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionTrue,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionFalse,
+			},
+		},
+		{
+			name: "with other customer types in combination",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foobar",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foobar",
+						Labels: map[string]string{
+							"security.openshift.io/scc.podSecurityLabelSync": "false",
+						},
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionTrue,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionFalse,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionFalse,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionTrue,
+			},
+		},
+		{
+			name: "with other system types in combination",
+			namespace: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openshift-namespace",
+						Labels: map[string]string{
+							"pod-security.kubernetes.io/audit":         "restricted",
+							"pod-security.kubernetes.io/audit-version": "v1.24",
+							"pod-security.kubernetes.io/warn":          "restricted",
+							"pod-security.kubernetes.io/warn-version":  "v1.24",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "kube-system",
+						Labels: map[string]string{},
+					},
+				},
+			},
+			expected: map[string]operatorv1.ConditionStatus{
+				"PodSecurityCustomerEvaluationConditionsDetected":       operatorv1.ConditionFalse,
+				"PodSecurityOpenshiftEvaluationConditionsDetected":      operatorv1.ConditionTrue,
+				"PodSecurityRunLevelZeroEvaluationConditionsDetected":   operatorv1.ConditionTrue,
+				"PodSecurityDisabledSyncerEvaluationConditionsDetected": operatorv1.ConditionFalse,
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cond := podSecurityOperatorConditions{}
+
+			for _, ns := range tt.namespace {
+				cond.addViolation(ns)
+			}
+
+			status := &operatorv1.OperatorStatus{}
+			for _, f := range cond.toConditionFuncs() {
+				if err := f(status); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			for expectedType, expectedStatus := range tt.expected {
+				found := false
+
+				for _, condition := range status.Conditions {
+					if condition.Type == expectedType {
+						found = true
+						if condition.Status != expectedStatus {
+							t.Errorf("expected %s to be %v, have %v", expectedType, expectedStatus, condition.Status)
+						}
+					}
+				}
+
+				if !found {
+					t.Errorf("expected condition %s not found", expectedType)
+				}
+			}
+		})
+	}
 }

--- a/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
+++ b/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
@@ -79,7 +79,7 @@ func (c *PodSecurityReadinessController) sync(ctx context.Context, syncCtx facto
 				return err
 			}
 			if isViolating {
-				conditions.addViolation(ns.Name)
+				conditions.addViolation(&ns)
 			}
 
 			return nil

--- a/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
+++ b/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	applyconfiguration "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -24,11 +22,6 @@ import (
 const (
 	checkInterval = 240 * time.Minute // Adjust the interval as needed.
 )
-
-var podSecurityAlertLabels = []string{
-	psapi.AuditLevelLabel,
-	psapi.WarnLevelLabel,
-}
 
 // PodSecurityReadinessController checks if namespaces are ready for Pod Security Admission enforcement.
 type PodSecurityReadinessController struct {
@@ -46,19 +39,12 @@ func NewPodSecurityReadinessController(
 ) (factory.Controller, error) {
 	warningsHandler := &warningsHandler{}
 
-	kubeClientCopy := rest.CopyConfig(kubeConfig)
-	kubeClientCopy.WarningHandler = warningsHandler
-	// We don't want to overwhelm the apiserver with requests. On a cluster with
-	// 10k namespaces, we would send 10k + 1 requests to the apiserver.
-	kubeClientCopy.QPS = 2
-	kubeClientCopy.Burst = 2
-	kubeClient, err := kubernetes.NewForConfig(kubeClientCopy)
+	kubeClient, err := newWarningAwareKubeClient(warningsHandler, kubeConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	selector := labels.NewSelector()
-	labelsRequirement, err := labels.NewRequirement(psapi.EnforceLevelLabel, selection.DoesNotExist, []string{})
+	selector, err := nonEnforcingSelector()
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +53,7 @@ func NewPodSecurityReadinessController(
 		operatorClient:    operatorClient,
 		kubeClient:        kubeClient,
 		warningsHandler:   warningsHandler,
-		namespaceSelector: selector.Add(*labelsRequirement).String(),
+		namespaceSelector: selector,
 	}
 
 	return factory.New().
@@ -114,58 +100,23 @@ func (c *PodSecurityReadinessController) sync(ctx context.Context, syncCtx facto
 	return err
 }
 
-func (c *PodSecurityReadinessController) isNamespaceViolating(ctx context.Context, ns *corev1.Namespace) (bool, error) {
-	if ns.Labels[psapi.EnforceLevelLabel] != "" {
-		// If someone has taken care of the enforce label, we don't need to
-		// check for violations. Global Config nor PS-Label-Syncer will modify
-		// it.
-		return false, nil
-	}
-
-	targetLevel := ""
-	for _, label := range podSecurityAlertLabels {
-		levelStr, ok := ns.Labels[label]
-		if !ok {
-			continue
-		}
-
-		level, err := psapi.ParseLevel(levelStr)
-		if err != nil {
-			klog.V(4).InfoS("invalid level", "namespace", ns.Name, "level", levelStr)
-			continue
-		}
-
-		if targetLevel == "" {
-			targetLevel = levelStr
-			continue
-		}
-
-		if psapi.CompareLevels(psapi.Level(targetLevel), level) < 0 {
-			targetLevel = levelStr
-		}
-	}
-
-	if targetLevel == "" {
-		// Global Config will set it to "restricted".
-		targetLevel = string(psapi.LevelRestricted)
-	}
-
-	nsApply := applyconfiguration.Namespace(ns.Name).WithLabels(map[string]string{
-		psapi.EnforceLevelLabel: string(targetLevel),
-	})
-
-	_, err := c.kubeClient.CoreV1().
-		Namespaces().
-		Apply(ctx, nsApply, metav1.ApplyOptions{
-			DryRun:       []string{metav1.DryRunAll},
-			FieldManager: "pod-security-readiness-controller",
-		})
+func nonEnforcingSelector() (string, error) {
+	selector := labels.NewSelector()
+	labelsRequirement, err := labels.NewRequirement(psapi.EnforceLevelLabel, selection.DoesNotExist, []string{})
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
-	// The information we want is in the warnings. It collects violations.
-	warnings := c.warningsHandler.PopAll()
+	return selector.Add(*labelsRequirement).String(), nil
+}
 
-	return len(warnings) > 0, nil
+func newWarningAwareKubeClient(warningsHandler *warningsHandler, kubeConfig *rest.Config) (*kubernetes.Clientset, error) {
+	kubeClientCopy := rest.CopyConfig(kubeConfig)
+	kubeClientCopy.WarningHandler = warningsHandler
+	// We don't want to overwhelm the apiserver with requests. On a cluster with
+	// 10k namespaces, we would send 10k + 1 requests to the apiserver.
+	kubeClientCopy.QPS = 2
+	kubeClientCopy.Burst = 2
+
+	return kubernetes.NewForConfig(kubeClientCopy)
 }

--- a/pkg/operator/podsecurityreadinesscontroller/violation.go
+++ b/pkg/operator/podsecurityreadinesscontroller/violation.go
@@ -1,0 +1,72 @@
+package podsecurityreadinesscontroller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyconfiguration "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/klog/v2"
+	psapi "k8s.io/pod-security-admission/api"
+)
+
+var podSecurityAlertLabels = []string{
+	psapi.AuditLevelLabel,
+	psapi.WarnLevelLabel,
+}
+
+func (c *PodSecurityReadinessController) isNamespaceViolating(ctx context.Context, ns *corev1.Namespace) (bool, error) {
+	if ns.Labels[psapi.EnforceLevelLabel] != "" {
+		// If someone has taken care of the enforce label, we don't need to
+		// check for violations. Global Config nor PS-Label-Syncer will modify
+		// it.
+		return false, nil
+	}
+
+	targetLevel := ""
+	for _, label := range podSecurityAlertLabels {
+		levelStr, ok := ns.Labels[label]
+		if !ok {
+			continue
+		}
+
+		level, err := psapi.ParseLevel(levelStr)
+		if err != nil {
+			klog.V(4).InfoS("invalid level", "namespace", ns.Name, "level", levelStr)
+			continue
+		}
+
+		if targetLevel == "" {
+			targetLevel = levelStr
+			continue
+		}
+
+		if psapi.CompareLevels(psapi.Level(targetLevel), level) < 0 {
+			targetLevel = levelStr
+		}
+	}
+
+	if targetLevel == "" {
+		// Global Config will set it to "restricted".
+		targetLevel = string(psapi.LevelRestricted)
+	}
+
+	nsApply := applyconfiguration.Namespace(ns.Name).WithLabels(map[string]string{
+		psapi.EnforceLevelLabel: string(targetLevel),
+	})
+
+	_, err := c.kubeClient.CoreV1().
+		Namespaces().
+		Apply(ctx, nsApply, metav1.ApplyOptions{
+			DryRun:       []string{metav1.DryRunAll},
+			FieldManager: "pod-security-readiness-controller",
+		})
+	if err != nil {
+		return false, err
+	}
+
+	// The information we want is in the warnings. It collects violations.
+	warnings := c.warningsHandler.PopAll()
+
+	return len(warnings) > 0, nil
+}


### PR DESCRIPTION
## What

- Add a new reason that is being set if a customer disabled the label syncer.
- Check only namespaces, where we at least own one label.

## Why

We want to:

- identify who disabled it and will have a failing workload and
- "properly" calculate PSA violations and not "believe" every label we find