### PR TITLE
OCPBUGS-34310: Updating ose-cluster-kube-apiserver-operator-container image to be consistent with ART for 4.17

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -4,7 +4,7 @@ COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/


### PR DESCRIPTION
Updating ose-cluster-kube-apiserver-operator-container image to be consistent with ART for 4.17. There is a go version error fo origin PR https://github.com/openshift/cluster-kube-apiserver-operator/pull/1691 was created by [openshift-bot](https://github.com/openshift-bot), have to create new one manually and closing the PR https://github.com/openshift/cluster-kube-apiserver-operator/pull/1691.