### PR TITLE
Remove ValidatingAdmissionPolicy DefaultGroupVersionsByFeatureGate

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -15,7 +15,6 @@ import (
 )
 
 var DefaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]schema.GroupVersion{
-	"ValidatingAdmissionPolicy": {{Group: "admissionregistration.k8s.io", Version: "v1beta1"}},
 	"DynamicResourceAllocation": {{Group: "resource.k8s.io", Version: "v1alpha2"}},
 }
 


### PR DESCRIPTION
ValidatingAdmissionPolicy is now GA with v1 so it is enabled by default. This DefaultGroupVersionsByFeatureGate for this API is no longer needed.