### PR TITLE
OCPBUGS-60121: [release-4.19] Set goaway chance to 0.001

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -115,7 +115,7 @@ apiServerArguments:
   event-ttl:
     - 3h
   goaway-chance:
-    - "0"
+    - "0.001"
   http2-max-streams-per-connection:
     - "2000"  # recommended is 1000, but we need to mitigate https://github.com/kubernetes/kubernetes/issues/74412
   kubelet-certificate-authority:

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -195,6 +195,9 @@ type TemplateData struct {
 	// ShutdownDelayDuration is passed to kube-apiserver. Empty means not to override defaultconfig's value.
 	ShutdownDelayDuration string
 
+	// GoAwayChance is defaultconfig's goaway-chance setting. Empty means not to override defaultconfig's value.
+	GoAwayChance string
+
 	ServiceAccountIssuer string
 }
 

--- a/pkg/operator/configobservation/apiserver/observe_goaway_chance.go
+++ b/pkg/operator/configobservation/apiserver/observe_goaway_chance.go
@@ -1,0 +1,66 @@
+package apiserver
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+var goawayChancePath = []string{"apiServerArguments", "goaway-chance"}
+
+// ObserveGoawayChance ensures that goaway-chance is 0 for SNO topology
+func ObserveGoawayChance(genericListers configobserver.Listers, _ events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+	defer func() {
+		// Prune the observed config so that it only contains apiServerArguments field.
+		ret = configobserver.Pruned(ret, goawayChancePath)
+	}()
+
+	// read the observed value
+	listers := genericListers.(configobservation.Listers)
+	infra, err := listers.InfrastructureLister().Get("cluster")
+	if err != nil {
+		// we got an error so without the infrastructure object we are not able to determine the type of platform we are running on
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("ObserveGoawayChance: infras.%s/cluster not found", configv1.GroupName)
+		} else {
+			errs = append(errs, err)
+		}
+		return existingConfig, errs
+	}
+
+	observedGoawayChance := "0.001"
+	if infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
+		// for SNO we want to set goaway-chance to 0
+		observedGoawayChance = "0"
+	}
+
+	// read the current value
+	var currentGoawayChance string
+	currentGoawayChanceSlice, _, err := unstructured.NestedStringSlice(existingConfig, goawayChancePath...)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to extract goaway chance setting from the existing config: %v", err))
+		// keep going, we are only interested in the observed value which will overwrite the current configuration anyway
+	}
+	if len(currentGoawayChanceSlice) > 0 {
+		currentGoawayChance = currentGoawayChanceSlice[0]
+	}
+
+	// see if the current and the observed value differ
+	observedConfig := map[string]interface{}{}
+	if observedGoawayChance != currentGoawayChance {
+		if err = unstructured.SetNestedStringSlice(observedConfig, []string{observedGoawayChance}, goawayChancePath...); err != nil {
+			return existingConfig, append(errs, err)
+		}
+		return observedConfig, errs
+	}
+
+	// nothing has changed return the original configuration
+	return existingConfig, errs
+}

--- a/pkg/operator/configobservation/apiserver/observe_goaway_chance_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_goaway_chance_test.go
@@ -1,0 +1,188 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func TestObserveGoawayChance(t *testing.T) {
+	scenarios := []struct {
+		name                  string
+		existingKubeAPIConfig map[string]interface{}
+		expectedKubeAPIConfig map[string]interface{}
+		controlPlaneTopology  configv1.TopologyMode
+	}{
+
+		// scenario 1 - HA unset
+		{
+			name:                 "ha: defaults to 0.001",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+		},
+
+		// scenario 3 - HA, update not required
+		{
+			name:                 "ha: update not required",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+		},
+
+		// scenario 4 - HA, update required
+		{
+			name:                 "ha: update required",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.2"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+		},
+
+		// scenario 5 - SNO
+		{
+			name:                 "sno: defaults to 0",
+			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0"},
+			}},
+		},
+
+		// scenario 6 - SNO, update required
+		{
+			name:                 "sno: update required",
+			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0"},
+			}},
+		},
+
+		// scenario 7 - SNO, update not required
+		{
+			name:                 "sno: update not required",
+			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0"},
+			}},
+		},
+
+		// scenario 8 - Invalid goaway-chance value (negative)
+		{
+			name:                 "invalid: negative value",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"-0.1"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+		},
+
+		// scenario 9 - Invalid goaway-chance value (greater than 0.2)
+		{
+			name:                 "invalid: value greater than 0.2",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.3"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"goaway-chance": []interface{}{"0.001"},
+			}},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewInMemoryRecorder("", clock.RealClock{})
+			infrastructureIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			infrastructureIndexer.Add(&configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status:     configv1.InfrastructureStatus{ControlPlaneTopology: scenario.controlPlaneTopology},
+			})
+			listers := configobservation.Listers{
+				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infrastructureIndexer),
+			}
+
+			// act
+			observedKubeAPIConfig, err := ObserveGoawayChance(listers, eventRecorder, scenario.existingKubeAPIConfig)
+
+			// validate
+			if len(err) > 0 {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(scenario.expectedKubeAPIConfig, observedKubeAPIConfig); diff != "" {
+				t.Fatalf("unexpected configuration, diff = %s", diff)
+			}
+		})
+	}
+}
+
+func TestObserveGoawayChanceErrors(t *testing.T) {
+	scenarios := []struct {
+		name             string
+		infraIndexerFunc func(cache.Indexer)
+		expectedErrs     []error
+	}{
+		{
+			name: "happy path",
+			infraIndexerFunc: func(indexer cache.Indexer) {
+				indexer.Add(&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{ControlPlaneTopology: configv1.HighlyAvailableTopologyMode},
+				})
+			},
+			expectedErrs: nil,
+		},
+		{
+			name:             "no cluster infra",
+			infraIndexerFunc: nil,
+			expectedErrs:     nil,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// test data
+			eventRecorder := events.NewInMemoryRecorder("", clock.RealClock{})
+			infrastructureIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if scenario.infraIndexerFunc != nil {
+				scenario.infraIndexerFunc(infrastructureIndexer)
+			}
+			listers := configobservation.Listers{
+				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infrastructureIndexer),
+			}
+
+			// act
+			_, errs := ObserveGoawayChance(listers, eventRecorder, map[string]interface{}{})
+
+			// validate
+			if diff := cmp.Diff(scenario.expectedErrs, errs); diff != "" {
+				t.Fatalf("unexpected errs, diff = %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -123,6 +123,7 @@ func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInf
 			apiserver.ObserveShutdownDelayDuration,
 			apiserver.ObserveGracefulTerminationDuration,
 			apiserver.ObserveSendRetryAfterWhileNotReadyOnce,
+			apiserver.ObserveGoawayChance,
 			libgoapiserver.ObserveTLSSecurityProfile,
 			auth.ObserveAuthMetadata,
 			auth.ObserveServiceAccountIssuer,


### PR DESCRIPTION
Backport PR https://github.com/openshift/cluster-kube-apiserver-operator/pull/1863 to release-4.19 manually.