### PR TITLE
OCPBUGS-55274: Change validity / refresh for some certs which should not be affected by dev cycle rotation change

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -138,8 +138,8 @@ func newCertRotationController(
 		monthPeriod = 2 * time.Hour
 		yearPeriod = 3 * time.Hour
 		tenMonthPeriod = 150 * time.Minute
-		klog.Infof("Setting monthPeriod to %v, yearPeriod to %v, tenMonthPeriod to %v", monthPeriod, yearPeriod, tenMonthPeriod)
 	}
+	klog.Infof("Setting monthPeriod to %v, yearPeriod to %v, tenMonthPeriod to %v", monthPeriod, yearPeriod, tenMonthPeriod)
 
 	certRotator := certrotation.NewCertRotationController(
 		"AggregatorProxyClientCert",

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -124,9 +124,15 @@ func newCertRotationController(
 	// This must be reverted before we ship
 	rotationDay = rotationDay / 60
 
-	monthPeriod := rotationDay * 30
-	yearPeriod := monthPeriod * 12
-	tenMonthPeriod := monthPeriod * 10
+	// Some certificates should not be affected by development cycle rotation
+	devRotationExceptionDay := 24 * time.Hour
+
+	monthPeriod := 30 * rotationDay
+	devRotationExceptionMonth := 30 * devRotationExceptionDay
+	yearPeriod := 365 * rotationDay
+	devRotationExceptionYear := 365 * devRotationExceptionDay
+	tenMonthPeriod := 292 * rotationDay
+	devRotationExceptionTenMonth := 292 * devRotationExceptionDay
 
 	// Set custom rotation duration when FeatureShortCertRotation is enabled
 	featureGates, err := featureGateAccessor.CurrentFeatureGates()
@@ -136,8 +142,11 @@ func newCertRotationController(
 
 	if featureGates.Enabled(features.FeatureShortCertRotation) {
 		monthPeriod = 2 * time.Hour
+		devRotationExceptionMonth = monthPeriod
 		yearPeriod = 3 * time.Hour
+		devRotationExceptionYear = yearPeriod
 		tenMonthPeriod = 150 * time.Minute
+		devRotationExceptionTenMonth = tenMonthPeriod
 	}
 	klog.Infof("Setting monthPeriod to %v, yearPeriod to %v, tenMonthPeriod to %v", monthPeriod, yearPeriod, tenMonthPeriod)
 
@@ -206,10 +215,10 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[sig-cli] Kubectl logs logs should be able to retrieve and filter logs  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]'",
 				Description:                      "Signer for the kube-apiserver-to-kubelet-client so kubelets can recognize the kube-apiserver.",
 			},
-			Validity: monthPeriod * 2, // this comes from the installer
+			Validity: devRotationExceptionYear, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
-			Refresh:                monthPeriod,
+			Refresh:                devRotationExceptionMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -552,8 +561,8 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
 				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
-			Validity:               2 * monthPeriod,
-			Refresh:                monthPeriod,
+			Validity:               2 * devRotationExceptionMonth,
+			Refresh:                devRotationExceptionMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -607,8 +616,8 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
 				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
-			Validity:               2 * monthPeriod,
-			Refresh:                monthPeriod,
+			Validity:               2 * devRotationExceptionMonth,
+			Refresh:                devRotationExceptionMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -662,8 +671,8 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
 				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
-			Validity:               2 * monthPeriod,
-			Refresh:                monthPeriod,
+			Validity:               2 * devRotationExceptionMonth,
+			Refresh:                devRotationExceptionMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -716,8 +725,8 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
 				Description:                      "Signer for kube-controller-manager and kube-scheduler client certificates.",
 			},
-			Validity:               2 * monthPeriod,
-			Refresh:                monthPeriod,
+			Validity:               2 * devRotationExceptionMonth,
+			Refresh:                devRotationExceptionMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -771,10 +780,10 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'operator conditions kube-apiserver'",
 				Description:                      "Signer for the per-master-debugging-client.",
 			},
-			Validity: yearPeriod,
+			Validity: devRotationExceptionYear,
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
-			Refresh:                tenMonthPeriod,
+			Refresh:                devRotationExceptionTenMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
@@ -805,7 +814,7 @@ func newCertRotationController(
 			// This needs to live longer then control plane certs so there is high chance that if a cluster breaks
 			// because of expired certs these are still valid to use for collecting data using localhost-recovery
 			// endpoint with long lived serving certs for localhost.
-			Validity: 2 * yearPeriod,
+			Validity: 2 * devRotationExceptionYear,
 			// We rotate sooner so certs are always valid for 90 days (30 days more then kube-control-plane-signer)
 			Refresh:                monthPeriod,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,


### PR DESCRIPTION
Some certificates should be excepted from rotation being set sizty times faster in development mode - i.e. localhost-recovery.kubeconfig