### PR TITLE
podsecurityreadinesscontroller: add user SCC violation detection

### DIFF
--- a/pkg/operator/podsecurityreadinesscontroller/README.md
+++ b/pkg/operator/podsecurityreadinesscontroller/README.md
@@ -1,0 +1,113 @@
+# Pod Security Readiness Controller
+
+The Pod Security Readiness Controller evaluates namespace compatibility with Pod Security Admission (PSA) enforcement in clusters.
+
+## Purpose
+
+This controller performs dry-run PSA evaluations to determine which namespaces would experience pod creation failures if PSA enforcement labels were applied.
+
+The controller generates telemetry data for `ClusterFleetEvaluation` and helps us to understand PSA compatibility before enabling enforcement.
+
+## Implementation
+
+The controller follows this evaluation algorithm:
+
+1. **Namespace Discovery** - Find namespaces without PSA enforcement
+2. **PSA Level Determination** - Predict what enforcement level would be applied
+3. **Dry-Run Evaluation** - Test namespace against predicted PSA level
+4. **Violation Classification** - Categorize any violations found for telemetry
+
+### Namespace Discovery
+
+Selects namespaces without PSA enforcement labels:
+
+```go
+selector := "!pod-security.kubernetes.io/enforce"
+```
+
+### PSA Level Determination
+
+The controller determines the effective PSA enforcement level using this precedence:
+
+1. `security.openshift.io/MinimallySufficientPodSecurityStandard` annotation
+2. Most restrictive of existing `pod-security.kubernetes.io/warn` or `pod-security.kubernetes.io/audit` labels, if owned by the PSA label syncer
+3. Kube API server's future global default: `restricted`
+
+### Dry-Run Evaluation
+
+The controller performs the equivalent of this oc command:
+
+```bash
+oc label --dry-run=server --overwrite namespace $NAMESPACE_NAME \
+    pod-security.kubernetes.io/enforce=$POD_SECURITY_STANDARD
+```
+
+PSA warnings during dry-run indicate the namespace contains violating workloads.
+
+### Violation Classification
+
+Violating namespaces are categorized for telemetry analysis:
+
+| Classification   | Criteria                                                        | Purpose                                |
+|------------------|-----------------------------------------------------------------|----------------------------------------|
+| `runLevelZero`   | Core namespaces: `kube-system`, `default`, `kube-public`        | Platform infrastructure tracking       |
+| `openshift`      | Namespaces with `openshift-` prefix                             | OpenShift component tracking           |
+| `disabledSyncer` | Label `security.openshift.io/scc.podSecurityLabelSync: "false"` | Intentionally excluded namespaces      |
+| `userSCC`        | Contains user workloads that violate PSA                        | SCC vs PSA policy conflicts |
+| `customer`       | All other violating namespaces                                  | Customer workload compatibility issues |
+| `inconclusive`   | Evaluation failed due to API errors                             | Operational problems                   |
+
+#### User SCC Detection
+
+The PSA label syncer bases its evaluation exclusively on a ServiceAccount's SCCs, ignoring a user's SCCs.
+When a pod's SCC assignment comes from user permissions rather than its ServiceAccount, the syncer's predicted PSA level may be incorrect.
+Therefore we need to evaluate the affected pods (if any) against the target PSA level.
+
+### Inconclusive Handling
+
+When the evaluation process fails, namespaces are marked as `inconclusive`.
+
+Common causes for inconclusive results:
+
+- **API server unavailable** - Network timeouts, etcd issues
+- **Resource conflicts** - Concurrent namespace modifications
+- **Invalid PSA levels** - Malformed enforcement level strings
+- **Pod listing failures** - RBAC issues or resource pressure
+
+High rates of inconclusive results across the fleet may indicate systematic issues that requires investigation.
+
+## Output
+
+The controller updates `OperatorStatus` conditions for each violation type:
+
+```go
+type podSecurityOperatorConditions struct {
+    violatingRunLevelZeroNamespaces   []string
+    violatingOpenShiftNamespaces      []string  
+    violatingDisabledSyncerNamespaces []string
+    violatingCustomerNamespaces       []string
+    userSCCViolationNamespaces        []string
+    inconclusiveNamespaces            []string
+}
+```
+
+Conditions follow the pattern:
+
+- `PodSecurity{Type}EvaluationConditionsDetected`
+- Status: `True` (violations found) / `False` (no violations)
+- Message includes violating namespace list
+
+## Configuration
+
+The controller runs with a configurable interval (default: 4 hours) and uses rate limiting to avoid overwhelming the API server:
+
+```go
+kubeClientCopy.QPS = 2
+kubeClientCopy.Burst = 2  
+```
+
+## Integration Points
+
+- **PSA Label Syncer**: Reads syncer-managed PSA labels to predict enforcement levels
+- **Cluster Operator**: Reports status through standard operator conditions
+- **Telemetry**: Violation data feeds into cluster fleet analysis systems

--- a/pkg/operator/podsecurityreadinesscontroller/classification.go
+++ b/pkg/operator/podsecurityreadinesscontroller/classification.go
@@ -1,0 +1,126 @@
+package podsecurityreadinesscontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	psapi "k8s.io/pod-security-admission/api"
+)
+
+func (c *PodSecurityReadinessController) classifyViolatingNamespace(ctx context.Context, conditions *podSecurityOperatorConditions, ns *corev1.Namespace, enforceLevel string) error {
+	if runLevelZeroNamespaces.Has(ns.Name) {
+		conditions.addViolatingRunLevelZero(ns)
+		return nil
+	}
+	if strings.HasPrefix(ns.Name, "openshift") {
+		conditions.addViolatingOpenShift(ns)
+		return nil
+	}
+	if ns.Labels[labelSyncControlLabel] == "false" {
+		conditions.addViolatingDisabledSyncer(ns)
+		return nil
+	}
+	klog.InfoS("Checking for user violations", "namespace", ns.Name, "enforceLevel", enforceLevel)
+	isUserViolation, err := c.isUserViolation(ctx, ns, enforceLevel)
+	if err != nil {
+		klog.V(2).ErrorS(err, "Error checking user violations", "namespace", ns.Name)
+		// Transient API server error or temporary resource unavailability (most likely).
+		// Theoretically, psapi parsing errors could occur that retry without hope for recovery.
+		return err
+	}
+	klog.InfoS("User violation check result", "namespace", ns.Name, "isUserViolation", isUserViolation)
+	if isUserViolation {
+		klog.InfoS("Adding namespace to user SCC violations", "namespace", ns.Name)
+		conditions.addUserSCCViolation(ns)
+		return nil
+	}
+
+	// Historically, we assume that this is a customer issue, but
+	// actually it means we don't know what the root cause is.
+	conditions.addViolatingCustomer(ns)
+
+	return nil
+}
+
+func (c *PodSecurityReadinessController) isUserViolation(ctx context.Context, ns *corev1.Namespace, label string) (bool, error) {
+	// Parse the violating level
+	var enforcementLevel psapi.Level
+	switch strings.ToLower(label) {
+	case "restricted":
+		enforcementLevel = psapi.LevelRestricted
+	case "baseline":
+		enforcementLevel = psapi.LevelBaseline
+	case "privileged":
+		// If privileged is violating, something is seriously wrong
+		// but testing against privileged level is pointless (everything passes)
+		klog.V(2).InfoS("Namespace violating privileged level - skipping user check",
+			"namespace", ns.Name)
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown level: %q", label)
+	}
+
+	// List all pods and filter for user-annotated ones
+	allPods, err := c.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.V(2).ErrorS(err, "Failed to list pods in namespace", "namespace", ns.Name)
+		return false, err
+	}
+
+	// Filter for user-annotated pods
+	var userPods []corev1.Pod
+	for _, pod := range allPods.Items {
+		if pod.Annotations[securityv1.ValidatedSCCSubjectTypeAnnotation] == "user" {
+			userPods = append(userPods, pod)
+		}
+	}
+
+	if len(userPods) == 0 {
+		return false, nil // No user pods = violation is from service accounts
+	}
+
+	// Test user pods against the violating level
+	enforcementVersion := psapi.LatestVersion()
+	for _, pod := range userPods {
+		klog.InfoS("Evaluating user pod against PSA level",
+			"namespace", ns.Name, "pod", pod.Name, "level", label,
+			"podSecurityContext", pod.Spec.SecurityContext)
+
+		// Log container security contexts for debugging
+		for i, container := range pod.Spec.Containers {
+			klog.InfoS("Container security context",
+				"namespace", ns.Name, "pod", pod.Name, "container", i,
+				"securityContext", container.SecurityContext)
+		}
+
+		results := c.psaEvaluator.EvaluatePod(
+			psapi.LevelVersion{Level: enforcementLevel, Version: enforcementVersion},
+			&pod.ObjectMeta,
+			&pod.Spec,
+		)
+
+		klog.InfoS("PSA evaluation results",
+			"namespace", ns.Name, "pod", pod.Name, "level", label,
+			"resultCount", len(results))
+
+		for _, result := range results {
+			klog.InfoS("PSA evaluation result",
+				"namespace", ns.Name, "pod", pod.Name, "level", label,
+				"allowed", result.Allowed, "reason", result.ForbiddenReason,
+				"detail", result.ForbiddenDetail)
+			if !result.Allowed {
+				klog.InfoS("User pod violates PSA level",
+					"namespace", ns.Name, "pod", pod.Name, "level", label)
+				return true, nil // User pod violates the level
+			}
+		}
+	}
+
+	return false, nil // User pods all pass - violation is from service accounts
+}
+

--- a/pkg/operator/podsecurityreadinesscontroller/classification_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/classification_test.go
@@ -1,0 +1,367 @@
+package podsecurityreadinesscontroller
+
+import (
+	"context"
+	"testing"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/pod-security-admission/policy"
+)
+
+func TestClassifyViolatingNamespace(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		namespace          *corev1.Namespace
+		pods               []corev1.Pod
+		enforceLevel       string
+		expectedConditions map[string][]string
+		expectError        bool
+	}{
+		{
+			name: "run-level zero namespace - kube-system",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-system",
+				},
+			},
+			pods:         []corev1.Pod{},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"runLevelZero": {"kube-system"},
+			},
+			expectError: false,
+		},
+		{
+			name: "run-level zero namespace - default",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+			pods:         []corev1.Pod{},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"runLevelZero": {"default"},
+			},
+			expectError: false,
+		},
+		{
+			name: "openshift namespace",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "openshift-test",
+				},
+			},
+			pods:         []corev1.Pod{},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"openshift": {"openshift-test"},
+			},
+			expectError: false,
+		},
+		{
+			name: "disabled syncer namespace",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-disabled",
+					Labels: map[string]string{
+						"security.openshift.io/scc.podSecurityLabelSync": "false",
+					},
+				},
+			},
+			pods:         []corev1.Pod{},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"disabledSyncer": {"test-disabled"},
+			},
+			expectError: false,
+		},
+		{
+			name: "customer namespace with user SCC violation",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods: []corev1.Pod{
+				newUserSCCPodPrivileged("user-pod", "customer-ns"),
+			},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"userSCC": {"customer-ns"},
+			},
+			expectError: false,
+		},
+		{
+			name: "user pod with privileged container - exact test manifest case",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "user-scc-violation-test",
+				},
+			},
+			pods: []corev1.Pod{
+				newUserSCCPodWithPrivilegedContainer("user-scc-violating-pod", "user-scc-violation-test"),
+			},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"userSCC": {"user-scc-violation-test"},
+			},
+			expectError: false,
+		},
+		{
+			name: "customer namespace without user SCC violation",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods: []corev1.Pod{
+				newServiceAccountPod("sa-pod", "customer-ns"),
+			},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"customer": {"customer-ns"},
+			},
+			expectError: false,
+		},
+		{
+			// TODO: Ideally we would not drop the "customer" condition.
+			name: "customer namespace with mixed pods - user violates",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods: []corev1.Pod{
+				newServiceAccountPod("sa-pod", "customer-ns"),
+				newUserSCCPodPrivileged("user-pod", "customer-ns"),
+			},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"userSCC": {"customer-ns"},
+			},
+			expectError: false,
+		},
+		{
+			name: "customer namespace with user pods that pass PSA",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods: []corev1.Pod{
+				newUserSCCPodRestricted("user-pod", "customer-ns"),
+			},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"customer": {"customer-ns"},
+			},
+			expectError: false,
+		},
+		{
+			name: "customer namespace with no pods",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods:         []corev1.Pod{},
+			enforceLevel: "restricted",
+			expectedConditions: map[string][]string{
+				"customer": {"customer-ns"},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid PSA level causes error",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "customer-ns",
+				},
+			},
+			pods:               []corev1.Pod{},
+			enforceLevel:       "invalid-level",
+			expectedConditions: map[string][]string{},
+			expectError:        true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset()
+
+			// Add pods to fake client
+			for _, pod := range tt.pods {
+				_, err := fakeClient.CoreV1().Pods(tt.namespace.Name).Create(context.Background(), &pod, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create test pod: %v", err)
+				}
+			}
+
+			psaEvaluator, err := policy.NewEvaluator(policy.DefaultChecks())
+			if err != nil {
+				t.Fatalf("Failed to create PSA evaluator: %v", err)
+			}
+
+			controller := &PodSecurityReadinessController{
+				kubeClient:   fakeClient,
+				psaEvaluator: psaEvaluator,
+			}
+
+			conditions := podSecurityOperatorConditions{}
+
+			err = controller.classifyViolatingNamespace(
+				context.Background(), &conditions,
+				tt.namespace, tt.enforceLevel,
+			)
+
+			if (err != nil) != tt.expectError {
+				t.Errorf("classifyViolatingNamespace() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+
+			if err != nil {
+				return // Expected error, nothing more to check
+			}
+
+			// Verify the conditions were set correctly
+			for conditionType, expectedNamespaces := range tt.expectedConditions {
+				var actualNamespaces []string
+				switch conditionType {
+				case "runLevelZero":
+					actualNamespaces = conditions.violatingRunLevelZeroNamespaces
+				case "openshift":
+					actualNamespaces = conditions.violatingOpenShiftNamespaces
+				case "disabledSyncer":
+					actualNamespaces = conditions.violatingDisabledSyncerNamespaces
+				case "customer":
+					actualNamespaces = conditions.violatingCustomerNamespaces
+				case "userSCC":
+					actualNamespaces = conditions.userSCCViolationNamespaces
+				}
+
+				if len(actualNamespaces) != len(expectedNamespaces) {
+					t.Errorf("expected %d %s namespaces, got %d", len(expectedNamespaces), conditionType, len(actualNamespaces))
+				}
+
+				for _, expected := range expectedNamespaces {
+					found := false
+					for _, actual := range actualNamespaces {
+						if actual == expected {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("expected %s namespace %s not found in %v", conditionType, expected, actualNamespaces)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Test pod creation helpers
+func newUserSCCPodPrivileged(name, namespace string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &[]bool{false}[0],
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "container",
+					Image: "image",
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &[]bool{true}[0],
+					},
+				},
+			},
+		},
+	}
+}
+
+func newServiceAccountPod(name, namespace string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				securityv1.ValidatedSCCSubjectTypeAnnotation: "service-account",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &[]bool{false}[0],
+			},
+		},
+	}
+}
+
+func newUserSCCPodWithPrivilegedContainer(name, namespace string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "test-container",
+					Image:   "busybox:latest",
+					Command: []string{"sleep", "infinity"},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:   &[]bool{true}[0],
+						RunAsNonRoot: &[]bool{false}[0],
+						RunAsUser:    &[]int64{0}[0],
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func newUserSCCPodRestricted(name, namespace string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+			},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   &[]bool{true}[0],
+				RunAsUser:      &[]int64{1000}[0],
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				FSGroup:        &[]int64{1000}[0],
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "container",
+					Image: "image",
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &[]bool{false}[0],
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: &[]bool{true}[0],
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
+++ b/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	psapi "k8s.io/pod-security-admission/api"
+	"k8s.io/pod-security-admission/policy"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -30,6 +31,7 @@ type PodSecurityReadinessController struct {
 
 	warningsHandler   *warningsHandler
 	namespaceSelector string
+	psaEvaluator      policy.Evaluator
 }
 
 func NewPodSecurityReadinessController(
@@ -49,11 +51,17 @@ func NewPodSecurityReadinessController(
 		return nil, err
 	}
 
+	psaEvaluator, err := policy.NewEvaluator(policy.DefaultChecks())
+	if err != nil {
+		return nil, err
+	}
+
 	c := &PodSecurityReadinessController{
 		operatorClient:    operatorClient,
 		kubeClient:        kubeClient,
 		warningsHandler:   warningsHandler,
 		namespaceSelector: selector,
+		psaEvaluator:      psaEvaluator,
 	}
 
 	return factory.New().
@@ -62,7 +70,7 @@ func NewPodSecurityReadinessController(
 		ToController("PodSecurityReadinessController", recorder), nil
 }
 
-func (c *PodSecurityReadinessController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *PodSecurityReadinessController) sync(ctx context.Context, _ factory.SyncContext) error {
 	nsList, err := c.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: c.namespaceSelector})
 	if err != nil {
 		return err
@@ -71,18 +79,18 @@ func (c *PodSecurityReadinessController) sync(ctx context.Context, syncCtx facto
 	conditions := podSecurityOperatorConditions{}
 	for _, ns := range nsList.Items {
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			isViolating, err := c.isNamespaceViolating(ctx, &ns)
+			isViolating, enforceLevel, err := c.isNamespaceViolating(ctx, &ns)
 			if apierrors.IsNotFound(err) {
 				return nil
 			}
 			if err != nil {
 				return err
 			}
-			if isViolating {
-				conditions.addViolation(&ns)
+			if !isViolating {
+				return nil
 			}
 
-			return nil
+			return c.classifyViolatingNamespace(ctx, &conditions, &ns, enforceLevel)
 		})
 		if err != nil {
 			klog.V(2).ErrorS(err, "namespace:", ns.Name)

--- a/pkg/operator/podsecurityreadinesscontroller/user_scc_violation_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/user_scc_violation_test.go
@@ -1,0 +1,430 @@
+package podsecurityreadinesscontroller
+
+import (
+	"context"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/pod-security-admission/policy"
+)
+
+func TestUserSCCViolationConditionDetection(t *testing.T) {
+	tests := []struct {
+		name                     string
+		namespace                *corev1.Namespace
+		pods                     []*corev1.Pod
+		expectedUserViolation    bool
+		expectedConditionStatus  operatorv1.ConditionStatus
+		expectedConditionMessage string
+	}{
+		{
+			name: "user pod violates baseline PSA with privileged container",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-user-violation",
+					Annotations: map[string]string{
+						securityv1.MinimallySufficientPodSecurityStandard: "baseline",
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-violating-pod",
+						Namespace: "test-user-violation",
+						Annotations: map[string]string{
+							securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+							"openshift.io/scc":                           "privileged",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true, // Violates baseline
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test:latest",
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: &[]bool{true}[0], // Violates baseline
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUserViolation:    true,
+			expectedConditionStatus:  operatorv1.ConditionTrue,
+			expectedConditionMessage: "Violations detected in namespaces: [test-user-violation]",
+		},
+		{
+			name: "user pod passes baseline PSA",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-user-compliant",
+					Annotations: map[string]string{
+						securityv1.MinimallySufficientPodSecurityStandard: "baseline",
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-compliant-pod",
+						Namespace: "test-user-compliant",
+						Annotations: map[string]string{
+							securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+							"openshift.io/scc":                           "restricted",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test:latest",
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: &[]bool{false}[0],
+									RunAsNonRoot:             &[]bool{true}[0],
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
+								},
+							},
+						},
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+			expectedUserViolation:   false,
+			expectedConditionStatus: operatorv1.ConditionFalse,
+		},
+		{
+			name: "no user pods - only service account pods",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-no-user-pods",
+					Annotations: map[string]string{
+						securityv1.MinimallySufficientPodSecurityStandard: "baseline",
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sa-violating-pod",
+						Namespace: "test-no-user-pods",
+						Annotations: map[string]string{
+							securityv1.ValidatedSCCSubjectTypeAnnotation: "serviceaccount",
+							"openshift.io/scc":                           "privileged",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true, // Violates baseline but shouldn't count as user violation
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test:latest",
+							},
+						},
+					},
+				},
+			},
+			expectedUserViolation:   false,
+			expectedConditionStatus: operatorv1.ConditionFalse,
+		},
+		{
+			name: "mixed user and service account pods - user pod violates",
+			namespace: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mixed-pods",
+					Annotations: map[string]string{
+						securityv1.MinimallySufficientPodSecurityStandard: "restricted",
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sa-violating-pod",
+						Namespace: "test-mixed-pods",
+						Annotations: map[string]string{
+							securityv1.ValidatedSCCSubjectTypeAnnotation: "serviceaccount",
+							"openshift.io/scc":                           "privileged",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						Containers: []corev1.Container{
+							{
+								Name:  "sa-container",
+								Image: "test:latest",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-violating-pod",
+						Namespace: "test-mixed-pods",
+						Annotations: map[string]string{
+							securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+							"openshift.io/scc":                           "anyuid",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "user-container",
+								Image: "test:latest",
+								SecurityContext: &corev1.SecurityContext{
+									// Missing required restricted settings
+									RunAsNonRoot:             &[]bool{false}[0], // Violates restricted
+									AllowPrivilegeEscalation: &[]bool{true}[0],  // Violates restricted
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUserViolation:    true,
+			expectedConditionStatus:  operatorv1.ConditionTrue,
+			expectedConditionMessage: "Violations detected in namespaces: [test-mixed-pods]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test data
+			objects := []runtime.Object{tt.namespace}
+			for _, pod := range tt.pods {
+				objects = append(objects, pod)
+			}
+			fakeClient := fake.NewSimpleClientset(objects...)
+
+			// Create PSA evaluator
+			psaEvaluator, err := policy.NewEvaluator(policy.DefaultChecks())
+			if err != nil {
+				t.Fatalf("Failed to create PSA evaluator: %v", err)
+			}
+
+			// Create controller
+			controller := &PodSecurityReadinessController{
+				kubeClient:   fakeClient,
+				psaEvaluator: psaEvaluator,
+			}
+
+			// Determine enforcement level from namespace annotation
+			enforcementLevel := "baseline"
+			if level, ok := tt.namespace.Annotations[securityv1.MinimallySufficientPodSecurityStandard]; ok {
+				enforcementLevel = level
+			}
+
+			// Test isUserViolation method directly
+			isUserViolation, err := controller.isUserViolation(context.Background(), tt.namespace, enforcementLevel)
+			if err != nil {
+				t.Errorf("isUserViolation returned error: %v", err)
+			}
+			if isUserViolation != tt.expectedUserViolation {
+				t.Errorf("Expected isUserViolation=%v, got %v", tt.expectedUserViolation, isUserViolation)
+			}
+
+			// Test full classification workflow
+			conditions := podSecurityOperatorConditions{}
+			err = controller.classifyViolatingNamespace(context.Background(), &conditions, tt.namespace, enforcementLevel)
+			if err != nil {
+				t.Errorf("classifyViolatingNamespace returned error: %v", err)
+			}
+
+			// Verify user SCC violation condition
+			conditionFuncs := conditions.toConditionFuncs()
+			userSCCConditionFound := false
+
+			for _, conditionFunc := range conditionFuncs {
+				// Create a mock status to apply the condition to
+				mockStatus := &operatorv1.OperatorStatus{}
+				err := conditionFunc(mockStatus)
+				if err != nil {
+					t.Errorf("Condition function returned error: %v", err)
+					continue
+				}
+
+				// Check if this is the user SCC condition
+				for _, condition := range mockStatus.Conditions {
+					if condition.Type == PodSecurityUserSCCType {
+						userSCCConditionFound = true
+						if condition.Status != tt.expectedConditionStatus {
+							t.Errorf("Expected condition status %v, got %v", tt.expectedConditionStatus, condition.Status)
+						}
+						if tt.expectedConditionMessage != "" && condition.Message != tt.expectedConditionMessage {
+							t.Errorf("Expected condition message %q, got %q", tt.expectedConditionMessage, condition.Message)
+						}
+						t.Logf("User SCC condition: Status=%s, Message=%s", condition.Status, condition.Message)
+					}
+				}
+			}
+
+			if !userSCCConditionFound {
+				t.Errorf("User SCC violation condition not found in condition functions")
+			}
+
+			// Verify namespace classification
+			if tt.expectedUserViolation {
+				if len(conditions.userSCCViolationNamespaces) != 1 || conditions.userSCCViolationNamespaces[0] != tt.namespace.Name {
+					t.Errorf("Expected namespace %s in userSCCViolationNamespaces, got %v", tt.namespace.Name, conditions.userSCCViolationNamespaces)
+				}
+			} else {
+				if len(conditions.userSCCViolationNamespaces) != 0 {
+					t.Errorf("Expected no user SCC violations, got %v", conditions.userSCCViolationNamespaces)
+				}
+			}
+		})
+	}
+}
+
+func TestUserSCCViolationDetectionWithSpecificPSALevels(t *testing.T) {
+	// Test specifically against different PSA levels
+	tests := []struct {
+		name             string
+		enforcementLevel string
+		podSpec          corev1.PodSpec
+		expectViolation  bool
+	}{
+		{
+			name:             "privileged hostNetwork violates baseline",
+			enforcementLevel: "baseline",
+			podSpec: corev1.PodSpec{
+				HostNetwork: true,
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test:latest",
+					},
+				},
+			},
+			expectViolation: true,
+		},
+		{
+			name:             "privileged container violates baseline",
+			enforcementLevel: "baseline",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Privileged: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+			expectViolation: true,
+		},
+		{
+			name:             "allowPrivilegeEscalation=true violates restricted",
+			enforcementLevel: "restricted",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test:latest",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: &[]bool{true}[0],
+						},
+					},
+				},
+			},
+			expectViolation: true,
+		},
+		{
+			name:             "runAsNonRoot=false violates restricted",
+			enforcementLevel: "restricted",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test:latest",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: &[]bool{false}[0],
+						},
+					},
+				},
+			},
+			expectViolation: true,
+		},
+		{
+			name:             "compliant restricted pod",
+			enforcementLevel: "restricted",
+			podSpec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: &[]bool{true}[0],
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "test",
+						Image: "test:latest",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: &[]bool{false}[0],
+							RunAsNonRoot:             &[]bool{true}[0],
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					},
+				},
+			},
+			expectViolation: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-psa-levels",
+				},
+			}
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-user-pod",
+					Namespace: namespace.Name,
+					Annotations: map[string]string{
+						securityv1.ValidatedSCCSubjectTypeAnnotation: "user",
+					},
+				},
+				Spec: tt.podSpec,
+			}
+
+			fakeClient := fake.NewSimpleClientset(namespace, pod)
+			psaEvaluator, err := policy.NewEvaluator(policy.DefaultChecks())
+			if err != nil {
+				t.Fatalf("Failed to create PSA evaluator: %v", err)
+			}
+
+			controller := &PodSecurityReadinessController{
+				kubeClient:   fakeClient,
+				psaEvaluator: psaEvaluator,
+			}
+
+			isUserViolation, err := controller.isUserViolation(context.Background(), namespace, tt.enforcementLevel)
+			if err != nil {
+				t.Errorf("isUserViolation returned error: %v", err)
+			}
+
+			if isUserViolation != tt.expectViolation {
+				t.Errorf("Expected violation=%v for level %s, got %v", tt.expectViolation, tt.enforcementLevel, isUserViolation)
+			}
+
+			t.Logf("PSA level %s: violation=%v (expected %v)", tt.enforcementLevel, isUserViolation, tt.expectViolation)
+		})
+	}
+}
+


### PR DESCRIPTION
## What

Collect metrics for workloads that have user-based SCC, which would cause violations, when PSA would be enforced.

## Why

It is possible that a workload has a ServiceAccount that isn't authorized to use a certain SCC, but the user is. Those user-based SCCs are not honored by the PSA label syncer and cause it to assign a potentially too strict PSS.