### PR TITLE
bootkube: create openshift-config / openshift-config-managed namespaces

### DIFF
--- a/bindata/bootkube/manifests/00_openshift-config-managed-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-config-managed-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/run-level: "0"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+  name: openshift-config-managed

--- a/bindata/bootkube/manifests/00_openshift-config-ns.yaml
+++ b/bindata/bootkube/manifests/00_openshift-config-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/run-level: "0"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+  name: openshift-config


### PR DESCRIPTION
This should make bootstrap cleaner, as this namespace is created by CVO late in bootstrap phase, but can be created early by cluster-bootstrap