### PR TITLE
API-1689: TLS registry: add description

### DIFF
--- a/bindata/assets/kube-apiserver/trusted-ca-cm.yaml
+++ b/bindata/assets/kube-apiserver/trusted-ca-cm.yaml
@@ -5,5 +5,6 @@ metadata:
   name: trusted-ca-bundle
   annotations:
     "openshift.io/owning-component": "Networking / cluster-network-operator"
+    "openshift.io/description": "CA used to recognize proxy servers.  By default this will contain standard root CAs on the cluster-network-operator pod."
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-admin-kubeconfig-client-ca.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openshift-config
   annotations:
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "CA for kube-apiserver to recognize the system:master created by the installer."
 data:
   ca-bundle.crt: |
     {{ .Assets | load "admin-kubeconfig-ca-bundle.crt" | indent 4 }}
-

--- a/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
+++ b/bindata/bootkube/manifests/configmap-csr-controller-ca.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openshift-config-managed
   annotations:
     "openshift.io/owning-component": "kube-controller-manager"
+    "openshift.io/description": "CA to recognize the CSRs (both serving and client) signed by the kube-controller-manager."
 data:
   ca-bundle.crt: |
     {{ .Assets | load "kubelet-client-ca-bundle.crt" | indent 4 }}
-

--- a/bindata/bootkube/manifests/secret-aggregator-client-signer.yaml
+++ b/bindata/bootkube/manifests/secret-aggregator-client-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "aggregator-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "aggregator-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer for the kube-apiserver to create client certificates for aggregated apiservers to recognize as a front-proxy."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "aggregator-signer.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-control-plane-client-signer.yaml
+++ b/bindata/bootkube/manifests/secret-control-plane-client-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-control-plane-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-control-plane-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer for kube-controller-manager and kube-scheduler client certificates."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kube-control-plane-signer.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-kube-apiserver-to-kubelet-signer.yaml
+++ b/bindata/bootkube/manifests/secret-kube-apiserver-to-kubelet-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer for the kube-apiserver-to-kubelet-client so kubelets can recognize the kube-apiserver."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kube-apiserver-to-kubelet-signer.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-loadbalancer-serving-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-lb-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-lb-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer used by the kube-apiserver operator to create serving certificates for the kube-apiserver via internal and external load balancers."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kube-apiserver-lb-signer.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-localhost-serving-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-localhost-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer used by the kube-apiserver to create serving certificates for the kube-apiserver via localhost."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kube-apiserver-localhost-signer.crt" | base64 }}

--- a/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
+++ b/bindata/bootkube/manifests/secret-service-network-serving-signer.yaml
@@ -8,6 +8,7 @@ metadata:
     "auth.openshift.io/certificate-not-after": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | notAfter }}
     "auth.openshift.io/certificate-issuer": {{ .Assets | load "kube-apiserver-service-network-signer.crt" | issuer }}
     "openshift.io/owning-component": "kube-apiserver"
+    "openshift.io/description": "Signer used by the kube-apiserver to create serving certificates for the kube-apiserver via the service network."
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Assets | load "kube-apiserver-service-network-signer.crt" | base64 }}

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -136,6 +136,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions openshift-apiserver'",
+				Description:                      "Signer for the kube-apiserver to create client certificates for aggregated apiservers to recognize as a front-proxy",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -151,6 +152,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions openshift-apiserver'",
+				Description:                      "CA for aggregated apiservers to recognize kube-apiserver as front-proxy.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Lister(),
@@ -163,6 +165,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions openshift-apiserver'",
+				Description:                      "Client certificate used by the kube-apiserver to communicate to aggregated apiservers.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -188,6 +191,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[sig-cli] Kubectl logs logs should be able to retrieve and filter logs  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]'",
+				Description:                      "Signer for the kube-apiserver-to-kubelet-client so kubelets can recognize the kube-apiserver.",
 			},
 			Validity: 1 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -205,6 +209,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[sig-cli] Kubectl logs logs should be able to retrieve and filter logs  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]'",
+				Description:                      "CA for the kubelet to recognize the kube-apiserver client certificate.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -217,6 +222,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[sig-cli] Kubectl logs logs should be able to retrieve and filter logs  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]'",
+				Description:                      "Client certificate used by the kube-apiserver to authenticate to the kubelet for requests like exec and logs.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -241,6 +247,7 @@ func newCertRotationController(
 			Name:      "localhost-serving-signer",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Signer used by the kube-apiserver to create serving certificates for the kube-apiserver via localhost.",
 			},
 			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -259,6 +266,7 @@ func newCertRotationController(
 			Name:      "localhost-serving-ca",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "CA for recognizing the kube-apiserver when connecting via localhost.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -271,6 +279,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Serving certificate used by the kube-apiserver to terminate requests via localhost.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -295,6 +304,7 @@ func newCertRotationController(
 			Name:      "service-network-serving-signer",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Signer used by the kube-apiserver to create serving certificates for the kube-apiserver via the service network.",
 			},
 			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -313,6 +323,7 @@ func newCertRotationController(
 			Name:      "service-network-serving-ca",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "CA for recognizing the kube-apiserver when connecting via the service network (kuberentes.default.svc).",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -325,6 +336,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Serving certificate used by the kube-apiserver to terminate requests via the service network.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -350,6 +362,7 @@ func newCertRotationController(
 			Name:      "loadbalancer-serving-signer",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Signer used by the kube-apiserver operator to create serving certificates for the kube-apiserver via internal and external load balancers.",
 			},
 			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -368,6 +381,7 @@ func newCertRotationController(
 			Name:      "loadbalancer-serving-ca",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "CA for recognizing the kube-apiserver when connecting via the internal or external load balancers.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -380,6 +394,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Serving certificate used by the kube-apiserver to terminate requests via the external load balancer.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -405,6 +420,7 @@ func newCertRotationController(
 			Name:      "loadbalancer-serving-signer",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Signer used by the kube-apiserver operator to create serving certificates for the kube-apiserver via internal and external load balancers.",
 			},
 			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -423,6 +439,7 @@ func newCertRotationController(
 			Name:      "loadbalancer-serving-ca",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "CA for recognizing the kube-apiserver when connecting via the internal or external load balancers.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -435,6 +452,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[bz-kube-apiserver] kube-apiserver should be accessible by clients using internal load balancer without iptables issues'",
+				Description:                      "Serving certificate used by the kube-apiserver to terminate requests via the internal load balancer.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -460,6 +478,7 @@ func newCertRotationController(
 			Name:      "localhost-recovery-serving-signer",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Signer used by the kube-apiserver to create serving certificates for the kube-apiserver via the service network.",
 			},
 			Validity: 10 * 365 * defaultRotationDay, // this comes from the installer
 			// Refresh set to 80% of the validity.
@@ -477,6 +496,7 @@ func newCertRotationController(
 			Name:      "localhost-recovery-serving-ca",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "CA for recognizing the kube-apiserver when connecting via the localhost recovery SNI ServerName.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -488,6 +508,7 @@ func newCertRotationController(
 			Name:      "localhost-recovery-serving-certkey",
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent: "kube-apiserver",
+				Description:   "Serving certificate used by the kube-apiserver to terminate requests via the localhost recovery SNI ServerName.",
 			},
 			Validity: 10 * 365 * defaultRotationDay,
 			// Refresh set to 80% of the validity.
@@ -516,6 +537,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
@@ -531,6 +553,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "CA for kube-apiserver to recognize the kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -543,6 +566,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-controller-manager'",
+				Description:                      "Client certificate used by the kube-controller-manager to authenticate to the kube-apiserver.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -568,6 +592,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
@@ -583,6 +608,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "CA for kube-apiserver to recognize the kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -595,6 +621,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-scheduler'",
+				Description:                      "Client certificate used by the kube-scheduler to authenticate to the kube-apiserver.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -620,6 +647,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
@@ -635,6 +663,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "CA for kube-apiserver to recognize the kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -672,6 +701,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Validity:               60 * defaultRotationDay,
 			Refresh:                30 * defaultRotationDay,
@@ -687,6 +717,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "CA for kube-apiserver to recognize the kube-controller-manager and kube-scheduler client certificates.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -699,6 +730,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Client certificate used by the network connectivity checker of the kube-apiserver.",
 			},
 			Validity:               30 * rotationDay,
 			Refresh:                15 * rotationDay,
@@ -724,6 +756,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Signer for the per-master-debugging-client.",
 			},
 			Validity: 1 * 365 * defaultRotationDay,
 			// Refresh set to 80% of the validity.
@@ -741,6 +774,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "CA for kube-apiserver to recognize local system:masters rendered to each master.",
 			},
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
@@ -753,6 +787,7 @@ func newCertRotationController(
 			AdditionalAnnotations: certrotation.AdditionalAnnotations{
 				JiraComponent:                    "kube-apiserver",
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
+				Description:                      "Client certificate (system:masters) placed on each master to allow communication to kube-apiserver for debugging.",
 			},
 			// This needs to live longer then control plane certs so there is high chance that if a cluster breaks
 			// because of expired certs these are still valid to use for collecting data using localhost-recovery


### PR DESCRIPTION
This adds description to certificates managed by cluster-kube-apiserver-operator. These are taken from https://github.com/openshift/api/tree/master/tls/docs