### PR TITLE
NO-JIRA: exclude etcd check from livez

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -102,7 +102,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: livez
+        path: livez?verbose&exclude=etcd
       initialDelaySeconds: 0
       periodSeconds: 10
       timeoutSeconds: 10

--- a/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
+++ b/bindata/bootkube/bootstrap-manifests/kube-apiserver-pod.yaml
@@ -71,7 +71,7 @@ spec:
       httpGet:
         scheme: HTTPS
         port: 6443
-        path: livez
+        path: livez?verbose&exclude=etcd
       initialDelaySeconds: 45
       timeoutSeconds: 10
     readinessProbe:


### PR DESCRIPTION
the motivation for removal is the belief that a broken connection to the etcd cluster will not be fixed by simply deleting the KAS pod.

alternative to https://github.com/openshift/kubernetes/pull/2061