### PR TITLE
library-go certrotation: avoid using applySecret to catch racy cert updates

### DIFF
--- a/pkg/operator/boundsatokensignercontroller/controller.go
+++ b/pkg/operator/boundsatokensignercontroller/controller.go
@@ -110,7 +110,7 @@ func (c *BoundSATokenSignerController) ensureNextOperatorSigningSecret(ctx conte
 			return err
 		}
 
-		secret, _, err = resourceapply.ApplySecret(ctx, c.secretClient, syncCtx.Recorder(), newSecret)
+		secret, _, err = resourceapply.ApplySecret(ctx, c.secretClient, syncCtx.Recorder(), newSecret, false)
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func (c *BoundSATokenSignerController) ensurePublicKeyConfigMap(ctx context.Cont
 
 		// Ensure the configmap is updated with the current public key
 		configMap.Data[nextKeyKey] = currPublicKey
-		configMap, _, err = resourceapply.ApplyConfigMap(ctx, c.configMapClient, syncCtx.Recorder(), configMap)
+		configMap, _, err = resourceapply.ApplyConfigMap(ctx, c.configMapClient, syncCtx.Recorder(), configMap, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
@@ -153,7 +153,7 @@ func ensureNodeKubeconfigs(ctx context.Context, client coreclientv1.CoreV1Interf
 	}
 	requiredSecret.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
-	_, _, err = resourceapply.ApplySecret(ctx, client, recorder, requiredSecret)
+	_, _, err = resourceapply.ApplySecret(ctx, client, recorder, requiredSecret, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -227,7 +227,7 @@ func manageKubeAPIServerConfig(ctx context.Context, client coreclientv1.ConfigMa
 	if err != nil {
 		return nil, false, err
 	}
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap, false)
 }
 
 func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, isStartupMonitorEnabledFn func() (bool, error), recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec string) (*corev1.ConfigMap, bool, error) {
@@ -263,7 +263,7 @@ func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, isSta
 	if optionalStartupMonitor != nil {
 		configMap.Data[startupMonitorPodKey] = resourceread.WritePodV1OrDie(optionalStartupMonitor)
 	}
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, configMap)
+	return resourceapply.ApplyConfigMap(ctx, client, recorder, configMap, false)
 }
 
 func generateOptionalStartupMonitorPod(isStartupMonitorEnabledFn func() (bool, error), operatorSpec *operatorv1.StaticPodOperatorSpec, operatorImagePullSpec string) (string, *corev1.Pod, error) {
@@ -312,7 +312,7 @@ func ManageClientCABundle(ctx context.Context, lister corev1listers.ConfigMapLis
 	}
 	requiredConfigMap.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap, false)
 }
 
 func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
@@ -339,7 +339,7 @@ func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.Confi
 	}
 	requiredConfigMap.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap, false)
 }
 
 func ensureKubeAPIServerTrustedCA(ctx context.Context, client coreclientv1.CoreV1Interface, recorder events.Recorder) error {

--- a/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/auditpolicy/auditpolicy_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/apiserver/controller/auditpolicy/auditpolicy_controller.go
@@ -123,6 +123,6 @@ func (c *auditPolicyController) syncAuditPolicy(ctx context.Context, config conf
 		},
 	}
 
-	_, _, err = resourceapply.ApplyConfigMap(ctx, c.kubeClient.CoreV1(), recorder, cm)
+	_, _, err = resourceapply.ApplyConfigMap(ctx, c.kubeClient.CoreV1(), recorder, cm, false)
 	return err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/library-go/pkg/certs"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 )
 
 // CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from RotatedSigningCASecret, and by removing expired old ones.
@@ -63,12 +64,10 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 	}
 	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
-		copiedCABundleConfigMap := caBundleConfigMap.DeepCopy()
-		actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Update(ctx, copiedCABundleConfigMap, metav1.UpdateOptions{})
+		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
 		if err != nil {
 			return nil, err
 		}
-		caBundleConfigMap = actualCABundleConfigMap
 	}
 
 	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
@@ -79,23 +78,15 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
 		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
-		if len(caBundleConfigMap.ResourceVersion) == 0 {
-			actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Create(ctx, caBundleConfigMap, metav1.CreateOptions{})
-			if err != nil {
-				return nil, err
-			}
-			caBundleConfigMap = actualCABundleConfigMap
-		} else {
-			copiedCABundleConfigMap := caBundleConfigMap.DeepCopy()
-			actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Update(ctx, copiedCABundleConfigMap, metav1.UpdateOptions{})
-			if err != nil {
-				return nil, err
-			}
-			if !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
-				klog.V(2).Infof("Updated ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
-			}
-			caBundleConfigMap = actualCABundleConfigMap
+		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		if err != nil {
+			return nil, err
 		}
+		if modified {
+			klog.V(2).Infof("Updated ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		}
+
+		caBundleConfigMap = actualCABundleConfigMap
 	}
 
 	caBundle := caBundleConfigMap.Data["ca-bundle.crt"]

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -64,7 +64,7 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 	}
 	needsMetadataUpdate = c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta) || needsMetadataUpdate
 	if needsMetadataUpdate && len(caBundleConfigMap.ResourceVersion) > 0 {
-		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		_, _, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap, true)
 		if err != nil {
 			return nil, err
 		}
@@ -78,7 +78,7 @@ func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingC
 		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert", c.Name, c.Namespace)
 		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
 
-		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap)
+		actualCABundleConfigMap, modified, err := resourceapply.ApplyConfigMap(ctx, c.Client, c.EventRecorder, caBundleConfigMap, true)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,15 +79,11 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 		}
 	}
 
-	applyFn := resourceapply.ApplySecret
-	if c.UseSecretUpdateOnly {
-		applyFn = resourceapply.ApplySecretDoNotUse
-	}
-
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) && len(signingCertKeyPairSecret.ResourceVersion) > 0 {
+		copiedSigningCertKeyPairSecret := signingCertKeyPairSecret.DeepCopy()
+		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, copiedSigningCertKeyPairSecret, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, false, err
 		}
@@ -104,9 +99,18 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
-		if err != nil {
-			return nil, false, err
+		var actualSigningCertKeyPairSecret *corev1.Secret
+		if len(signingCertKeyPairSecret.ResourceVersion) == 0 {
+			actualSigningCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Create(ctx, signingCertKeyPairSecret, metav1.CreateOptions{})
+			if err != nil {
+				return nil, false, err
+			}
+		} else {
+			copiedSigningCertKeyPairSecret := signingCertKeyPairSecret.DeepCopy()
+			actualSigningCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Update(ctx, copiedSigningCertKeyPairSecret, metav1.UpdateOptions{})
+			if err != nil {
+				return nil, false, err
+			}
 		}
 		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
 		signerUpdated = true

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -88,7 +88,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(signingCertKeyPairSecret) {
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret, true)
 		if err != nil {
 			return nil, false, err
 		}
@@ -104,7 +104,7 @@ func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*
 
 		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
 
-		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret)
+		actualSigningCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, signingCertKeyPairSecret, true)
 		if err != nil {
 			return nil, false, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/library-go/pkg/certs"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -112,16 +111,11 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 			Type: corev1.SecretTypeTLS,
 		}
 	}
-
-	applyFn := resourceapply.ApplySecret
-	if c.UseSecretUpdateOnly {
-		applyFn = resourceapply.ApplySecretDoNotUse
-	}
-
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
-	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) && len(targetCertKeyPairSecret.ResourceVersion) > 0 {
+		copiedSigningCertKeyPairSecret := targetCertKeyPairSecret.DeepCopy()
+		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, copiedSigningCertKeyPairSecret, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -136,9 +130,18 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
-		if err != nil {
-			return nil, err
+		var actualTargetCertKeyPairSecret *corev1.Secret
+		if len(targetCertKeyPairSecret.ResourceVersion) == 0 {
+			actualTargetCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Create(ctx, targetCertKeyPairSecret, metav1.CreateOptions{})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			copiedSigningCertKeyPairSecret := targetCertKeyPairSecret.DeepCopy()
+			actualTargetCertKeyPairSecret, err = c.Client.Secrets(c.Namespace).Update(ctx, copiedSigningCertKeyPairSecret, metav1.UpdateOptions{})
+			if err != nil {
+				return nil, err
+			}
 		}
 		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -121,7 +121,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 	// apply necessary metadata (possibly via delete+recreate) if secret exists
 	// this is done before content update to prevent unexpected rollouts
 	if ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations) && ensureSecretTLSTypeSet(targetCertKeyPairSecret) {
-		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret, true)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Cont
 
 		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
 
-		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret)
+		actualTargetCertKeyPairSecret, _, err := applyFn(ctx, c.Client, c.EventRecorder, targetCertKeyPairSecret, true)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -246,7 +246,7 @@ func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.C
 				return nil
 			}
 
-			_, _, updateErr := resourceapply.ApplySecret(ctx, c.secretClient, syncContext.Recorder(), s)
+			_, _, updateErr := resourceapply.ApplySecret(ctx, c.secretClient, syncContext.Recorder(), s, false)
 			return updateErr
 		}); err != nil {
 			errs = append(errs, err)

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
@@ -154,7 +154,7 @@ func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, encry
 		return false, err
 	}
 
-	_, changed, applyErr := resourceapply.ApplySecret(ctx, c.secretClient, recorder, s)
+	_, changed, applyErr := resourceapply.ApplySecret(ctx, c.secretClient, recorder, s, false)
 	return changed, applyErr
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -131,7 +131,7 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if client == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyConfigMapImproved(ctx, client, recorder, t, cache)
+				result.Result, result.Changed, result.Error = ApplyConfigMapImproved(ctx, client, recorder, t, cache, false)
 			}
 		case *corev1.Secret:
 			client := clients.secretsGetter()


### PR DESCRIPTION
Alternative for https://github.com/openshift/library-go/pull/1722