### PR TITLE
OCPBUGS-34800: Update APIRemovedInNextReleaseInUse for kube 1.30 / ocp 4.17

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -16,7 +16,7 @@ spec:
               a successful upgrade to the next cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: >-
-            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release="1.30"})
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release="1.31"})
             * on (group,version,resource) group_left ()
             sum by (group,version,resource) (
             rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])
@@ -34,7 +34,7 @@ spec:
               a successful upgrade to the next EUS cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: >-
-            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release=~"1.3[01]"})
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release=~"1.31"})
             * on (group,version,resource) group_left ()
             sum by (group,version,resource) (
             rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])


### PR DESCRIPTION
APIRemovedInNextReleaseInUse: 1.30 -> 1.31
APIRemovedInNextEUSReleaseInUse: 1.3[01] -> 1.31