### PR TITLE
NO-JIRA: nodekubeconfigcontroller: add auto-regenerate-after-expiry annotation to node kubeconfig configmap

### DIFF
--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/bindata"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
@@ -152,6 +153,7 @@ func ensureNodeKubeconfigs(ctx context.Context, client coreclientv1.CoreV1Interf
 		requiredSecret.Annotations = map[string]string{}
 	}
 	requiredSecret.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
+	requiredSecret.Annotations[certrotation.AutoRegenerateAfterOfflineExpiryAnnotation] = "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1757,'operator conditions kube-apiserver'"
 
 	_, _, err = resourceapply.ApplySecret(ctx, client, recorder, requiredSecret)
 	if err != nil {

--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller_test.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/api/annotations"
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -142,7 +143,8 @@ func TestEnsureNodeKubeconfigs(t *testing.T) {
 							Namespace: "openshift-kube-apiserver",
 							Name:      "node-kubeconfigs",
 							Annotations: map[string]string{
-								annotations.OpenShiftComponent: "kube-apiserver",
+								annotations.OpenShiftComponent:                          "kube-apiserver",
+								certrotation.AutoRegenerateAfterOfflineExpiryAnnotation: "PR_LINK, ,'operator conditions kube-apiserver'",
 							},
 						},
 						Data: map[string][]byte{


### PR DESCRIPTION
`node-kubeconfigs` contains configmaps contain lb-ext/lb-int/localhost/localhost-recovery kubeconfigs, which get updated every two years. The configmap should have annotation to mark it as being updated offline