### PR TITLE
issue #1728 fix time units in kube-apiserver-operator api performance dashboard

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -119,15 +119,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -227,15 +219,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -335,15 +319,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -546,15 +522,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1744,15 +1712,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2038,15 +1998,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -2653,15 +2605,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
…_dashboard.yaml

Solves issue #1728 by replacing the unit-less "short" format by "s" for seconds.

(Just a suggestion - did not verify the change locally, as my Grafana seems to use a different version using a different dashboard syntax)