### PR TITLE
OCPBUGS-34544: Disable PersistentVolumeLabel admission plugin

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -65,7 +65,6 @@ apiServerArguments:
     - NodeRestriction
     - OwnerReferencesPermissionEnforcement
     - PersistentVolumeClaimResize
-    - PersistentVolumeLabel
     - PodNodeSelector
     - PodTolerationRestriction
     - Priority


### PR DESCRIPTION
PersistentVolumeLabel admission plugin needs a valid cloud config. kube-apiserver does not get it in OCP 4.17, and thus it rejects valid in-tree GCE PersistentVolumes.

The admission plugin was deprecated upstream a long time ago, it was removed from Kubernetes 1.31 (OCP 4.18) and it cannot work without a cloud provider in kube-apiserver anyway.

cc @openshift/storage