### PR TITLE
CNTRLPLANE-79: Disable oauth admission plugins

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -70,8 +70,6 @@ apiServerArguments:
     - TaintNodesByCondition
     - ValidatingAdmissionWebhook
     - ValidatingAdmissionPolicy
-    - authorization.openshift.io/RestrictSubjectBindings
-    - authorization.openshift.io/ValidateRoleBindingRestriction
     - config.openshift.io/DenyDeleteClusterConfiguration
     - config.openshift.io/ValidateAPIServer
     - config.openshift.io/ValidateAuthentication

--- a/pkg/operator/configobservation/apiserver/observe_admission_plugins.go
+++ b/pkg/operator/configobservation/apiserver/observe_admission_plugins.go
@@ -1,0 +1,99 @@
+package apiserver
+
+import (
+	"fmt"
+	"slices"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type pluginCheckerFunc func(listers configobservation.Listers) (enabled, disabled []string, err error)
+
+var (
+	enableAdmissionPluginsPath  = []string{"apiServerArguments", "enable-admission-plugins"}
+	disableAdmissionPluginsPath = []string{"apiServerArguments", "disable-admission-plugins"}
+
+	pluginCheckers = []pluginCheckerFunc{
+		roleBindingRestrictionPluginChecker,
+	}
+)
+
+// ObserveAdmissionPlugins manages the apiServerArguments.enable-admission-plugins and
+// apiServerArguments.disable-admission-plugins fields of the configuration. It defines a list of
+// plugin checkers which check the state of specific plugins, and add them to the enabled or disabled
+// list as required. This observer will overwrite any pre-existing values of the two fields in the existingConfig.
+func ObserveAdmissionPlugins(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]any) (ret map[string]any, _ []error) {
+	defer func() {
+		ret = configobserver.Pruned(ret, enableAdmissionPluginsPath, disableAdmissionPluginsPath)
+	}()
+
+	if len(pluginCheckers) == 0 {
+		return existingConfig, nil
+	}
+
+	listers := genericListers.(configobservation.Listers)
+	enabledSet := sets.New[string]()
+	disabledSet := sets.New[string]()
+
+	for _, pluginChecker := range pluginCheckers {
+		enabled, disabled, err := pluginChecker(listers)
+		if err != nil {
+			return existingConfig, []error{err}
+		}
+
+		enabledSet.Insert(enabled...)
+		disabledSet.Insert(disabled...)
+	}
+
+	if intersection := enabledSet.Intersection(disabledSet); intersection.Len() > 0 {
+		return existingConfig, []error{fmt.Errorf("plugins cannot be enabled and disabled at the same time: %v", intersection.UnsortedList())}
+	}
+
+	observedConfig := map[string]any{}
+
+	if enabledSet.Len() > 0 {
+		sorted := slices.Sorted[string](slices.Values(enabledSet.UnsortedList()))
+		err := unstructured.SetNestedStringSlice(observedConfig, sorted, enableAdmissionPluginsPath...)
+		if err != nil {
+			return existingConfig, []error{err}
+		}
+	}
+
+	if disabledSet.Len() > 0 {
+		sorted := slices.Sorted[string](slices.Values(disabledSet.UnsortedList()))
+		err := unstructured.SetNestedStringSlice(observedConfig, sorted, disableAdmissionPluginsPath...)
+		if err != nil {
+			return existingConfig, []error{err}
+		}
+	}
+
+	return observedConfig, nil
+}
+
+func roleBindingRestrictionPluginChecker(listers configobservation.Listers) (enabled, disabled []string, err error) {
+	auth, err := listers.AuthConfigLister.Get("cluster")
+	if err != nil {
+		return
+	}
+
+	rbrPlugins := []string{
+		"authorization.openshift.io/RestrictSubjectBindings",
+		"authorization.openshift.io/ValidateRoleBindingRestriction",
+	}
+
+	switch auth.Spec.Type {
+	case configv1.AuthenticationTypeIntegratedOAuth, "":
+		enabled = rbrPlugins
+
+	case configv1.AuthenticationTypeNone, configv1.AuthenticationTypeOIDC:
+		disabled = rbrPlugins
+	}
+
+	return
+}

--- a/pkg/operator/configobservation/apiserver/observe_admission_plugins_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_admission_plugins_test.go
@@ -1,0 +1,231 @@
+package apiserver
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/tools/cache"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+)
+
+func TestObserveAdmissionPlugins(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		pluginCheckers []pluginCheckerFunc
+		existingConfig map[string]any
+
+		expectErrors   bool
+		expectedConfig map[string]any
+	}{
+		{
+			name:           "no plugin checkers available",
+			existingConfig: map[string]any{"key": "value"},
+			pluginCheckers: []pluginCheckerFunc{},
+			expectErrors:   false,
+			expectedConfig: map[string]any{},
+		},
+		{
+			name: "observer returns pruned config",
+			existingConfig: map[string]any{
+				"key": "value",
+				"apiServerArguments": map[string]any{
+					"enable-admission-plugins":  []any{"enabled1", "enabled2"},
+					"disable-admission-plugins": []any{"disabled1", "disabled2"},
+				},
+			},
+			pluginCheckers: []pluginCheckerFunc{},
+			expectErrors:   false,
+			expectedConfig: map[string]any{
+				"apiServerArguments": map[string]any{
+					"enable-admission-plugins":  []any{"enabled1", "enabled2"},
+					"disable-admission-plugins": []any{"disabled1", "disabled2"},
+				},
+			},
+		},
+		{
+			name:           "plugin checker with error",
+			existingConfig: map[string]any{"key": "value"},
+			pluginCheckers: []pluginCheckerFunc{
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return nil, nil, fmt.Errorf("plugin checker error")
+				},
+			},
+			expectErrors:   true,
+			expectedConfig: map[string]any{},
+		},
+		{
+			name:           "plugin checkers must enable and disable plugins",
+			existingConfig: map[string]any{"key": "value"},
+			pluginCheckers: []pluginCheckerFunc{
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled1"}, nil, nil
+				},
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return nil, []string{"disabled1"}, nil
+				},
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled2"}, []string{"disabled2"}, nil
+				},
+			},
+			expectErrors: false,
+			expectedConfig: map[string]any{
+				"apiServerArguments": map[string]any{
+					"enable-admission-plugins":  []any{"enabled1", "enabled2"},
+					"disable-admission-plugins": []any{"disabled1", "disabled2"},
+				},
+			},
+		},
+		{
+			name: "plugin checkers must overwrite existing enabled and disabled",
+			existingConfig: map[string]any{
+				"key": "value",
+				"apiServerArguments": map[string]any{
+					"enable-admission-plugins":  []any{"another1"},
+					"disable-admission-plugins": []any{"another2"},
+				},
+			},
+			pluginCheckers: []pluginCheckerFunc{
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled1"}, nil, nil
+				},
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return nil, []string{"disabled1"}, nil
+				},
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled2"}, []string{"disabled2"}, nil
+				},
+			},
+			expectErrors: false,
+			expectedConfig: map[string]any{
+				"apiServerArguments": map[string]any{
+					"enable-admission-plugins":  []any{"enabled1", "enabled2"},
+					"disable-admission-plugins": []any{"disabled1", "disabled2"},
+				},
+			},
+		},
+		{
+			name: "plugin checkers must return disjoint enabled and disabled plugin slices",
+			pluginCheckers: []pluginCheckerFunc{
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled1", "enabled2"}, nil, nil
+				},
+				func(_ configobservation.Listers) ([]string, []string, error) {
+					return []string{"enabled3"}, []string{"enabled2"}, nil
+				},
+			},
+			expectErrors: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pluginCheckers = tt.pluginCheckers
+
+			eventRecorder := events.NewInMemoryRecorder("TestObserveAdmissionPlugins", clocktesting.NewFakePassiveClock(time.Now()))
+			listers := configobservation.Listers{}
+			gotConfig, gotErrs := ObserveAdmissionPlugins(listers, eventRecorder, tt.existingConfig)
+
+			if tt.expectErrors != (len(gotErrs) > 0) {
+				t.Errorf("expected errors: %v; got %v", tt.expectErrors, gotErrs)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedConfig, gotConfig) {
+				t.Errorf("unexpected config diff: %s", diff.ObjectReflectDiff(tt.expectedConfig, gotConfig))
+			}
+		})
+	}
+}
+
+func TestRoleBindingRestrictionPluginChecker(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		authType         *configv1.AuthenticationType
+		expectedEnabled  []string
+		expectedDisabled []string
+		expectError      bool
+	}{
+		{
+			name:        "authentication cluster not found",
+			expectError: true,
+		},
+		{
+			name:     "auth type IntegratedOAuth",
+			authType: ptr.To(configv1.AuthenticationTypeIntegratedOAuth),
+			expectedEnabled: []string{
+				"authorization.openshift.io/RestrictSubjectBindings",
+				"authorization.openshift.io/ValidateRoleBindingRestriction",
+			},
+			expectedDisabled: []string{},
+			expectError:      false,
+		},
+		{
+			name:     "auth type empty string",
+			authType: ptr.To(configv1.AuthenticationType("")),
+			expectedEnabled: []string{
+				"authorization.openshift.io/RestrictSubjectBindings",
+				"authorization.openshift.io/ValidateRoleBindingRestriction",
+			},
+			expectedDisabled: []string{},
+			expectError:      false,
+		},
+		{
+			name:            "auth type None",
+			authType:        ptr.To(configv1.AuthenticationTypeNone),
+			expectedEnabled: []string{},
+			expectedDisabled: []string{
+				"authorization.openshift.io/RestrictSubjectBindings",
+				"authorization.openshift.io/ValidateRoleBindingRestriction",
+			},
+			expectError: false,
+		},
+		{
+			name:            "auth type OIDC",
+			authType:        ptr.To(configv1.AuthenticationTypeOIDC),
+			expectedEnabled: []string{},
+			expectedDisabled: []string{
+				"authorization.openshift.io/RestrictSubjectBindings",
+				"authorization.openshift.io/ValidateRoleBindingRestriction",
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if tt.authType != nil {
+				indexer.Add(&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.AuthenticationSpec{
+						Type: *tt.authType,
+					},
+				})
+			}
+
+			listers := configobservation.Listers{
+				AuthConfigLister: configlistersv1.NewAuthenticationLister(indexer),
+			}
+
+			enabled, disabled, err := roleBindingRestrictionPluginChecker(listers)
+			if tt.expectError != (err != nil) {
+				t.Errorf("expected errors: %v; got %v", tt.expectError, err)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedEnabled, enabled) {
+				t.Errorf("unexpected enabled plugins: %s", diff.ObjectReflectDiff(tt.expectedEnabled, enabled))
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expectedDisabled, disabled) {
+				t.Errorf("unexpected disabled plugins: %s", diff.ObjectReflectDiff(tt.expectedDisabled, disabled))
+			}
+		})
+	}
+}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -123,6 +123,7 @@ func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInf
 			apiserver.ObserveShutdownDelayDuration,
 			apiserver.ObserveGracefulTerminationDuration,
 			apiserver.ObserveSendRetryAfterWhileNotReadyOnce,
+			apiserver.ObserveAdmissionPlugins,
 			libgoapiserver.ObserveTLSSecurityProfile,
 			auth.ObserveAuthMetadata,
 			auth.ObserveServiceAccountIssuer,

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -266,7 +267,13 @@ func manageKubeAPIServerConfig(ctx context.Context, client coreclientv1.ConfigMa
 	configMap := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/kube-apiserver/cm.yaml"))
 	defaultConfig := bindata.MustAsset("assets/config/defaultconfig.yaml")
 	configOverrides := bindata.MustAsset("assets/config/config-overrides.yaml")
-	specialMergeRules := map[string]resourcemerge.MergeFunc{}
+
+	// resourcemerge will not merge slice contents; therefore we must set up special merge rules for
+	// enable-admission-plugins/disable-admission-plugins in order to merge the config from the various sources
+	specialMergeRules := map[string]resourcemerge.MergeFunc{
+		".apiServerArguments.enable-admission-plugins":  mergeStringSlices,
+		".apiServerArguments.disable-admission-plugins": mergeStringSlices,
+	}
 
 	// Guarantee the authorization-mode will be present in the base config, regardless of whether the observer is running
 	authModeOverride := map[string]interface{}{}
@@ -617,4 +624,43 @@ func manageTemplate(rawTemplate string, imagePullSpec string, operatorImagePullS
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func mergeStringSlices(dst, src any, _ string) (any, error) {
+	if src == nil {
+		return dst, nil
+	}
+
+	if dst == nil {
+		return src, nil
+	}
+
+	dstSlice, dstIsSlice := dst.([]any)
+	if !dstIsSlice {
+		return nil, fmt.Errorf("destination is not a slice (type: %T)", dst)
+	}
+
+	srcSlice, srcIsSlice := src.([]any)
+	if !srcIsSlice {
+		return nil, fmt.Errorf("source is not a slice (type: %T)", dst)
+	}
+
+	values := sets.NewString()
+	for _, elem := range dstSlice {
+		s, ok := elem.(string)
+		if !ok {
+			return nil, fmt.Errorf("destination slice element is not a string (type: %T)", elem)
+		}
+		values.Insert(s)
+	}
+
+	for _, elem := range srcSlice {
+		s, ok := elem.(string)
+		if !ok {
+			return nil, fmt.Errorf("source slice element is not a string (type: %T)", elem)
+		}
+		values.Insert(s)
+	}
+
+	return values.List(), nil
 }

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -7,14 +7,21 @@ import (
 	"strings"
 	"testing"
 
-	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	"github.com/ghodss/yaml"
+	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/stretchr/testify/require"
 )
 
 var codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
@@ -413,6 +420,142 @@ func TestIsRequiredConfigPresentEtcdEndpoints(t *testing.T) {
 			case actual != nil && len(test.expectedError) != 0 && !strings.Contains(actual.Error(), test.expectedError):
 				t.Fatal(actual)
 			}
+		})
+	}
+}
+
+func TestSpecialMergeRules(t *testing.T) {
+	mergeRules := map[string]resourcemerge.MergeFunc{
+		".apiServerArguments.enable-admission-plugins":  mergeStringSlices,
+		".apiServerArguments.disable-admission-plugins": mergeStringSlices,
+	}
+
+	configsToMerge := []*kubecontrolplanev1.KubeAPIServerConfig{
+		{
+			APIServerArguments: map[string]kubecontrolplanev1.Arguments{
+				"audit-log-format":          []string{"json"},
+				"enable-admission-plugins":  []string{"enabled0"},
+				"disable-admission-plugins": []string{"disabled0"},
+			},
+		},
+		{
+			APIServerArguments: map[string]kubecontrolplanev1.Arguments{
+				"audit-log-format":          []string{"yaml"},
+				"enable-admission-plugins":  []string{"enabled1"},
+				"disable-admission-plugins": []string{"disabled1"},
+			},
+		},
+		{
+			APIServerArguments: map[string]kubecontrolplanev1.Arguments{
+				"enable-admission-plugins":  []string{"enabled2"},
+				"disable-admission-plugins": []string{"disabled2"},
+			},
+		},
+	}
+
+	configs := make([][]byte, 0, len(configsToMerge))
+	for _, cfg := range configsToMerge {
+		cfgBytes, err := yaml.Marshal(cfg)
+		require.NoError(t, err)
+		configs = append(configs, cfgBytes)
+	}
+
+	result, _, err := resourcemerge.MergePrunedConfigMap(
+		&kubecontrolplanev1.KubeAPIServerConfig{},
+		&corev1.ConfigMap{Data: map[string]string{"config.yaml": ""}},
+		"config.yaml",
+		mergeRules,
+		configs...,
+	)
+	require.NoError(t, err)
+
+	config := &kubecontrolplanev1.KubeAPIServerConfig{}
+	err = yaml.Unmarshal([]byte(result.Data["config.yaml"]), config)
+	require.NoError(t, err)
+
+	// plugins have special merge rules, therefore slices must be merged
+	require.ElementsMatch(t, config.APIServerArguments["enable-admission-plugins"], []string{"enabled0", "enabled1", "enabled2"})
+	require.ElementsMatch(t, config.APIServerArguments["disable-admission-plugins"], []string{"disabled0", "disabled1", "disabled2"})
+
+	// audit-log-format does not have any special merge rules, therefore value gets replaced
+	require.ElementsMatch(t, config.APIServerArguments["audit-log-format"], []string{"yaml"})
+}
+
+func TestMergeStringSlices(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		dst         any
+		src         any
+		expected    any
+		expectError bool
+	}{
+		{
+			name:        "dst and src empty",
+			dst:         nil,
+			src:         nil,
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name:        "src empty",
+			dst:         []any{"value"},
+			src:         nil,
+			expected:    []any{"value"},
+			expectError: false,
+		},
+		{
+			name:        "dst empty",
+			dst:         nil,
+			src:         []any{"value"},
+			expected:    []any{"value"},
+			expectError: false,
+		},
+		{
+			name:        "dst not a slice",
+			dst:         "not-a-slice",
+			src:         []any{"new-item"},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "src not a slice",
+			dst:         []any{"existing-item"},
+			src:         "not-a-slice",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "dst not a string slice",
+			dst:         []any{1, 2, 3},
+			src:         []any{"new-item"},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "src not a string slice",
+			dst:         []any{"existing-item"},
+			src:         []any{1, 2, 3},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "dst and src merged",
+			dst:         []any{"existing-item"},
+			src:         []any{"new-item"},
+			expected:    []string{"existing-item", "new-item"},
+			expectError: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			merged, err := mergeStringSlices(tt.dst, tt.src, "")
+			if tt.expectError != (err != nil) {
+				t.Errorf("expected error: %v; got %v", tt.expectError, err)
+			}
+
+			if !equality.Semantic.DeepEqual(tt.expected, merged) {
+				t.Errorf("unexpected merged slice: %s", diff.ObjectReflectDiff(tt.expected, merged))
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
When auth type is not OAuth (i.e. `OIDC` or `None`), we must disable the plugins relevant for RoleBindingRestrictions, as this API relies on the User & Group APIs, which are part of the OAuth apiserver.

This PR does the following:
- adds a generic config observer for admission plugins, which manages the `apiServerArguments.enable-admission-plugins` and `apiServerArguments.disable-admission-plugins` fields of the KAS config
- adds two special merge rules for the fields mentioned above
- removes RoleBindingRestriction related plugins from `defaultconfig.yaml`; these are now managed by the admission plugins config observer

**_Why a generic admission plugin config observer and not specific to the RBR plugins?_**

There are mainly two reasons behind this choice:
1. Follow the config observer pattern where each observer manages configuration fields as a whole and not partially. Thus, this observer will manage the two fields as a whole and not only a subset of their potential contents.
2. Provide a generic structure and central point that can be reused in the future for other admission plugins.

**_Why do we need special merge rules?_**

The `resourcemerge` which is used to merge all config sources into one configmap, does not merge contents of slices; if a field is a slice, it will replace the contents completely. Defining special merge rules for the enabled/disabled admission plugins allows us to merge together lists of plugins that come from various sources (e.g. the default config and the admission plugin config observer).

**_Why remove the RoleBindingRestrictions from the default config?_**

Anything that is part of the default config will _not_ be passed as an input to a config observer. Therefore, in order to disable the plugins, we need to both remove them from the enabled list, but also add them to the disabled list as well. The simplest way to do that is to have the config observer decide whether to enable or disable these plugins.