### PR TITLE
ioutil deprecation

### DIFF
--- a/pkg/cmd/insecurereadyz/readyz.go
+++ b/pkg/cmd/insecurereadyz/readyz.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -92,7 +92,7 @@ func (r *readyzOpts) Run() error {
 
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			http.Error(w, "failed to read response from kube-apiserver", http.StatusInternalServerError)
 			klog.Warningf("Failed to read the response body: %v", err)

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -226,7 +225,7 @@ func (r *renderOpts) Run() error {
 	renderConfig.RuntimeConfig = apienablement.RuntimeConfigFromFeatureGates(featureGates, r.groupVersionsByFeatureGate)
 
 	if len(r.clusterConfigFile) > 0 {
-		clusterConfigFileData, err := ioutil.ReadFile(r.clusterConfigFile)
+		clusterConfigFileData, err := os.ReadFile(r.clusterConfigFile)
 		if err != nil {
 			return err
 		}
@@ -235,7 +234,7 @@ func (r *renderOpts) Run() error {
 		}
 	}
 	if len(r.clusterAuthFile) > 0 {
-		clusterAuthFileData, err := ioutil.ReadFile(r.clusterAuthFile)
+		clusterAuthFileData, err := os.ReadFile(r.clusterAuthFile)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to load authentication config: %v", err)
 		}
@@ -260,11 +259,11 @@ func (r *renderOpts) Run() error {
 			return fmt.Errorf("failed to generate an RSA keypair for bound SA token signing: %v", err)
 		}
 
-		if err := ioutil.WriteFile(boundSAPrivatePath, privPEM, os.FileMode(0600)); err != nil {
+		if err := os.WriteFile(boundSAPrivatePath, privPEM, os.FileMode(0600)); err != nil {
 			return fmt.Errorf("failed to write private key for bound SA token signing: %v", err)
 		}
 
-		if err := ioutil.WriteFile(boundSAPublicPath, pubPEM, os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(boundSAPublicPath, pubPEM, os.FileMode(0644)); err != nil {
 			return fmt.Errorf("failed to write public key for bound SA token verification: %v", err)
 		}
 	}
@@ -417,7 +416,7 @@ func convertToUnstructured(raw []byte) (map[string]interface{}, error) {
 }
 
 func mustReadTemplateFile(fname string) genericrenderoptions.Template {
-	bs, err := ioutil.ReadFile(fname)
+	bs, err := os.ReadFile(fname)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load %q: %v", fname, err))
 	}
@@ -595,7 +594,7 @@ func generateKeyPairPEM() (pubKeyPEM []byte, privKeyPEM []byte, err error) {
 
 func getInfrastructure(file string) (*configv1.Infrastructure, error) {
 	config := &configv1.Infrastructure{}
-	yamlData, err := ioutil.ReadFile(file)
+	yamlData, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -223,7 +222,7 @@ func TestDiscoverCIDRs(t *testing.T) {
 }
 
 func TestRenderCommand(t *testing.T) {
-	assetsInputDir, err := ioutil.TempDir("", "testdata")
+	assetsInputDir, err := os.MkdirTemp("", "testdata")
 	if err != nil {
 		t.Errorf("unable to create assets input directory, error: %v", err)
 	}
@@ -313,7 +312,7 @@ func TestRenderCommand(t *testing.T) {
 				"--operand-kubernetes-version=1.31.0",
 			},
 			setupFunction: func() error {
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "config-v6.yaml"), []byte(networkConfigV6), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "config-v6.yaml"), []byte(networkConfigV6), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				if cfg.ServingInfo.BindAddress != "[::]:6443" {
@@ -339,7 +338,7 @@ func TestRenderCommand(t *testing.T) {
 				"--operand-kubernetes-version=1.31.0",
 			},
 			setupFunction: func() error {
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "config-dual.yaml"), []byte(networkConfigDual), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "config-dual.yaml"), []byte(networkConfigDual), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				if cfg.ServingInfo.BindAddress != "0.0.0.0:6443" {
@@ -391,7 +390,7 @@ func TestRenderCommand(t *testing.T) {
 			},
 			setupFunction: func() error {
 				data := ``
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				issuer := cfg.APIServerArguments["service-account-issuer"]
@@ -421,7 +420,7 @@ kind: Authentication
 metadata:
   name: cluster
 spec: {}`
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				issuer := cfg.APIServerArguments["service-account-issuer"]
@@ -452,7 +451,7 @@ metadata:
   name: cluster
 spec:
   serviceAccountIssuer: https://test.dummy.url`
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "authentication.yaml"), []byte(data), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				if len(cfg.APIServerArguments["service-account-issuer"]) == 0 {
@@ -494,10 +493,10 @@ spec:
 				if err := os.Mkdir(filepath.Join(assetsInputDir, "2"), 0700); err != nil {
 					return err
 				}
-				if err := ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.key"), []byte(data), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.key"), []byte(data), 0644); err != nil {
 					return err
 				}
-				if err := ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.pub"), []byte(data), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.pub"), []byte(data), 0644); err != nil {
 					return err
 				}
 				return nil
@@ -563,7 +562,7 @@ spec:
 				"--operand-kubernetes-version=1.31.0",
 			},
 			setupFunction: func() error {
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "infrastructure.yaml"), []byte(infrastructureHA), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "infrastructure.yaml"), []byte(infrastructureHA), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				if len(cfg.APIServerArguments["shutdown-delay-duration"]) == 0 {
@@ -598,7 +597,7 @@ spec:
 				"--operand-kubernetes-version=1.31.0",
 			},
 			setupFunction: func() error {
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "infrastructure.yaml"), []byte(infrastructureSNO), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "infrastructure.yaml"), []byte(infrastructureSNO), 0644)
 			},
 			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
 				if len(cfg.APIServerArguments["shutdown-delay-duration"]) == 0 {
@@ -642,7 +641,7 @@ spec:
 				t.Fatalf("%s: got unexpected error %v", test.name, err)
 			}
 
-			rawConfigFile, err := ioutil.ReadFile(filepath.Join(outputDir, "configs", "config.yaml"))
+			rawConfigFile, err := os.ReadFile(filepath.Join(outputDir, "configs", "config.yaml"))
 			if err != nil {
 				t.Fatalf("cannot read the rendered config file, error: %v", err)
 			}
@@ -651,7 +650,7 @@ spec:
 				t.Fatalf("cannot unmarshal config into KubeAPIServerConfig, error: %v", err)
 			}
 
-			rawStaticPodFile, err := ioutil.ReadFile(filepath.Join(outputDir, "manifests", "bootstrap-manifests", "kube-apiserver-pod.yaml"))
+			rawStaticPodFile, err := os.ReadFile(filepath.Join(outputDir, "manifests", "bootstrap-manifests", "kube-apiserver-pod.yaml"))
 			if err != nil {
 				t.Fatalf("cannot read the rendered config file, error: %v", err)
 			}
@@ -708,7 +707,7 @@ func TestGetDefaultConfigWithAuditPolicy(t *testing.T) {
 }
 
 func setupAssetOutputDir(testName string) (teardown func(), outputDir string, err error) {
-	outputDir, err = ioutil.TempDir("", testName)
+	outputDir, err = os.MkdirTemp("", testName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -752,7 +751,7 @@ func runRender(args []string, overrides []func(*renderOpts)) error {
 }
 
 func Test_renderOpts_Validate(t *testing.T) {
-	assetsInputDir, err := ioutil.TempDir("", "testdata")
+	assetsInputDir, err := os.MkdirTemp("", "testdata")
 	if err != nil {
 		t.Errorf("unable to create assets input directory, error: %v", err)
 	}
@@ -774,7 +773,7 @@ func Test_renderOpts_Validate(t *testing.T) {
 				if err := os.Mkdir(filepath.Join(assetsInputDir, "0"), 0700); err != nil {
 					return err
 				}
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "0", "bound-service-account-signing-key.key"), []byte(data), 0600)
+				return os.WriteFile(filepath.Join(assetsInputDir, "0", "bound-service-account-signing-key.key"), []byte(data), 0600)
 			},
 			operatorImage:            "kube-apiserver-operator:latest",
 			operandKubernetesVersion: "1.31.0",
@@ -788,7 +787,7 @@ func Test_renderOpts_Validate(t *testing.T) {
 				if err := os.Mkdir(filepath.Join(assetsInputDir, "1"), 0700); err != nil {
 					return err
 				}
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "1", "bound-service-account-signing-key.pub"), []byte(data), 0644)
+				return os.WriteFile(filepath.Join(assetsInputDir, "1", "bound-service-account-signing-key.pub"), []byte(data), 0644)
 			},
 			operatorImage:            "kube-apiserver-operator:latest",
 			operandKubernetesVersion: "1.31.0",
@@ -802,10 +801,10 @@ func Test_renderOpts_Validate(t *testing.T) {
 				if err := os.Mkdir(filepath.Join(assetsInputDir, "2"), 0700); err != nil {
 					return err
 				}
-				if err := ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.pub"), []byte(data), 0644); err != nil {
+				if err := os.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.pub"), []byte(data), 0644); err != nil {
 					return err
 				}
-				return ioutil.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.key"), []byte(data), 0600)
+				return os.WriteFile(filepath.Join(assetsInputDir, "2", "bound-service-account-signing-key.key"), []byte(data), 0600)
 			},
 			operatorImage:            "kube-apiserver-operator:latest",
 			operandKubernetesVersion: "1.31.0",

--- a/pkg/operator/startupmonitorreadiness/readiness_checks.go
+++ b/pkg/operator/startupmonitorreadiness/readiness_checks.go
@@ -3,7 +3,7 @@ package startupmonitorreadiness
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -323,7 +323,7 @@ func doHTTPCheck(ctx context.Context, client *http.Client, rawURL string) (int, 
 
 	// we expect small responses from the server
 	// so it is okay to read the entire body
-	rawResponse, err := ioutil.ReadAll(resp.Body)
+	rawResponse, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, "", fmt.Errorf("error while reading body from %v, err %v", targetURL.String(), err)
 	}

--- a/pkg/recovery/apiserver.go
+++ b/pkg/recovery/apiserver.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -235,7 +234,7 @@ func (s *Apiserver) Create() error {
 	}
 
 	recoveryConfigPath := filepath.Join(s.recoveryResourcesDir, RecoveryCofigFileName)
-	err = ioutil.WriteFile(recoveryConfigPath, recoveryConfigBytes, 644)
+	err = os.WriteFile(recoveryConfigPath, recoveryConfigBytes, 644)
 	if err != nil {
 		return fmt.Errorf("failed to write recovery config %q: %v", recoveryConfigPath, err)
 	}
@@ -258,7 +257,7 @@ func (s *Apiserver) Create() error {
 		}
 
 		recoveryEncryptionConfigPath := filepath.Join(s.recoveryResourcesDir, RecoveryEncryptionCofigFileName)
-		err = ioutil.WriteFile(recoveryEncryptionConfigPath, recoveryEncryptionConfigBytes, 644)
+		err = os.WriteFile(recoveryEncryptionConfigPath, recoveryEncryptionConfigBytes, 644)
 		if err != nil {
 			return fmt.Errorf("failed to write recovery encryption config %q: %v", recoveryEncryptionConfigPath, err)
 		}
@@ -275,7 +274,7 @@ func (s *Apiserver) Create() error {
 	}
 
 	recoveryPodManifestPath := filepath.Join(s.PodManifestDir, RecoveryPodFileName)
-	err = ioutil.WriteFile(recoveryPodManifestPath, recoveryPodBytes, 644)
+	err = os.WriteFile(recoveryPodManifestPath, recoveryPodBytes, 644)
 	if err != nil {
 		return fmt.Errorf("failed to write recovery pod manifest %q: %v", recoveryPodManifestPath, err)
 	}
@@ -323,7 +322,7 @@ func (s *Apiserver) Create() error {
 	}
 
 	kubeconfigPath := filepath.Join(s.recoveryResourcesDir, AdminKubeconfigFileName)
-	err = ioutil.WriteFile(kubeconfigPath, kubeconfigBytes, 600)
+	err = os.WriteFile(kubeconfigPath, kubeconfigBytes, 600)
 	if err != nil {
 		return fmt.Errorf("failed to write kubeconfig %q: %v", kubeconfigPath, err)
 	}

--- a/pkg/recovery/helpers.go
+++ b/pkg/recovery/helpers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -92,7 +91,7 @@ func EnsureFileContent(filePath string, data []byte) error {
 			return fmt.Errorf("file %q is a directory", filePath)
 		}
 
-		fileBytes, err := ioutil.ReadFile(filePath)
+		fileBytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("failed to read file %q: %v", filePath, err)
 		}
@@ -113,7 +112,7 @@ func EnsureFileContent(filePath string, data []byte) error {
 		klog.Warningf("File %q doesn't exist.", filePath)
 	}
 
-	err = ioutil.WriteFile(filePath, data, mode)
+	err = os.WriteFile(filePath, data, mode)
 	if err != nil {
 		return fmt.Errorf("failed to write content into %q: %v", filePath, err)
 	}


### PR DESCRIPTION
As of Go 1.16, `ioutil` was deprecated.  Read more about it [here](https://go.dev/doc/go1.16#ioutil).

Similar to:
- https://github.com/openshift-kni/cnf-features-deploy/pull/1777