### PR TITLE
OCPBUGS-49980: change one sum:apiserver_request:burnrate5m to sum:apiserver_request:burnrate6h

### DIFF
--- a/bindata/assets/alerts/kube-apiserver-slos-basic.yaml
+++ b/bindata/assets/alerts/kube-apiserver-slos-basic.yaml
@@ -214,7 +214,7 @@ spec:
           sum(apiserver_request:burn6h)
           /
           sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE"}[6h]))
-      record: sum:apiserver_request:burnrate5m
+      record: sum:apiserver_request:burnrate6h
     - expr: |
         sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
       labels:


### PR DESCRIPTION
see https://issues.redhat.com/browse/OCPBUGS-49980, there are 2 `sum:apiserver_request:burnrate5m` recording rule for 4.19, change the rate[6h] one to correct recording name `sum:apiserver_request:burnrate6h`