### PR TITLE
OCPBUGS-55013: SCC: add hostmount-anyuid-v2

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount-anyuid-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_cr-scc-hostmount-anyuid-v2.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:openshift:scc:hostmount-anyuid-v2
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostmount-anyuid-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid-v2.yaml
@@ -1,0 +1,47 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities:
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+    kubernetes.io/description: |-
+      hostmount-anyuid-v2 provides all the features of the
+      restricted SCC but allows host mounts any UID, and any SELinux label by a pod.  This is primarily
+      used by the persistent volume recycler. WARNING: this SCC allows host file
+      system access as any UID, including UID 0.  Grant with caution.
+  name: hostmount-anyuid-v2
+priority:
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- ephemeral
+- hostPath
+- nfs
+- persistentVolumeClaim
+- projected
+- secret


### PR DESCRIPTION
the intent of hostmount-anyuid is to allow a pod access to paths on the host. The problem is, hostPath volumes aren't selinux relabeled, and there are paths that the default selinux type `container_t` cannot access.

This breaks expectation, and makes pods that rely on hostmount-anyuid brittle to selinux changes on the host (see https://issues.redhat.com/browse/OCPBUGS-55013)

Instead of relaxing permissions of all paths on the host, or increasing the ability of container_t, we should trust pods that are granted access to this already powerful SCC to use its power fully.