### PR TITLE
WIP Don't read featuregates in "only when expires" mode

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
@@ -15,9 +14,7 @@ import (
 	configeversionedclient "github.com/openshift/client-go/config/clientset/versioned"
 	configexternalinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
-	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator"
@@ -87,6 +84,8 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 		return fmt.Errorf("failed to create config client: %w", err)
 	}
 
+	configInformers := configexternalinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
+
 	kubeAPIServerInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
 		kubeClient,
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -94,8 +93,6 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 		operatorclient.OperatorNamespace,
 		operatorclient.TargetNamespace,
 	)
-
-	configInformers := configexternalinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 
 	operatorClient, dynamicInformers, err := genericoperatorclient.NewStaticPodOperatorClient(
 		clock,
@@ -109,37 +106,12 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 		return err
 	}
 
-	// We can't start informers until after the resources have been requested. Now is the time.
-	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
-	dynamicInformers.Start(ctx.Done())
-
-	desiredVersion := status.VersionForOperatorFromEnv()
-	missingVersion := "0.0.1-snapshot"
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		desiredVersion, missingVersion,
-		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
-		o.controllerContext.EventRecorder,
-	)
-
-	go configInformers.Start(ctx.Done())
-	go featureGateAccessor.Run(ctx)
-
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, _ := featureGateAccessor.CurrentFeatureGates()
-		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
-	case <-time.After(1 * time.Minute):
-		klog.Errorf("timed out waiting for FeatureGate detection")
-		return fmt.Errorf("timed out waiting for FeatureGate detection")
-	}
-
 	kubeAPIServerCertRotationController, err := certrotationcontroller.NewCertRotationControllerOnlyWhenExpired(
 		kubeClient,
 		operatorClient,
 		configInformers,
 		kubeAPIServerInformersForNamespaces,
 		o.controllerContext.EventRecorder,
-		featureGateAccessor,
 	)
 	if err != nil {
 		return err
@@ -153,6 +125,11 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 	if err != nil {
 		return err
 	}
+
+	// We can't start informers until after the resources have been requested. Now is the time.
+	configInformers.Start(ctx.Done())
+	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
+	dynamicInformers.Start(ctx.Done())
 
 	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
 	// (@deads2k wants time to think it through)

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	features "github.com/openshift/api/features"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	configlisterv1 "github.com/openshift/client-go/config/listers/config/v1"
@@ -71,8 +72,12 @@ func NewCertRotationControllerOnlyWhenExpired(
 	configInformer configinformers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventRecorder events.Recorder,
-	featureGateAccessor featuregates.FeatureGateAccess,
 ) (*CertRotationController, error) {
+	// Create fake feature gate accessor - in refresh only when expired mode there is no API server to fetch feature gates from
+	// Here ShortCertRotation is always disabled
+	emptyFeatureGates := []configv1.FeatureGateName{""}
+	knownFeatureGates := []configv1.FeatureGateName{"ShortCertRotation"}
+	featureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(emptyFeatureGates, knownFeatureGates)
 	return newCertRotationController(
 		kubeClient,
 		operatorClient,


### PR DESCRIPTION
This controller runs as a sidecar alongside kube-apiserver
and expected
to refresh certificates. However, adding featuregate
check in this flow may break as feature gates may not be readable.

Besides, this controller is not used in ShortCertRotation flow - the
operator would generate necessary certificates instead.