### PR TITLE
OCPBUGS-34782: manifests: add ownership annotation for kubelet-bootstrap-kubeconfig

### DIFF
--- a/bindata/bootkube/manifests/configmap-kubelet-bootstrap-kubeconfig-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-kubelet-bootstrap-kubeconfig-ca.yaml
@@ -4,7 +4,8 @@ kind: ConfigMap
 metadata:
   name: kubelet-bootstrap-kubeconfig
   namespace: openshift-config-managed
+  annotations:
+    "openshift.io/owning-component": "kube-apiserver"
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kubelet-bootstrap-kubeconfig-ca-bundle.crt" | indent 4 }}
-


### PR DESCRIPTION
Make sure kubelet-bootstrap-kubeconfig (generated by installer) is annotated