### PR TITLE
NO-JIRA: remove unused yaml

### DIFF
--- a/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_04_servicemonitor-apiserver.yaml
@@ -248,12 +248,3 @@ spec:
       expr: sum(rate(apiserver_tls_handshake_errors_total{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}[5m])) by (apiserver)
     - record: resource:apiserver_storage_objects:max
       expr: max(apiserver_storage_objects{apiserver=~"openshift-apiserver|kube-apiserver|openshift-oauth-apiserver"}) by (apiserver, resource)
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: kube-apiserver-recording-rules
-  namespace: openshift-kube-apiserver
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/delete: "true"

--- a/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
+++ b/manifests/0000_90_kube-apiserver-operator_05_api_performance_dashboard.yaml
@@ -3329,14 +3329,3 @@ data:
       "uid": "X9gzM6XFF",
       "version": 2
     }
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: grafana-dashboard-api-performance
-  namespace: openshift-config-managed
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/delete: "true"
-  labels:
-    console.openshift.io/dashboard: 'true'


### PR DESCRIPTION
These yamls only works when upgrade from 4.14, no need in the newest 4.20 versions

next steps of https://github.com/openshift/cluster-kube-apiserver-operator/pull/1565