### PR TITLE
[DO-NOT-MERGE] operator: add external OIDC CA as a revision configmap

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -587,6 +587,9 @@ var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "sa-token-signing-certs"},
 
 	{Name: "kube-apiserver-audit-policies"},
+
+	// optional CA bundle of the external OIDC provider, if configured; meant to be used with the --oidc-ca-file KAS arg
+	{Name: "oidc-serving-ca", Optional: true},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.


### PR DESCRIPTION
**DO-NOT-MERGE**: Currently, this PR facilitates testing for the development of the configuration of an external OIDC provider.

This PR adds a revision ConfigMap to the KAS-o in order to mount the (optional) OIDC CA as a file to the KAS pods.