### PR TITLE
NO-ISSUE: Bump TraceAll log level to v=10

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -567,7 +567,7 @@ func manageTemplate(rawTemplate string, imagePullSpec string, operatorImagePullS
 	case operatorv1.Trace:
 		verbosity = fmt.Sprintf(" -v=%d", 6)
 	case operatorv1.TraceAll:
-		verbosity = fmt.Sprintf(" -v=%d", 8)
+		verbosity = fmt.Sprintf(" -v=%d", 10)
 	default:
 		verbosity = fmt.Sprintf(" -v=%d", 2)
 	}


### PR DESCRIPTION
- The kube-scheduler-operator has already set the TraceAll to 10, as seen in https://github.com/openshift/cluster-kube-scheduler-operator/blame/b1cc4471e2f6c5dc81b2b9471f4634f1ecdb88b4/pkg/operator/targetconfigcontroller/targetconfigcontroller.go#L267
- The kube-controller-manager-operator also set the TraceAll to 10 **https://github.com/openshift/cluster-kube-controller-manager-operator/blob/9a7a572080a663bda581c0567e3921a99acd993e/pkg/operator/targetconfigcontroller/targetconfigcontroller.go#L540**

If we use TraceALL, we want to trace all the logs really, and some important k8s logs are v(10)