### PR TITLE
AUTH-541: OIDC structured auth config

### DIFF
--- a/pkg/operator/configobservation/auth/auth_metadata.go
+++ b/pkg/operator/configobservation/auth/auth_metadata.go
@@ -20,14 +20,21 @@ const (
 	managedNamespace      = "openshift-config-managed"
 )
 
+var (
+	topLevelMetadataFilePath = []string{"authConfig", "oauthMetadataFile"}
+)
+
 // ObserveAuthMetadata fills in authConfig.OauthMetadataFile with the path for a configMap referenced by the authentication
 // config.
-func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, topLevelMetadataFilePath)
+	}()
+
 	listers := genericListers.(configobservation.Listers)
 	errs := []error{}
 	prevObservedConfig := map[string]interface{}{}
 
-	topLevelMetadataFilePath := []string{"authConfig", "oauthMetadataFile"}
 	currentMetadataFilePath, _, err := unstructured.NestedString(existingConfig, topLevelMetadataFilePath...)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/operator/configobservation/auth/auth_metadata.go
+++ b/pkg/operator/configobservation/auth/auth_metadata.go
@@ -8,6 +8,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -46,8 +47,9 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 	}
 
 	observedConfig := map[string]interface{}{}
-	authConfigNoDefaults, err := listers.AuthConfigLister.Get("cluster")
+	authConfig, err := listers.AuthConfigLister.Get("cluster")
 	if errors.IsNotFound(err) {
+		recorder.Eventf("ObserveAuthMetadataConfigMap", "authentications.config.openshift.io/cluster: not found")
 		klog.Warningf("authentications.config.openshift.io/cluster: not found")
 		return observedConfig, errs
 	}
@@ -56,34 +58,45 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 		return prevObservedConfig, errs
 	}
 
-	authConfig := defaultAuthConfig(authConfigNoDefaults)
-
 	var (
 		sourceNamespace string
 		sourceConfigMap string
-		statusConfigMap string
 	)
 
-	specConfigMap := authConfig.Spec.OAuthMetadata.Name
+	switch authConfig.Spec.Type {
+	case configv1.AuthenticationTypeIntegratedOAuth, "":
+		specConfigMap := authConfig.Spec.OAuthMetadata.Name
+		statusConfigMap := authConfig.Status.IntegratedOAuthMetadata.Name
+		if len(statusConfigMap) == 0 {
+			klog.V(5).Infof("no integrated oauth metadata configmap observed from status")
+		}
 
-	// TODO: Add a case here for the KeyCloak type.
-	switch {
-	case len(authConfig.Status.IntegratedOAuthMetadata.Name) > 0 && authConfig.Spec.Type == configv1.AuthenticationTypeIntegratedOAuth:
-		statusConfigMap = authConfig.Status.IntegratedOAuthMetadata.Name
-	default:
-		klog.V(5).Infof("no integrated oauth metadata configmap observed from status")
-	}
+		// Spec configMap takes precedence over Status.
+		switch {
+		case len(specConfigMap) > 0:
+			sourceConfigMap = specConfigMap
+			sourceNamespace = configNamespace
+		case len(statusConfigMap) > 0:
+			sourceConfigMap = statusConfigMap
+			sourceNamespace = managedNamespace
+		default:
+			klog.V(5).Infof("no authentication config metadata specified")
+		}
 
-	// Spec configMap takes precedence over Status.
-	switch {
-	case len(specConfigMap) > 0:
-		sourceConfigMap = specConfigMap
-		sourceNamespace = configNamespace
-	case len(statusConfigMap) > 0:
-		sourceConfigMap = statusConfigMap
-		sourceNamespace = managedNamespace
-	default:
-		klog.V(5).Infof("no authentication config metadata specified")
+	case configv1.AuthenticationTypeNone:
+		// no oauth metadata is served; do not set anything as source
+		// in order to delete the configmap and unset oauthMetadataFile
+
+	case configv1.AuthenticationTypeOIDC:
+		if _, err := listers.ConfigmapLister_.ConfigMaps(operatorclient.TargetNamespace).Get(AuthConfigCMName); errors.IsNotFound(err) {
+			// auth-config does not exist in target namespace yet; do not remove oauth metadata until it's there
+			return prevObservedConfig, errs
+		} else if err != nil {
+			return prevObservedConfig, append(errs, err)
+		}
+
+		// no oauth metadata is served; do not set anything as source
+		// in order to delete the configmap and unset oauthMetadataFile
 	}
 
 	// Sync the user or status-specified configMap to the well-known resting place that corresponds to the oauthMetadataFile path.
@@ -115,14 +128,4 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 	}
 
 	return observedConfig, errs
-}
-
-func defaultAuthConfig(authConfig *configv1.Authentication) *configv1.Authentication {
-	out := authConfig.DeepCopy() // do not mutate informer cache
-
-	if len(out.Spec.Type) == 0 {
-		out.Spec.Type = configv1.AuthenticationTypeIntegratedOAuth
-	}
-
-	return out
 }

--- a/pkg/operator/configobservation/auth/auth_metadata_test.go
+++ b/pkg/operator/configobservation/auth/auth_metadata_test.go
@@ -18,7 +18,17 @@ import (
 )
 
 var (
-	baseAuthMetadataConfig = map[string]interface{}{
+	unprunedBaseAuthMetadataConfig = map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"authentication-token-webhook-config-file": webhookTokenAuthenticatorFile,
+			"authentication-token-webhook-version":     webhookTokenAuthenticatorVersion,
+		},
+		"authConfig": map[string]interface{}{
+			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
+		},
+	}
+
+	prunedBaseAuthMetadataConfig = map[string]interface{}{
 		"authConfig": map[string]interface{}{
 			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
 		},
@@ -53,15 +63,15 @@ func TestObserveAuthMetadata(t *testing.T) {
 		{
 			name:           "auth resource lister error",
 			authSpec:       nil,
-			existingConfig: baseAuthMetadataConfig,
+			existingConfig: unprunedBaseAuthMetadataConfig,
 			authIndexer:    &everFailingIndexer{},
-			expectedConfig: baseAuthMetadataConfig,
+			expectedConfig: prunedBaseAuthMetadataConfig,
 			expectedSynced: nil,
 			expectErrors:   true,
 		},
 		{
 			name:           "syncer error",
-			existingConfig: baseAuthMetadataConfig,
+			existingConfig: unprunedBaseAuthMetadataConfig,
 			syncerError:    fmt.Errorf("configmap not found"),
 			authSpec: &configv1.AuthenticationSpec{
 				Type: configv1.AuthenticationTypeIntegratedOAuth,
@@ -70,7 +80,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 				},
 			},
 			statusMetadataName: "non-existing-configmap",
-			expectedConfig:     baseAuthMetadataConfig,
+			expectedConfig:     prunedBaseAuthMetadataConfig,
 			expectedSynced:     nil,
 			expectErrors:       true,
 		},
@@ -92,7 +102,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 		},
 		{
 			name:           "empty auth metadata with existing",
-			existingConfig: baseAuthMetadataConfig,
+			existingConfig: unprunedBaseAuthMetadataConfig,
 			authSpec: &configv1.AuthenticationSpec{
 				Type: configv1.AuthenticationTypeIntegratedOAuth,
 				OAuthMetadata: configv1.ConfigMapNameReference{
@@ -115,7 +125,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 				},
 			},
 			statusMetadataName: "metadata-from-status",
-			expectedConfig:     baseAuthMetadataConfig,
+			expectedConfig:     prunedBaseAuthMetadataConfig,
 			expectedSynced: map[string]string{
 				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
 			},
@@ -130,7 +140,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 				},
 			},
 			statusMetadataName: "metadata-from-status",
-			expectedConfig:     baseAuthMetadataConfig,
+			expectedConfig:     prunedBaseAuthMetadataConfig,
 			expectedSynced: map[string]string{
 				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
 			},
@@ -177,7 +187,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 				},
 			},
 			statusMetadataName: "metadata-from-status",
-			expectedConfig:     baseAuthMetadataConfig,
+			expectedConfig:     prunedBaseAuthMetadataConfig,
 			expectedSynced: map[string]string{
 				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-status.openshift-config-managed",
 			},
@@ -192,7 +202,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 				},
 			},
 			statusMetadataName: "metadata-from-status",
-			expectedConfig:     baseAuthMetadataConfig,
+			expectedConfig:     prunedBaseAuthMetadataConfig,
 			expectedSynced: map[string]string{
 				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-status.openshift-config-managed",
 			},

--- a/pkg/operator/configobservation/auth/auth_metadata_test.go
+++ b/pkg/operator/configobservation/auth/auth_metadata_test.go
@@ -1,0 +1,286 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+)
+
+var (
+	baseAuthMetadataConfig = map[string]interface{}{
+		"authConfig": map[string]interface{}{
+			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
+		},
+	}
+)
+
+func TestObserveAuthMetadata(t *testing.T) {
+
+	for _, tt := range []struct {
+		name string
+
+		authIndexer cache.Indexer
+		cmIndexer   cache.Indexer
+
+		existingConfig     map[string]interface{}
+		existingConfigMap  *corev1.ConfigMap
+		authSpec           *configv1.AuthenticationSpec
+		statusMetadataName string
+		syncerError        error
+
+		expectedConfig map[string]interface{}
+		expectedSynced map[string]string
+		expectErrors   bool
+	}{
+		{
+			name:           "auth resource not found",
+			authSpec:       nil,
+			expectedConfig: map[string]interface{}{},
+			expectedSynced: nil,
+			expectErrors:   false,
+		},
+		{
+			name:           "auth resource lister error",
+			authSpec:       nil,
+			existingConfig: baseAuthMetadataConfig,
+			authIndexer:    &everFailingIndexer{},
+			expectedConfig: baseAuthMetadataConfig,
+			expectedSynced: nil,
+			expectErrors:   true,
+		},
+		{
+			name:           "syncer error",
+			existingConfig: baseAuthMetadataConfig,
+			syncerError:    fmt.Errorf("configmap not found"),
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeIntegratedOAuth,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "non-existing-configmap",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced:     nil,
+			expectErrors:       true,
+		},
+		{
+			name:           "empty auth metadata without existing",
+			existingConfig: nil,
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeIntegratedOAuth,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "",
+			expectedConfig:     nil,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+		},
+		{
+			name:           "empty auth metadata with existing",
+			existingConfig: baseAuthMetadataConfig,
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeIntegratedOAuth,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "",
+			expectedConfig:     nil,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from spec",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeIntegratedOAuth,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from spec with auth type empty",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: "",
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from spec with auth type None",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeNone,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				// FIXME should be delete
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from spec with auth type OIDC",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeOIDC,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				// FIXME should be delete
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from status",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeIntegratedOAuth,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-status.openshift-config-managed",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from status with auth type empty",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: "",
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     baseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-status.openshift-config-managed",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from status with auth type None",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeNone,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     nil,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "metadata from status with auth type OIDC",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeOIDC,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     nil,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synced := map[string]string{}
+			eventRecorder := events.NewInMemoryRecorder("authmetadatatest", clock.RealClock{})
+
+			if tt.authIndexer == nil {
+				tt.authIndexer = cache.NewIndexer(func(obj interface{}) (string, error) {
+					return "cluster", nil
+				}, cache.Indexers{})
+			}
+
+			if tt.authSpec != nil {
+				tt.authIndexer.Add(&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: *tt.authSpec,
+					Status: configv1.AuthenticationStatus{
+						IntegratedOAuthMetadata: configv1.ConfigMapNameReference{
+							Name: tt.statusMetadataName,
+						},
+					},
+				})
+			}
+
+			if tt.cmIndexer == nil {
+				tt.cmIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			}
+
+			if tt.existingConfigMap != nil {
+				tt.cmIndexer.Add(tt.existingConfigMap)
+			}
+
+			listers := configobservation.Listers{
+				AuthConfigLister: configlistersv1.NewAuthenticationLister(tt.authIndexer),
+				ConfigmapLister_: corelistersv1.NewConfigMapLister(tt.cmIndexer),
+				ResourceSync:     &mockResourceSyncer{t: t, synced: synced, error: tt.syncerError},
+			}
+
+			actualConfig, errs := ObserveAuthMetadata(listers, eventRecorder, tt.existingConfig)
+
+			if tt.expectErrors != (len(errs) > 0) {
+				t.Errorf("expected errors: %v; got %v", tt.expectErrors, errs)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedConfig, actualConfig) {
+				t.Errorf("unexpected config diff: %s", diff.ObjectReflectDiff(tt.expectedConfig, actualConfig))
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedSynced, synced) {
+				t.Errorf("expected resources not synced: %s", diff.ObjectReflectDiff(tt.expectedSynced, synced))
+			}
+
+		})
+	}
+}

--- a/pkg/operator/configobservation/auth/external_oidc.go
+++ b/pkg/operator/configobservation/auth/external_oidc.go
@@ -1,0 +1,143 @@
+package auth
+
+import (
+	"fmt"
+	"path"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+)
+
+const (
+	SourceAuthConfigCMNamespace = "openshift-config-managed"
+	AuthConfigCMName            = "auth-config"
+	authConfigKeyName           = "auth-config.json"
+)
+
+var (
+	authConfigPath = []string{"apiServerArguments", "authentication-config"}
+)
+
+func NewObserveExternalOIDC(featureGateAccessor featuregates.FeatureGateAccess) configobserver.ObserveConfigFunc {
+	return (&externalOIDC{
+		featureGateAccessor: featureGateAccessor,
+	}).ObserveExternalOIDC
+}
+
+type externalOIDC struct {
+	featureGateAccessor featuregates.FeatureGateAccess
+}
+
+// ObserveExternalOIDC observes the authentication.config/cluster resource
+// and if the type field is set to OIDC, it configures an external OIDC provider
+// to the KAS pods by setting the --authentication-config apiserver argument. It also
+// takes care of synchronizing the structured auth config file into the apiserver's namespace
+// so that it gets mounted as a static file on each node.
+func (o *externalOIDC) ObserveExternalOIDC(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, authConfigPath)
+	}()
+
+	if !o.featureGateAccessor.AreInitialFeatureGatesObserved() {
+		// if we haven't observed featuregates yet, return the existing
+		return existingConfig, nil
+	}
+
+	featureGates, err := o.featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return existingConfig, []error{err}
+	}
+
+	if !featureGates.Enabled(features.FeatureGateExternalOIDC) {
+		return existingConfig, nil
+	}
+
+	listers := genericListers.(configobservation.Listers)
+	auth, err := listers.AuthConfigLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		recorder.Eventf("ObserveExternalOIDC", "authentications.config.openshift.io/cluster: not found")
+		klog.Warningf("authentications.config.openshift.io/cluster: not found")
+		return existingConfig, nil
+	} else if err != nil {
+		return existingConfig, []error{err}
+	}
+
+	targetAuthConfig, err := listers.ConfigMapLister().ConfigMaps(operatorclient.TargetNamespace).Get(AuthConfigCMName)
+	if err != nil && !errors.IsNotFound(err) {
+		return existingConfig, []error{err}
+	}
+
+	if auth.Spec.Type != configv1.AuthenticationTypeOIDC {
+		// empty source name/namespace effectively deletes target configmap
+		if err := genericListers.ResourceSyncer().SyncConfigMap(
+			resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: AuthConfigCMName},
+			resourcesynccontroller.ResourceLocation{Namespace: "", Name: ""},
+		); err != nil {
+			return existingConfig, []error{err}
+		}
+
+		if targetAuthConfig != nil {
+			recorder.Eventf("ObserveExternalOIDC", "OIDC auth configmap %s/%s exists; requested deletion", operatorclient.TargetNamespace, AuthConfigCMName)
+		}
+
+		return nil, nil
+	}
+
+	// auth type is OIDC
+
+	sourceAuthConfig, err := validateSourceConfigMap(listers)
+	if err != nil {
+		return existingConfig, []error{err}
+
+	} else if sourceAuthConfig == nil {
+		klog.Warningf("configmap %s/%s not found; skipping configuration of OIDC", SourceAuthConfigCMNamespace, AuthConfigCMName)
+		return existingConfig, nil
+	}
+
+	if err := genericListers.ResourceSyncer().SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: AuthConfigCMName},
+		resourcesynccontroller.ResourceLocation{Namespace: sourceAuthConfig.Namespace, Name: sourceAuthConfig.Name},
+	); err != nil {
+		return existingConfig, []error{err}
+	}
+
+	if targetAuthConfig == nil {
+		recorder.Eventf("ObserveExternalOIDC", "OIDC auth configmap %s/%s does not exist; requested sync", operatorclient.TargetNamespace, AuthConfigCMName)
+	}
+
+	observedConfig := make(map[string]interface{})
+	if err := unstructured.SetNestedStringSlice(observedConfig, []string{path.Join("/etc/kubernetes/static-pod-resources/configmaps/", AuthConfigCMName, authConfigKeyName)}, authConfigPath...); err != nil {
+		return existingConfig, []error{err}
+	}
+
+	return observedConfig, nil
+}
+
+func validateSourceConfigMap(listers configobservation.Listers) (*corev1.ConfigMap, error) {
+	sourceAuthConfig, err := listers.ConfigMapLister().ConfigMaps(SourceAuthConfigCMNamespace).Get(AuthConfigCMName)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get configmap %s/%s: %v", SourceAuthConfigCMNamespace, AuthConfigCMName, err)
+	}
+
+	if data, found := sourceAuthConfig.Data[authConfigKeyName]; !found {
+		return nil, fmt.Errorf("configmap %s/%s is invalid: key '%s' missing", SourceAuthConfigCMNamespace, AuthConfigCMName, authConfigKeyName)
+
+	} else if len(data) == 0 {
+		return nil, fmt.Errorf("configmap %s/%s is invalid: key '%s' has empty value", SourceAuthConfigCMNamespace, AuthConfigCMName, authConfigKeyName)
+	}
+
+	return sourceAuthConfig, nil
+}

--- a/pkg/operator/configobservation/auth/external_oidc_test.go
+++ b/pkg/operator/configobservation/auth/external_oidc_test.go
@@ -1,0 +1,539 @@
+package auth
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+)
+
+var (
+	featureGatesWithOIDC = featuregates.NewHardcodedFeatureGateAccessForTesting(
+		[]configv1.FeatureGateName{features.FeatureGateExternalOIDC},
+		[]configv1.FeatureGateName{},
+		makeClosedChannel(),
+		nil,
+	)
+
+	authResourceWithOAuth = configv1.Authentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.AuthenticationSpec{
+			Type: configv1.AuthenticationTypeIntegratedOAuth,
+		},
+	}
+
+	authResourceWithOIDC = configv1.Authentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.AuthenticationSpec{
+			Type: configv1.AuthenticationTypeOIDC,
+		},
+	}
+
+	baseConfig = map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"authentication-config": []interface{}{path.Join("/etc/kubernetes/static-pod-resources/configmaps/", AuthConfigCMName, authConfigKeyName)},
+		},
+	}
+
+	baseSourceConfigMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth-config",
+			Namespace: "openshift-config-managed",
+		},
+		Data: map[string]string{
+			"auth-config.json": `{"kind":"AuthenticationConfiguration","apiVersion":"apiserver.config.k8s.io/v1beta1"}`,
+		},
+	}
+
+	invalidSourceConfigMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth-config",
+			Namespace: "openshift-config-managed",
+		},
+		Data: map[string]string{
+			"invalid-auth-config.json": `{}`,
+		},
+	}
+
+	emptyValueSourceConfigMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth-config",
+			Namespace: "openshift-config-managed",
+		},
+		Data: map[string]string{
+			"auth-config.json": ``,
+		},
+	}
+
+	updatedBaseSourceConfigMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth-config",
+			Namespace: "openshift-config-managed",
+		},
+		Data: map[string]string{
+			"auth-config.json": `{"kind":"AuthenticationConfiguration","apiVersion":"apiserver.config.k8s.io/v1beta1","jwt":[]}`,
+		},
+	}
+
+	baseTargetConfigMap = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "auth-config",
+			Namespace: "openshift-kube-apiserver",
+		},
+		Data: map[string]string{
+			"auth-config.json": `{"kind":"AuthenticationConfiguration","apiVersion":"apiserver.config.k8s.io/v1beta1"}`,
+		},
+	}
+)
+
+func TestObserveExternalOIDC(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		featureGates   featuregates.FeatureGateAccess
+		existingConfig map[string]interface{}
+
+		existingSourceConfigMap *corev1.ConfigMap
+		existingTargetConfigMap *corev1.ConfigMap
+
+		auth             *configv1.Authentication
+		authIndexer      cache.Indexer
+		cmIndexer        cache.Indexer
+		listerErrorForNS sets.Set[string]
+		syncerError      error
+
+		expectedConfig map[string]interface{}
+		expectedSynced map[string]string
+		expectErrors   bool
+		expectEvents   bool
+	}{
+		{
+			name: "initial feature gates not observed",
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{},
+				make(chan struct{}),
+				nil,
+			),
+			existingConfig: baseConfig,
+			expectedConfig: baseConfig,
+			expectErrors:   false,
+		},
+		{
+			name: "feature gates access error",
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{},
+				makeClosedChannel(),
+				fmt.Errorf("error"),
+			),
+			existingConfig: baseConfig,
+			expectedConfig: baseConfig,
+			expectErrors:   true,
+		},
+		{
+			name: "ExternalOIDC feature gate disabled",
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{features.FeatureGateExternalOIDC},
+				makeClosedChannel(),
+				nil,
+			),
+			existingConfig: baseConfig,
+			expectedConfig: baseConfig,
+			expectErrors:   false,
+		},
+		{
+			name: "ExternalOIDC feature gate disabled with oauth config",
+			featureGates: featuregates.NewHardcodedFeatureGateAccessForTesting(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{features.FeatureGateExternalOIDC},
+				makeClosedChannel(),
+				nil,
+			),
+			existingConfig: map[string]interface{}{
+				"apiServerArguments": map[string]interface{}{
+					"authentication-token-webhook-config-file": []interface{}{webhookTokenAuthenticatorFile},
+				},
+			},
+			expectedConfig: nil,
+			expectErrors:   false,
+		},
+		{
+			name:           "auth resource not found",
+			featureGates:   featureGatesWithOIDC,
+			existingConfig: baseConfig,
+			expectedConfig: baseConfig,
+			expectErrors:   false,
+			expectEvents:   true,
+		},
+		{
+			name:           "auth resource retrieval error",
+			featureGates:   featureGatesWithOIDC,
+			authIndexer:    &everFailingIndexer{},
+			existingConfig: baseConfig,
+			expectedConfig: baseConfig,
+			expectErrors:   true,
+		},
+		{
+			name:                    "OAuth target configmap does not exist",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          nil,
+			existingTargetConfigMap: nil,
+			auth:                    &authResourceWithOAuth,
+			expectedConfig:          nil,
+			expectedSynced: map[string]string{
+				"configmap/auth-config.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+			expectEvents: false,
+		},
+		{
+			name:                    "OAuth target configmap syncer error",
+			featureGates:            featureGatesWithOIDC,
+			syncerError:             fmt.Errorf("syncer error"),
+			existingConfig:          nil,
+			existingTargetConfigMap: &baseTargetConfigMap,
+			auth:                    &authResourceWithOAuth,
+			expectedConfig:          nil,
+			expectedSynced:          nil,
+			expectErrors:            true,
+			expectEvents:            false,
+		},
+		{
+			name:                    "OAuth target configmap exists",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          nil,
+			existingTargetConfigMap: &baseTargetConfigMap,
+			auth:                    &authResourceWithOAuth,
+			expectedConfig:          nil,
+			expectedSynced: map[string]string{
+				"configmap/auth-config.openshift-kube-apiserver": "DELETE",
+			},
+			expectErrors: false,
+			expectEvents: true,
+		},
+		{
+			name:                    "OIDC new invalid config with expected key missing",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          nil,
+			existingSourceConfigMap: &invalidSourceConfigMap,
+			auth:                    &authResourceWithOIDC,
+			expectEvents:            false,
+			expectErrors:            true,
+		},
+		{
+			name:                    "OIDC updated invalid config",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          baseConfig,
+			existingSourceConfigMap: &invalidSourceConfigMap,
+			auth:                    &authResourceWithOIDC,
+			expectedConfig:          baseConfig,
+			expectEvents:            false,
+			expectErrors:            true,
+		},
+		{
+			name:                    "OIDC new valid config syncer error",
+			featureGates:            featureGatesWithOIDC,
+			syncerError:             fmt.Errorf("syncer error"),
+			existingConfig:          nil,
+			existingSourceConfigMap: &baseSourceConfigMap,
+			auth:                    &authResourceWithOIDC,
+			expectedConfig:          nil,
+			expectedSynced:          nil,
+			expectEvents:            false,
+			expectErrors:            true,
+		},
+		{
+			name:                    "OIDC new valid config",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          nil,
+			existingSourceConfigMap: &baseSourceConfigMap,
+			existingTargetConfigMap: nil,
+			auth:                    &authResourceWithOIDC,
+			expectedConfig:          baseConfig,
+			expectedSynced: map[string]string{
+				"configmap/auth-config.openshift-kube-apiserver": "configmap/auth-config.openshift-config-managed",
+			},
+			expectEvents: true,
+			expectErrors: false,
+		},
+		{
+			name:                    "OIDC updated valid config without changes",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          baseConfig,
+			existingSourceConfigMap: &baseSourceConfigMap,
+			existingTargetConfigMap: &baseTargetConfigMap,
+			auth:                    &authResourceWithOIDC,
+			expectedConfig:          baseConfig,
+			expectedSynced: map[string]string{
+				"configmap/auth-config.openshift-kube-apiserver": "configmap/auth-config.openshift-config-managed",
+			},
+			expectEvents: false,
+			expectErrors: false,
+		},
+		{
+			name:                    "OIDC updated valid config with changes",
+			featureGates:            featureGatesWithOIDC,
+			existingConfig:          baseConfig,
+			existingSourceConfigMap: &updatedBaseSourceConfigMap,
+			existingTargetConfigMap: &baseTargetConfigMap,
+			auth:                    &authResourceWithOIDC,
+			expectedConfig:          baseConfig,
+			expectedSynced: map[string]string{
+				"configmap/auth-config.openshift-kube-apiserver": "configmap/auth-config.openshift-config-managed",
+			},
+			expectEvents: false,
+			expectErrors: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synced := map[string]string{}
+			eventRecorder := events.NewInMemoryRecorder("externaloidctest", clock.RealClock{})
+
+			if tt.authIndexer == nil {
+				tt.authIndexer = cache.NewIndexer(func(obj interface{}) (string, error) {
+					return "cluster", nil
+				}, cache.Indexers{})
+			}
+
+			if tt.auth != nil {
+				tt.authIndexer.Add(tt.auth)
+			}
+
+			if tt.cmIndexer == nil {
+				tt.cmIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			}
+
+			if tt.existingSourceConfigMap != nil {
+				tt.cmIndexer.Add(tt.existingSourceConfigMap)
+			}
+
+			if tt.existingTargetConfigMap != nil {
+				tt.cmIndexer.Add(tt.existingTargetConfigMap)
+			}
+
+			listers := configobservation.Listers{
+				AuthConfigLister: configlistersv1.NewAuthenticationLister(tt.authIndexer),
+				ConfigmapLister_: newFakeConfigMapLister(tt.listerErrorForNS, tt.cmIndexer),
+				ResourceSync:     &mockResourceSyncer{t: t, synced: synced, error: tt.syncerError},
+			}
+
+			c := externalOIDC{featureGateAccessor: tt.featureGates}
+			actualConfig, errs := c.ObserveExternalOIDC(listers, eventRecorder, tt.existingConfig)
+
+			if tt.expectErrors != (len(errs) > 0) {
+				t.Errorf("expected errors: %v; got %v", tt.expectErrors, errs)
+			}
+
+			if recordedEvents := eventRecorder.Events(); tt.expectEvents != (len(recordedEvents) > 0) {
+				t.Errorf("expected events: %v; got %v", tt.expectEvents, recordedEvents)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedConfig, actualConfig) {
+				t.Errorf("unexpected config diff: %s", diff.ObjectReflectDiff(tt.expectedConfig, actualConfig))
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedSynced, synced) {
+				t.Errorf("expected resources not synced: %s", diff.ObjectReflectDiff(tt.expectedSynced, synced))
+			}
+		})
+	}
+}
+
+func TestValidateSourceConfigMap(t *testing.T) {
+
+	for _, tt := range []struct {
+		name              string
+		cmIndexer         cache.Indexer
+		expectedConfigMap *corev1.ConfigMap
+		expectError       bool
+	}{
+		{
+			name:              "source configmap not found",
+			cmIndexer:         cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+			expectedConfigMap: nil,
+			expectError:       false,
+		},
+		{
+			name:              "configmap lister error",
+			cmIndexer:         &everFailingIndexer{},
+			expectedConfigMap: nil,
+			expectError:       true,
+		},
+		{
+			name: "required key missing",
+			cmIndexer: func() cache.Indexer {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				indexer.Add(&invalidSourceConfigMap)
+				return indexer
+			}(),
+			expectedConfigMap: nil,
+			expectError:       true,
+		},
+		{
+			name: "required key has empty value",
+			cmIndexer: func() cache.Indexer {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				indexer.Add(&emptyValueSourceConfigMap)
+				return indexer
+			}(),
+			expectedConfigMap: nil,
+			expectError:       true,
+		},
+		{
+			name: "source configmap valid",
+			cmIndexer: func() cache.Indexer {
+				indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				indexer.Add(&baseSourceConfigMap)
+				return indexer
+			}(),
+			expectedConfigMap: &baseSourceConfigMap,
+			expectError:       false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			listers := configobservation.Listers{
+				ConfigmapLister_: corelistersv1.NewConfigMapLister(tt.cmIndexer),
+			}
+
+			cm, err := validateSourceConfigMap(listers)
+
+			if tt.expectError != (err != nil) {
+				t.Errorf("expected error: %v; got: %v", tt.expectError, err)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedConfigMap, cm) {
+				t.Errorf("unexpected config map: %s", diff.ObjectReflectDiff(tt.expectedConfigMap, cm))
+			}
+
+		})
+	}
+}
+
+func makeClosedChannel() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
+type fakeConfigMapLister struct {
+	failingNamespaces sets.Set[string]
+	defaultLister     corelistersv1.ConfigMapLister
+}
+
+func newFakeConfigMapLister(failingNamespaces sets.Set[string], defaultIndexer cache.Indexer) *fakeConfigMapLister {
+	return &fakeConfigMapLister{
+		failingNamespaces: failingNamespaces,
+		defaultLister:     corelistersv1.NewConfigMapLister(defaultIndexer),
+	}
+}
+
+func (l *fakeConfigMapLister) List(selector labels.Selector) (ret []*corev1.ConfigMap, err error) {
+	return l.defaultLister.List(selector)
+}
+
+func (l *fakeConfigMapLister) ConfigMaps(namespace string) corelistersv1.ConfigMapNamespaceLister {
+	if l.failingNamespaces.Has(namespace) {
+		return corelistersv1.NewConfigMapLister(&everFailingIndexer{}).ConfigMaps(namespace)
+	}
+
+	return l.defaultLister.ConfigMaps(namespace)
+}
+
+type everFailingIndexer struct{}
+
+// Index always returns an error
+func (i *everFailingIndexer) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	return nil, fmt.Errorf("Index method not implemented")
+}
+
+// IndexKeys always returns an error
+func (i *everFailingIndexer) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, fmt.Errorf("IndexKeys method not implemented")
+}
+
+// ListIndexFuncValues always returns an error
+func (i *everFailingIndexer) ListIndexFuncValues(indexName string) []string {
+	return nil
+}
+
+// ByIndex always returns an error
+func (i *everFailingIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	return nil, fmt.Errorf("ByIndex method not implemented")
+}
+
+// GetIndexers always returns an error
+func (i *everFailingIndexer) GetIndexers() cache.Indexers {
+	return nil
+}
+
+// AddIndexers always returns an error
+func (i *everFailingIndexer) AddIndexers(newIndexers cache.Indexers) error {
+	return fmt.Errorf("AddIndexers method not implemented")
+}
+
+// Add always returns an error
+func (s *everFailingIndexer) Add(obj interface{}) error {
+	return fmt.Errorf("Add method not implemented")
+}
+
+// Update always returns an error
+func (s *everFailingIndexer) Update(obj interface{}) error {
+	return fmt.Errorf("Update method not implemented")
+}
+
+// Delete always returns an error
+func (s *everFailingIndexer) Delete(obj interface{}) error {
+	return fmt.Errorf("Delete method not implemented")
+}
+
+// List always returns nil
+func (s *everFailingIndexer) List() []interface{} {
+	return nil
+}
+
+// ListKeys always returns nil
+func (s *everFailingIndexer) ListKeys() []string {
+	return nil
+}
+
+// Get always returns an error
+func (s *everFailingIndexer) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, fmt.Errorf("Get method not implemented")
+}
+
+// GetByKey always returns an error
+func (s *everFailingIndexer) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, fmt.Errorf("GetByKey method not implemented")
+}
+
+// Replace always returns an error
+func (s *everFailingIndexer) Replace(objects []interface{}, sKey string) error {
+	return fmt.Errorf("Replace method not implemented")
+}
+
+// Resync always returns an error
+func (s *everFailingIndexer) Resync() error {
+	return fmt.Errorf("Resync method not implemented")
+}

--- a/pkg/operator/configobservation/auth/webhook_authenticator.go
+++ b/pkg/operator/configobservation/auth/webhook_authenticator.go
@@ -33,7 +33,7 @@ var (
 // openshift-kube-apiserver NS.
 func ObserveWebhookTokenAuthenticator(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, _ []error) {
 	defer func() {
-		configobserver.Pruned(ret, webhookTokenAuthenticatorPath)
+		ret = configobserver.Pruned(ret, webhookTokenAuthenticatorPath, webhookTokenAuthenticatorVersionPath)
 	}()
 
 	listers := genericListers.(configobservation.Listers)

--- a/pkg/operator/configobservation/auth/webhook_authenticator_test.go
+++ b/pkg/operator/configobservation/auth/webhook_authenticator_test.go
@@ -21,7 +21,8 @@ import (
 	"k8s.io/utils/clock"
 )
 
-var correctKubeConfigString = []byte(`
+var (
+	correctKubeConfigString = []byte(`
 apiVersion: v1
 kind: Config
 clusters:
@@ -42,6 +43,24 @@ users:
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS0FJQkFBS0NBZ0VBc1l5OGNyTkcxOVR5cW5RMGV4Z2QyeFRORHNjUDVNayszZ0ZKUVZRSEk3ZEREaW12CkVyMFdHdGRqb2lFSTZXVFVpT1haUmI3R2pPMkdIbnJ0YkFXVVZRdE1tcG1xSi9JQ0FpTWpMOUFRNHdrb0M4TjIKdS9zR2N6bS9KanRGdmNqZ0xPTDZXTWJpbjRNZWJsbmZ1dkdIQlhhc3VvZ0VmcDVQWFg4Rkk4Q3dha0UyUHFaeApBWlQrbUdTMXJEalVldHB3UXlvQXJmRUZXaTZscTZYQ1BCcXJFa2JNUVJtVUMvT1dyZ29FU1JLQjJPSjJLY2FGCmNWY2w0bm15R0ZudTNlNWVlV2tkVXdWZyswWUdFTDMrTCtOR0p6OXM1M2JMamNJdnF5WkdmNnBvN2pHUExhSksKamE5QVFyTEZiVHJrTDRmZncyZzNaR05EMmwvRkM0U0xsYXJrZ3JsSkxYWGw3ajRnU2JkUFJoSVI1dU82b3JqMQpPMklwNjFvdWt5cWdmRE0reHFkNFF0WEJOcE9abUI2Y3JITXBDdXlVMVFyVW90b0JBZytFNmYydnQ3M1dWcDFDCjJoQVhFWWVQMGk4TzhKK1J3SzdUcFpyVDZZbmQwL3E4dzhEdUZDWUdOTE5rUFlqTE5sR1dyZlBIK0szQ3B6bWIKUGo3T3dybTZaWmtWV3ptd1VhVkUyeUwwcjd4QlpwMFdQM0FwUC9pUDM3enN0WmJaVzhpT0ZRdmtNZEdQcEpWcgo4b0pKV3B2em92amRoVUQ2QmZpVyt3ZmR3NGhqQStIZWRSOVVrcWMzRXRuQjJ1dkVIRTNNVFlDY3VlQ0VmOGh4CnFWZjdvdzM3bjg3aWtaTVlKakZubXBLcG1yQml1cnNsNFVEbGlxSXovc3V0cnNnNWdhZk1DSjBWL0FjQ0F3RUEKQVFLQ0FnQXpGaVNPK0VpVkI1Ky9MZXAvMUtPYWl2U3BvTnRRNEJybnRBVUkrQTJKMkV4Q0FmcHU4TnN3WS9NMgpEajFMTW9qNHp2SGlZSTh1czVWWXBkUTB0YkpGZWhmVGtBMW1xdnFxOU1OR0daOFNSR3N5WDA2RnJpZmY5YWlyCmJuaVZyL3ZZem9Kc0V1WFlNZGtLdFc5cmtkMWcxQkhGSmlmczZzNDVQN2dSM25xa1NCazhrNVdHZUFGOWhkVEUKTmlIbEszOEx4RVVueDJiYjJQb3dWbVI1K001cVZ0YWtrS0NKZzlCQ1NYMk1MUGdSbUsrWk81YmYwc3lDeXJOVQowR09ybGMrM0xXaVRuOE9VNlVRTGd5OWxSZ2JFZWpweXF6ck1raWczSGE5QlFwNG9remY0VUc4VkwyelZCQzFNClRacWtsbnJxOWN5aVpQRjhIdnhLWVJ2c3Q1eENDY1JONk5EQjNMOGdERWUyWnhXMFhrVGV2RHA0L2hubVdCUkQKaFNrV0lDS3JLRU5jR294VUFQUUFWZVljcHJ5aUdmWHc3UXV4OWpRKzlBYmozbEpiYmhJRHlqbk9Mci9HNEtrRAp5ZzcxNFZ3aDlXS1Q3M3FRd0wzR1FoYW1NajRhVXZOdmFNTVhtOVZwMG9QaktiSE9NVVRGanRNTzRpU0ozMkxHCjFRZ1h6RWxMYTBuQU1TQUdocjhwclBVd0MzRklPSU1lQi9IZzBYUzhGMk5IMGtxdytCVmNnZVlYMFFrcDdyamUKbEcxNkJ6b3FUMitrVHZyejFIWEk1K3FXUkJQUFN0TS9MYXBJdWNRcHlvZFFnUUswRVorcysvRFdXRnBVRHc3QwpFLzRPRUZKb1ZRRW5lckszSkRjdUliaDVqb01oZE5KMlRjZnRrcGQxT24rTVRzdDFRUUtDQVFFQTU1aDg1cVNqCnBIR2VicDEzSnJZV2RSVHQ0NVZMRzhUSnpOUmxFM08xbE1tLy9hZDRIYVhaVzJjMkQ4QW1iSDY5VVhqR0R4WXkKSGp4Mll0QVkrY0VCNHp5eXRlZXFOUUFmOGRCeFIxU2hpWFVpVWUvbzRZMVdXZGQwZFRTcE1UUHpnRmNwa1pJSQpnOFhvL3QrRUR3enZXSGozRmczWkFZMUk3VDdkY0hnRjU1NGNRK0hMQ05BVnd5cWQ4Wlg5cDZ6TjNCamNJbWhoCjZQYWx0cnRpS2IwYUZORjVRQTJwdEJjYXppK0w0c2xpVUZiZnA4T3RwdHc1MVkzQWhiem5YaW9DQVZtSEt2azkKUGtDSTBkTWE0WnprVHdVMnBwSFZRTUVLTTdXbnhWM0oxRktZMHM5K1pkNGR3NEg2YW5aeE1oVmN3QW9lNFlVLwpPNHZya3JieU4zd2c1d0tDQVFFQXhFSlBDdVVhSkNmLzFEUVBOQzJZaHZWYkcvcmdlbnl4VlpuOTlWWHJuNjZICmhyMzcvTG9jM2JvcU5WUlBPT3RSOUtmSVp4UnVCUWlxeVd2ZjhpaVo2TE1PWUQyOFAvVjFCVDloRktkWUl4cU0KL2djY2poSUwreitVOGNsdFMxQnlBYkROcjJJbG5LMGxJN2hFaFh1WkZrRnZyNmtSS1VlcWlZRUc4anNQV0cvYgoybkRMankxeHJ0VlF1YjV5ck1LQWN6bEFCMldEVEgrWm1YRGF6Vi9xOEtPTmRNMUZXdjNtc1lEMEZXbWxCeVM1ClZZbHdnVHRIVWhIT2RsTm0zVUR5Vk1oMlY3cWRLVVhrdG52a1lRWFI4K1lGQUJLbkVoTVNlVGpUVzh6WEZLL1oKWUFwS1FPSnU4VzlmMzZUN0JVS1I0a1gySHhuRTNlTnhzeHZCZ0p0SDRRS0NBUUFCQlhJZmprQk9mRlhIaFJnKwphblVrNVFlN2hqQURtbFdOZXE1TGJLb3pVc1J1K09zVnJtS0wvYU9HWkVHSEh2UDB4UVNTa25WOEhxWWkvMm5zCnlBWWJHMnhxVXZBME5hRHVidzNnMDZXMnRuYUZSL3FON0JLaWFNblJybjdFZ2Nja0hMNUpMd3lza0JYYjhkNWkKTnB0amwzejNjdTR2REpGeXdtRTFtc0hqNkpXVlV3eVRLRi9BTVpMcXVzK1lpckdKcys1Y2xIdENETHhrVnVVeQo2K3VPaGZIejcxdDlPTkRjY2VjN0E4cFVNbDNnSG9QSWhaWVhzLzFTV2FmbmlXWGkzYU16OUU5cDA5MEdsOWk1CmYvaWR4SmNlR3V5RzBaTWE4VVVoSUszQUt2RVRsT2lveUZiM1FyNTQ4N2JDRXNnSzdNQ0FIQmRRU3VpcUIvWi8KZWlPbkFvSUJBRVp1UVcxNGdHUWZVcWoxc2NzWTNkYjQ4Q1JmYVBXc0QvdlhVcE1iclg1VnBOOVBDTUpPakJOcQpQc0Y2cXgrVEc0dEFOeVArNmVpMmpvdlFRY0xtblMwc0xPbU8zaUxaMUkvNGliOWV1cnVHU0xqVkZvTkpxTEVXCnhUM3IrbVAvejVvWnVBYkxveEhSOVRVWGFNZTZibHJWU3Q1d1B1OWdmNnZ1K080dkViZThGTnNVaFlpeFYwM1YKMGEyRzBpSjdmcHRiSFVaS1FNOVFMM0FvVnUxREVjNGY4NkRLRmF5czE0QTE5ZUpGVW1yNDIrWDlkN2w0NjRSaApUWVdiTXB3T05ha0ZjNnJTRnBwOE1iTG5UVE1nWXBNenBmRzd2K2MxbnZpUDB4SHJ0ZmYvajNQdTNXemhsY3poCkdqZnBQZ2hLTm81TWF5SUlIbVUrdlV2NGx2MnZQQ0VDZ2dFQkFKdEx0WklNN1lQTU8zcFNHdjdBcnpJYkovSHcKYXQ4bnZBTk1jQjEvYk45em1oWWc3OHVtaUtUc3hRTFBQVk5uK09NN0JrU0l6RFM4QjBMRm5MekVtVVZuNnBWaApVUXJIUFh1c3dCS3V0dDV3NHBIV2hEZUs2aXFnNnZnc1NXUnpxaFFWTllUTW50NVFQeHVtRGtXMUcvdm52RnNNClRnVk9PQnJBTHpMUCtVWm5zcm5uWU1DcXp6bGhPUjU4VWU5OEJWajB6b0hQR0Q0UU1HcGlTb1pOdkhMNndkQ0gKcytFdlc1czdPOWE1SnhwRGYzcUl3RTRMbjBSc2xvMHBnVTZZQU1qd25tWUpXNk5JNE5kSitMQWFZM2ZBcXNicAorSFdyY21TQ2VVaVAwMEp4NzFzbXRvQ3JBY3RkY2hsU01JMGtiOUpNS05yOWhYZWlxRzErSmxzRGZUTT0KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K
 `)
 
+	unprunedBaseWebhookAuthenticatorConfig = map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"authentication-token-webhook-config-file": webhookTokenAuthenticatorFile,
+			"authentication-token-webhook-version":     webhookTokenAuthenticatorVersion,
+		},
+		"authConfig": map[string]interface{}{
+			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
+		},
+	}
+
+	prunedBaseWebhookAuthenticatorConfig = map[string]interface{}{
+		"apiServerArguments": map[string]interface{}{
+			"authentication-token-webhook-config-file": webhookTokenAuthenticatorFile,
+			"authentication-token-webhook-version":     webhookTokenAuthenticatorVersion,
+		},
+	}
+)
+
 func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -52,6 +71,7 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 		expectErrs        bool
 		expectEvents      bool
 		expectedSynced    map[string]string
+		expectedConfig    map[string]interface{}
 	}{
 		{
 			name: "empty config",
@@ -63,21 +83,19 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 					Name: "config-secret",
 				},
 			},
-			expectErrs: true,
+			expectedConfig: nil,
+			expectErrs:     true,
 		},
 		{
-			name: "config removal",
-			existingConfig: map[string]interface{}{
-				"apiServerArguments": map[string]interface{}{
-					"authentication-token-webhook-config-file": []interface{}{webhookTokenAuthenticatorFile},
-				},
-			},
+			name:           "config removal",
+			existingConfig: unprunedBaseWebhookAuthenticatorConfig,
 			config: &configv1.WebhookTokenAuthenticator{
 				KubeConfig: configv1.SecretNameReference{
 					Name: "",
 				},
 			},
-			expectEvents: true,
+			expectedConfig: nil,
+			expectEvents:   true,
 			expectedSynced: map[string]string{
 				"secret/webhook-authenticator.openshift-kube-apiserver": "DELETE",
 			},
@@ -93,18 +111,15 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 				"kubeConfig": correctKubeConfigString,
 			},
 			webhookConfigured: true,
+			expectedConfig:    prunedBaseWebhookAuthenticatorConfig,
 			expectedSynced: map[string]string{
 				"secret/webhook-authenticator.openshift-kube-apiserver": "secret/config-secret.openshift-config",
 			},
 			expectEvents: true,
 		},
 		{
-			name: "same existing and observed config",
-			existingConfig: map[string]interface{}{
-				"apiServerArguments": map[string]interface{}{
-					"authentication-token-webhook-config-file": []interface{}{webhookTokenAuthenticatorFile},
-				},
-			},
+			name:           "same existing and observed config",
+			existingConfig: unprunedBaseWebhookAuthenticatorConfig,
 			config: &configv1.WebhookTokenAuthenticator{
 				KubeConfig: configv1.SecretNameReference{
 					Name: "config-secret",
@@ -114,6 +129,7 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 				"kubeConfig": correctKubeConfigString,
 			},
 			webhookConfigured: true,
+			expectedConfig:    prunedBaseWebhookAuthenticatorConfig,
 			expectedSynced: map[string]string{
 				"secret/webhook-authenticator.openshift-kube-apiserver": "secret/config-secret.openshift-config",
 			},
@@ -158,6 +174,10 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 			eventRecorder := events.NewInMemoryRecorder("webhookauthenticatortest", clock.RealClock{})
 
 			gotConfig, errs := ObserveWebhookTokenAuthenticator(listers, eventRecorder, tt.existingConfig)
+			if !equality.Semantic.DeepEqual(tt.expectedConfig, gotConfig) {
+				t.Errorf("unexpected config diff: %s", diff.ObjectReflectDiff(tt.expectedConfig, gotConfig))
+			}
+
 			gotAuthenticator, _, err := unstructured.NestedStringSlice(gotConfig, webhookTokenAuthenticatorPath...)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/operator/configobservation/auth/webhook_authenticator_test.go
+++ b/pkg/operator/configobservation/auth/webhook_authenticator_test.go
@@ -281,11 +281,15 @@ users:
 }
 
 type mockResourceSyncer struct {
+	error  error
 	t      *testing.T
 	synced map[string]string
 }
 
 func (rs *mockResourceSyncer) SyncConfigMap(destination, source resourcesynccontroller.ResourceLocation) error {
+	if rs.error != nil {
+		return rs.error
+	}
 	if (source == resourcesynccontroller.ResourceLocation{}) {
 		rs.synced[fmt.Sprintf("configmap/%v.%v", destination.Name, destination.Namespace)] = "DELETE"
 	} else {
@@ -295,6 +299,9 @@ func (rs *mockResourceSyncer) SyncConfigMap(destination, source resourcesynccont
 }
 
 func (rs *mockResourceSyncer) SyncSecret(destination, source resourcesynccontroller.ResourceLocation) error {
+	if rs.error != nil {
+		return rs.error
+	}
 	if (source == resourcesynccontroller.ResourceLocation{}) {
 		rs.synced[fmt.Sprintf("secret/%v.%v", destination.Name, destination.Namespace)] = "DELETE"
 	} else {

--- a/pkg/operator/configobservation/auth/webhook_authenticator_test.go
+++ b/pkg/operator/configobservation/auth/webhook_authenticator_test.go
@@ -74,7 +74,8 @@ func TestObserveWebhookTokenAuthenticator(t *testing.T) {
 		expectedConfig    map[string]interface{}
 	}{
 		{
-			name: "empty config",
+			name:         "empty config",
+			expectEvents: true,
 		},
 		{
 			name: "referenced secret missing",

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -127,6 +127,7 @@ func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInf
 			auth.ObserveAuthMetadata,
 			auth.ObserveServiceAccountIssuer,
 			auth.ObserveWebhookTokenAuthenticator,
+			auth.NewObserveExternalOIDC(featureGateAccessor),
 			auth.NewObservePodSecurityAdmissionEnforcementFunc(featureGateAccessor),
 			encryption.NewEncryptionConfigObserver(
 				operatorclient.TargetNamespace,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationtimeupgradeablecontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configmetrics"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/apienablement"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/auth"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/configobservercontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/node"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/connectivitycheckcontroller"
@@ -613,6 +614,9 @@ var RevisionConfigMaps = []revision.RevisionResource{
 	{Name: "sa-token-signing-certs"},
 
 	{Name: "kube-apiserver-audit-policies"},
+
+	// optional configmap containing the OIDC structured auth config
+	{Name: auth.AuthConfigCMName, Optional: true},
 }
 
 // RevisionSecrets is a list of secrets that are directly copied for the current values.  A different actor/controller modifies these.


### PR DESCRIPTION
This PR does the following:
- adds unit tests for the `AuthMetadata` config observer
- adds a new config observer for direct OIDC; the config observer:
   - detects auth type `OIDC` and the structured auth config CM in `openshift-config-managed` (created by the CAO in [cluster-authentication-operator#713](https://github.com/openshift/cluster-authentication-operator/pull/713))
   - copies it to `openshift-kube-apiserver` where it will be used as a revisioned configmap and synced to a static file on all KAS nodes
   - enables OIDC config via the `--authentication-config` CLI flag of the KAS pods
- modifies the `AuthMetadata` and `WebhookTokenAuthenticator` config observers to delete their respective resources when auth type `OIDC` is detected

Enhancement: https://github.com/openshift/enhancements/pull/1632