### PR TITLE
OCPBUGS-59527: certrotationcontroller: extend node-system-admin-signer lifetime

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -812,10 +812,10 @@ func newCertRotationController(
 				AutoRegenerateAfterOfflineExpiry: "https://github.com/openshift/cluster-kube-apiserver-operator/pull/1631,'[Conformance][sig-api-machinery][Feature:APIServer] local kubeconfig \"localhost-recovery.kubeconfig\" should be present on all masters and work [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel/minimal]'",
 				Description:                      "Signer for the per-master-debugging-client.",
 			},
-			Validity: devRotationExceptionYear,
+			Validity: 3 * devRotationExceptionYear,
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
-			Refresh:                devRotationExceptionTenMonth,
+			Refresh:                3 * devRotationExceptionTenMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),


### PR DESCRIPTION
This signer is used to issue the certificate for node-system-admin-client. The target certificate is expected to last 2 years, however it cannot be valid longer than its signer. As a result, signer validity is extended to 3 years, being refreshed at 80% of its lifetime (2.5 years)

This change is required to test [1 year shutdowns](https://github.com/openshift/release/pull/64965) (instead of just 360d)