### PR TITLE
OCPBUGS-57811: Updating ose-cluster-kube-apiserver-operator-container image to be consistent with ART for 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-kube-apiserver-operator
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24.0
 
 require (
 	github.com/apparentlymart/go-cidr v1.0.1

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
@@ -173,7 +173,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 				t.Log(diff.StringDiff(tc.expectedMsgLines, condition.Message))
 			}
 			if t.Failed() {
-				t.Logf(condition.Message)
+				t.Logf("Condition message: %s", condition.Message)
 			}
 		})
 	}

--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	testlibrary "github.com/openshift/library-go/test/library"
 	"github.com/stretchr/testify/require"
@@ -11,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"reflect"
-	"testing"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 )
@@ -30,21 +31,21 @@ func TestServiceAccountIssuer(t *testing.T) {
 	t.Run("serviceaccountissuer set in authentication config results in apiserver config", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "https://first.foo.bar")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("pollForOperandIssuer failed: %v", err)
 		}
 	})
 
 	t.Run("second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "https://second.foo.bar")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("pollForOperandIssuer failed: %v", err)
 		}
 	})
 
 	t.Run("no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "")
 		if err := pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc"}); err != nil {
-			t.Errorf(err.Error())
+			t.Errorf("pollForOperandIssuer failed: %v", err)
 		}
 	})
 


### PR DESCRIPTION
What does the PR do?
1. Updated go version to 1.24 and ocp version to 4.20
2. Updated go version in go.mod and go mod tidy && go mod vendor && go mod verify
3. Fixed below unit test error,
```
# github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/kubeletversionskewcontroller
# [github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/kubeletversionskewcontroller]
pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go:176:12: non-constant format string in call to (*testing.common).Logf
```
4. Fixed make verify error,
```
$ make verify
Running `gofmt -s -l` on 137 file(s).
go vet -mod=vendor ./...
# github.com/openshift/cluster-kube-apiserver-operator/test/e2e
# [github.com/openshift/cluster-kube-apiserver-operator/test/e2e]
test/e2e/serviceaccountissuer_test.go:33:13: non-constant format string in call to (*testing.common).Errorf
test/e2e/serviceaccountissuer_test.go:40:13: non-constant format string in call to (*testing.common).Errorf
test/e2e/serviceaccountissuer_test.go:47:13: non-constant format string in call to (*testing.common).Errorf
```