### PR TITLE
OCPBUGS-58158: Enable watch termination grace period

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -161,8 +161,6 @@ apiServerArguments:
     - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   shutdown-send-retry-after:
   - "true"
-  shutdown-watch-termination-grace-period:
-    - 5s # shorter than the pod graceful termination period on single-node
   storage-backend:
     - etcd3
   storage-media-type:


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1846

See https://issues.redhat.com/browse/OCPBUGS-58158 for details

To re-test before bringing back in, I'd try /payload 4.20 ci blocking

This is expensive but I'm not sure if the more reasonable  "/payload-aggregate periodic-ci-openshift-release-master-ci-4.20-upgrade-from-stable-4.19-e2e-aws-ovn-upgrade 10" actually runs these standard deviation tests, it might...