### PR TITLE
OCPBUGS-33963: Create one-shot migrations for the flowcontrol group.

### DIFF
--- a/bindata/assets/kube-apiserver/storage-version-migration-flowschema-v1beta3.yaml
+++ b/bindata/assets/kube-apiserver/storage-version-migration-flowschema-v1beta3.yaml
@@ -1,0 +1,9 @@
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: flowcontrol-flowschema-storage-version-migration-v1beta3
+spec:
+  resource:
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta3
+    resource: flowschemas

--- a/bindata/assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration-v1beta3.yaml
+++ b/bindata/assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration-v1beta3.yaml
@@ -1,0 +1,9 @@
+apiVersion: migration.k8s.io/v1alpha1
+kind: StorageVersionMigration
+metadata:
+  name: flowcontrol-prioritylevel-storage-version-migration-v1beta3
+spec:
+  resource:
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta3
+    resource: prioritylevelconfigurations

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -206,6 +206,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			"assets/kube-apiserver/apiserver.openshift.io_apirequestcount.yaml",
 			"assets/kube-apiserver/storage-version-migration-flowschema.yaml",
 			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration.yaml",
+			"assets/kube-apiserver/storage-version-migration-flowschema-v1beta3.yaml",
+			"assets/kube-apiserver/storage-version-migration-prioritylevelconfiguration-v1beta3.yaml",
 			"assets/alerts/api-usage.yaml",
 			"assets/alerts/audit-errors.yaml",
 			"assets/alerts/cpu-utilization.yaml",


### PR DESCRIPTION
The v1alpha1 version of the flowcontrol.apiserver.k8s.io group is removed in 4.16. Clusters installed prior to 4.8 may still have flowcontrol resources that were persisted using v1alpha1. If the storage version of those resources is not migrated before updating to 4.16, they will not be decodable. This ultimately prevents kube-apiserver instances from becoming ready.