### PR TITLE
OCPBUGS-42083: Don't rollout revision until three etcd endpoints are listed

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -267,6 +267,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersForNamespaces,
 		kubeClient,
 		startupmonitorreadiness.IsStartupMonitorEnabledFunction(configInformers.Config().V1().Infrastructures().Lister(), operatorClient),
+		notOnSingleReplicaTopology,
 		controllerContext.EventRecorder,
 	)
 


### PR DESCRIPTION
Prevent apiserver from pointing to a single etcd endpoint (IP and localhost), which will lose connection when the single etcd is being updated