### PR TITLE
NO-JIRA: Enable watch termination grace period

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -163,6 +163,8 @@ apiServerArguments:
     - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   shutdown-send-retry-after:
   - "true"
+  shutdown-watch-termination-grace-period:
+    - 5s # shorter than the pod graceful termination period on single-node
   storage-backend:
     - etcd3
   storage-media-type:


### PR DESCRIPTION
This should mostly eliminate aligned informer re-lists during kube-apiserver rollout.