### PR TITLE
NO-JIRA: nodekubeconfigcontroller: set ownership component for node kubeconfigs

### DIFF
--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/api/annotations"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
@@ -146,6 +147,11 @@ func ensureNodeKubeconfigs(ctx context.Context, client coreclientv1.CoreV1Interf
 
 		requiredSecret.StringData[k] = data
 	}
+
+	if requiredSecret.Annotations == nil {
+		requiredSecret.Annotations = map[string]string{}
+	}
+	requiredSecret.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
 	_, _, err = resourceapply.ApplySecret(ctx, client, recorder, requiredSecret)
 	if err != nil {

--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller_test.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/api/annotations"
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -140,6 +141,9 @@ func TestEnsureNodeKubeconfigs(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "openshift-kube-apiserver",
 							Name:      "node-kubeconfigs",
+							Annotations: map[string]string{
+								annotations.OpenShiftComponent: "kube-apiserver",
+							},
 						},
 						Data: map[string][]byte{
 							"localhost.kubeconfig": []byte(`apiVersion: v1


### PR DESCRIPTION
Kubeconfigs are parsed as TLS artifact registry sources, so secrets containing kubeconfigs should have necessary annotations