### PR TITLE
WIP: Set goaway-chance to .001

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -115,7 +115,7 @@ apiServerArguments:
   event-ttl:
     - 3h
   goaway-chance:
-    - "0"
+    - ".001"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-certificate-authority:

--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -117,7 +117,7 @@ apiServerArguments:
   goaway-chance:
     - ".001"
   http2-max-streams-per-connection:
-    - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
+    - "1000"
   kubelet-certificate-authority:
     - /etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt
   kubelet-client-certificate:


### PR DESCRIPTION
Just to run disruption tests, once we know if this causes disruption test issues we'll fix those, by ensuring goaways are ignored, and be back to land this in a manner that sets the value to .001 for HA clusters and 0 non HA control planes.