### PR TITLE
OCPBUGS-55465: Stop serving admissionregistration.k8s.io/v1beta1.

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -16,8 +16,7 @@ import (
 )
 
 var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
-	"ValidatingAdmissionPolicy": {{GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}}},
-	"MutatingAdmissionPolicy":   {{GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}}},
+	"MutatingAdmissionPolicy": {{GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}}},
 	"DynamicResourceAllocation": {
 		{KubeVersionRange: semver.MustParseRange("< 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 		{KubeVersionRange: semver.MustParseRange(">= 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},


### PR DESCRIPTION
ValidatingAdmissionPolicy currently depends on admissionregistration.k8s.io/v1 and the feature gate is always on. The v1beta1 version wasn't meant to be served outside of tech preview clusters.

Resumes the work started in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1687.