### PR TITLE
OCPBUGS-55217: Optimistically update Kube Server and Client CA bundles

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/openshift/api/annotations"
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/bindata"
@@ -24,6 +23,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -354,12 +355,33 @@ func generateOptionalStartupMonitorPod(isStartupMonitorEnabledFn func() (bool, e
 }
 
 func ManageClientCABundle(ctx context.Context, lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
-	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "client-ca"},
+
+	additionalAnnotations := certrotation.AdditionalAnnotations{
+		JiraComponent: "kube-apiserver",
+	}
+	caBundleConfigMapName := "client-ca"
+
+	creationRequired := false
+	updateRequired := false
+
+	caBundleConfigMap, err := lister.ConfigMaps(operatorclient.TargetNamespace).Get(caBundleConfigMapName)
+	switch {
+	case apierrors.IsNotFound(err):
+		creationRequired = true
+		caBundleConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caBundleConfigMapName,
+				Namespace: operatorclient.TargetNamespace,
+			},
+		}
+	case err != nil:
+		return nil, false, err
+	}
+
+	requiredConfigMap, updateRequired, err := resourcesynccontroller.CombineCABundleConfigMapsOptimistically(
+		caBundleConfigMap,
 		lister,
-		certrotation.AdditionalAnnotations{
-			JiraComponent: "kube-apiserver",
-		},
+		additionalAnnotations,
 		// this is from the installer and contains the value to verify the admin.kubeconfig user
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace, Name: "admin-kubeconfig-client-ca"},
 		// this is from the installer and contains the value to verify the node bootstrapping cert that is baked into images
@@ -379,21 +401,56 @@ func ManageClientCABundle(ctx context.Context, lister corev1listers.ConfigMapLis
 	if err != nil {
 		return nil, false, err
 	}
-	if requiredConfigMap.Annotations == nil {
-		requiredConfigMap.Annotations = map[string]string{}
-	}
-	requiredConfigMap.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	if creationRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.TargetNamespace).Create(ctx, requiredConfigMap, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Created client CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	} else if updateRequired {
+		caBundleConfigMap, err = client.ConfigMaps(operatorclient.TargetNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Updated client CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	}
+
+	return caBundleConfigMap, false, nil
 }
 
 func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.ConfigMapLister, client coreclientv1.ConfigMapsGetter, recorder events.Recorder) (*corev1.ConfigMap, bool, error) {
-	requiredConfigMap, err := resourcesynccontroller.CombineCABundleConfigMaps(
-		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-apiserver-server-ca"},
+
+	additionalAnnotations := certrotation.AdditionalAnnotations{
+		JiraComponent: "kube-apiserver",
+	}
+	caBundleConfigMapName := "kube-apiserver-server-ca"
+
+	creationRequired := false
+	updateRequired := false
+
+	caBundleConfigMap, err := lister.ConfigMaps(operatorclient.TargetNamespace).Get(caBundleConfigMapName)
+	switch {
+	case apierrors.IsNotFound(err):
+		creationRequired = true
+		caBundleConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caBundleConfigMapName,
+				Namespace: operatorclient.TargetNamespace,
+			},
+		}
+	case err != nil:
+		return nil, false, err
+	}
+
+	requiredConfigMap, updateRequired, err := resourcesynccontroller.CombineCABundleConfigMapsOptimistically(
+		caBundleConfigMap,
 		lister,
-		certrotation.AdditionalAnnotations{
-			JiraComponent: "kube-apiserver",
-		},
+		additionalAnnotations,
 		// this bundle is what this operator uses to mint loadbalancers certs
 		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "loadbalancer-serving-ca"},
 		// this bundle is what this operator uses to mint localhost certs
@@ -406,12 +463,26 @@ func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.Confi
 	if err != nil {
 		return nil, false, err
 	}
-	if requiredConfigMap.Annotations == nil {
-		requiredConfigMap.Annotations = map[string]string{}
-	}
-	requiredConfigMap.Annotations[annotations.OpenShiftComponent] = "kube-apiserver"
 
-	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
+	if creationRequired {
+		caBundleConfigMap, err := client.ConfigMaps(operatorclient.TargetNamespace).Create(ctx, requiredConfigMap, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Created kube apiserver CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	} else if updateRequired {
+		caBundleConfigMap, err := client.ConfigMaps(operatorclient.TargetNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Updated kube apiserver CA bundle configmap %s/%s", caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		return caBundleConfigMap, true, nil
+	}
+
+	return caBundleConfigMap, false, nil
 }
 
 func ensureKubeAPIServerTrustedCA(ctx context.Context, client coreclientv1.CoreV1Interface, recorder events.Recorder) error {

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller_test.go
@@ -2,10 +2,17 @@ package targetconfigcontroller
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -16,10 +23,14 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/clock"
 
 	"github.com/ghodss/yaml"
+	"github.com/openshift/api/annotations"
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/stretchr/testify/require"
 )
@@ -604,4 +615,605 @@ func (l *configMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNa
 
 func (l *configMapLister) Get(name string) (*corev1.ConfigMap, error) {
 	return l.client.CoreV1().ConfigMaps(l.namespace).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+func TestManageClientCABundle(t *testing.T) {
+	cert1, err := generateTemporaryCertificate()
+	require.NoError(t, err)
+
+	cert2, err := generateTemporaryCertificate()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		existingConfigMaps []*corev1.ConfigMap
+		expectedConfigMap  *corev1.ConfigMap
+		expectedChanged    bool
+	}{
+		{
+			name:               "create new client-ca configmap when none exists",
+			existingConfigMaps: []*corev1.ConfigMap{},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": "",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "one source",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admin-kubeconfig-client-ca",
+						Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "set annotations if missing",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "client-ca",
+						Namespace:   operatorclient.TargetNamespace,
+						Annotations: map[string]string{},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admin-kubeconfig-client-ca",
+						Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "annotations update",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "client-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admin-kubeconfig-client-ca",
+						Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+						"foo":                          "bar",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "update existing client-ca configmap when new source appears",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "client-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							annotations.OpenShiftComponent: "kube-apiserver",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admin-kubeconfig-client-ca",
+						Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				// Add a new source that wasn't in the original bundle
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "csr-controller-ca",
+						Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert2),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1) + string(cert2),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "no changes required",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "client-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							annotations.OpenShiftComponent: "kube-apiserver",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "admin-kubeconfig-client-ca",
+						Namespace: operatorclient.GlobalUserSpecifiedConfigNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "client-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+
+			// Create existing configmaps
+			for _, cm := range test.existingConfigMaps {
+				_, err := client.CoreV1().ConfigMaps(cm.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			lister := &configMapLister{
+				client:    client,
+				namespace: "",
+			}
+
+			recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+			// Call the function under test
+			resultConfigMap, changed, err := ManageClientCABundle(context.Background(), lister, client.CoreV1(), recorder)
+
+			// Assert error expectations
+			require.NoError(t, err)
+
+			// Assert change expectations
+			require.Equal(t, test.expectedChanged, changed, "Expected changed=%v, got changed=%v", test.expectedChanged, changed)
+
+			// Compare with expected configmap
+			require.Equal(t, test.expectedConfigMap, resultConfigMap)
+
+			// Verify the configmap exists in the cluster
+			storedConfigMap, err := client.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(context.Background(), "client-ca", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, storedConfigMap)
+
+			// Ensure the returned configmap matches what's stored in the cluster
+			require.Equal(t, storedConfigMap, resultConfigMap, "returned configmap should match stored configmap")
+
+			// Verify events were recorded if changes were made
+			if test.expectedChanged {
+				events := recorder.Events()
+				require.NotEmpty(t, events)
+			}
+		})
+	}
+}
+
+func TestManageKubeAPIServerCABundle(t *testing.T) {
+	cert1, err := generateTemporaryCertificate()
+	require.NoError(t, err)
+
+	cert2, err := generateTemporaryCertificate()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		existingConfigMaps []*corev1.ConfigMap
+		expectedConfigMap  *corev1.ConfigMap
+		expectedChanged    bool
+	}{
+		{
+			name:               "create new kube-apiserver-server-ca configmap when none exists",
+			existingConfigMaps: []*corev1.ConfigMap{},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": "",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "one source",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loadbalancer-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "set annotations if missing",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "kube-apiserver-server-ca",
+						Namespace:   operatorclient.TargetNamespace,
+						Annotations: map[string]string{},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loadbalancer-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "annotations update",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-apiserver-server-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loadbalancer-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						"foo":                          "bar",
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "update existing kube-apiserver-server-ca configmap when new source appears",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-apiserver-server-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							annotations.OpenShiftComponent: "kube-apiserver",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loadbalancer-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				// Add a new source that wasn't in the original bundle
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "localhost-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert2),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1) + string(cert2),
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "no changes required",
+			existingConfigMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-apiserver-server-ca",
+						Namespace: operatorclient.TargetNamespace,
+						Annotations: map[string]string{
+							annotations.OpenShiftComponent: "kube-apiserver",
+						},
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loadbalancer-serving-ca",
+						Namespace: operatorclient.OperatorNamespace,
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": string(cert1),
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server-ca",
+					Namespace: operatorclient.TargetNamespace,
+					Annotations: map[string]string{
+						annotations.OpenShiftComponent: "kube-apiserver",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(cert1),
+				},
+			},
+			expectedChanged: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+
+			// Create existing configmaps
+			for _, cm := range test.existingConfigMaps {
+				_, err := client.CoreV1().ConfigMaps(cm.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+				require.NoError(t, err)
+			}
+
+			lister := &configMapLister{
+				client:    client,
+				namespace: "",
+			}
+
+			recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+
+			// Call the function under test
+			resultConfigMap, changed, err := manageKubeAPIServerCABundle(context.Background(), lister, client.CoreV1(), recorder)
+
+			// Assert error expectations
+			require.NoError(t, err)
+
+			// Assert change expectations
+			require.Equal(t, test.expectedChanged, changed, "Expected changed=%v, got changed=%v", test.expectedChanged, changed)
+
+			// Compare with expected configmap
+			require.Equal(t, test.expectedConfigMap, resultConfigMap)
+
+			// Verify the configmap exists in the cluster
+			storedConfigMap, err := client.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(context.Background(), "kube-apiserver-server-ca", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, storedConfigMap)
+
+			// Ensure the returned configmap matches what's stored in the cluster
+			require.Equal(t, storedConfigMap, resultConfigMap, "returned configmap should match stored configmap")
+
+			// Verify events were recorded if changes were made
+			if test.expectedChanged {
+				events := recorder.Events()
+				require.NotEmpty(t, events)
+			}
+		})
+	}
+}
+
+// generateTemporaryCertificate creates a new temporary, self-signed x509 certificate
+// and a corresponding RSA private key. The certificate will be valid for 24 hours.
+// It returns the PEM-encoded private key and certificate.
+func generateTemporaryCertificate() (certPEM []byte, err error) {
+	// 1. Generate a new RSA private key
+	// We are using a 2048-bit key, which is a common and secure choice.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Create a template for the certificate
+	// This template contains all the details about the certificate.
+	certTemplate := x509.Certificate{
+		// SerialNumber is a unique number for the certificate.
+		// We generate a large random number to ensure uniqueness.
+		SerialNumber: big.NewInt(time.Now().Unix()),
+
+		// Subject contains information about the owner of the certificate.
+		Subject: pkix.Name{
+			Organization: []string{"My Company, Inc."},
+			Country:      []string{"US"},
+			Province:     []string{"California"},
+			Locality:     []string{"San Francisco"},
+			CommonName:   "localhost", // Common Name (CN)
+		},
+
+		// NotBefore is the start time of the certificate's validity.
+		NotBefore: time.Now(),
+		// NotAfter is the end time. We set it to 24 hours from now.
+		NotAfter: time.Now().Add(24 * time.Hour),
+
+		// KeyUsage defines the purpose of the public key contained in the certificate.
+		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		// ExtKeyUsage indicates extended purposes (e.g., server/client authentication).
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+
+		// BasicConstraintsValid indicates if this is a CA certificate.
+		// Since this is a self-signed certificate, we set it to true.
+		BasicConstraintsValid: true,
+	}
+
+	// 3. Create the certificate
+	// x509.CreateCertificate creates a new certificate based on a template.
+	// Since this is a self-signed certificate, the parent certificate is the template itself.
+	// We use the public key from our generated private key.
+	// The final argument is the private key used to sign the certificate.
+	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Encode the certificate to the PEM format
+	certPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	return certPEM, nil
 }


### PR DESCRIPTION
Instead of re-creating configmap from scratch every time this function should attempt to use existing configmap and replace the contents only. This would prevent extra configmap updates when metadata changes.

Bump library-go to update https://github.com/openshift/library-go/pull/1936