### PR TITLE
terminationObserver: use lister instead of direct client calls

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -422,7 +422,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	terminationObserver := terminationobserver.NewTerminationObserver(
 		operatorclient.TargetNamespace,
 		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
-		kubeClient.CoreV1(),
+		kubeInformersForNamespaces.PodLister().Pods(operatorclient.TargetNamespace),
 		controllerContext.EventRecorder,
 	)
 


### PR DESCRIPTION
Termination observer does not need to do direct client calls, instead it can rely on pod lister information.