### PR TITLE
Revert "[release-4.19] OCPBUGS-58116: certregenerationcontroller: start configInformers again"

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -109,6 +109,10 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 		return err
 	}
 
+	// We can't start informers until after the resources have been requested. Now is the time.
+	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
+	dynamicInformers.Start(ctx.Done())
+
 	desiredVersion := status.VersionForOperatorFromEnv()
 	missingVersion := "0.0.1-snapshot"
 	featureGateAccessor := featuregates.NewFeatureGateAccess(
@@ -149,11 +153,6 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 	if err != nil {
 		return err
 	}
-
-	// We can't start informers until after the resources have been requested. Now is the time.
-	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
-	dynamicInformers.Start(ctx.Done())
-	configInformers.Start(ctx.Done())
 
 	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
 	// (@deads2k wants time to think it through)


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1861

Investigating [TRT-2190](https://issues.redhat.com/browse/TRT-2190) gcp minor upgrade failures due to pathological events like

```
event happened 25 times, something is wrong: namespace/openshift-kube-apiserver hmsg/cf99229525 - reason/SecretUpdated Updated Secret/kube-controller-manager-client-cert-key -n openshift-config-managed because it changed (05:57:30Z) result=reject 
```