### PR TITLE
Do not mark system namespaces as inconclusive

### DIFF
--- a/pkg/operator/podsecurityreadinesscontroller/conditions.go
+++ b/pkg/operator/podsecurityreadinesscontroller/conditions.go
@@ -65,7 +65,10 @@ func (c *podSecurityOperatorConditions) addViolation(ns *corev1.Namespace) {
 }
 
 func (c *podSecurityOperatorConditions) addInconclusive(ns *corev1.Namespace) {
-	c.inconclusiveNamespaces = append(c.inconclusiveNamespaces, ns.Name)
+	// We should not consider system namespaces as inconclusive
+	if !strings.HasPrefix(ns.Name, "openshift") && !runLevelZeroNamespaces.Has(ns.Name) {
+		c.inconclusiveNamespaces = append(c.inconclusiveNamespaces, ns.Name)
+	}
 }
 
 func makeCondition(conditionType, conditionReason string, namespaces []string) operatorv1.OperatorCondition {


### PR DESCRIPTION
System namespaces should not be reported as inconclusive when evaluating for PSA violations.
cc: @ibihim 