### PR TITLE
OCPBUGS-50489: Add missing service ports to apiserver service

### DIFF
--- a/bindata/assets/kube-apiserver/svc.yaml
+++ b/bindata/assets/kube-apiserver/svc.yaml
@@ -11,3 +11,12 @@ spec:
   - name: https
     port: 443
     targetPort: 6443
+    protocol: TCP
+  - name: insecure-readyz
+    port: 6080
+    targetPort: 6080
+    protocol: TCP
+  - name: check-endpoints
+    port: 17697
+    targetPort: 17697
+    protocol: TCP


### PR DESCRIPTION
Add ports 6080 (insecure-readyz) and 17697 (check-endpoints) to the apiserver service. These ports were already exposed by the pods but missing from the service definition, preventing EndpointSlice creation for communication matrix documentation (for mor details see [bug](https://issues.redhat.com/browse/OCPBUGS-50489) description)