### PR TITLE
Revert "Revert "OCPBUGS-56551: certregenerationcontroller: start configInformers again""

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -109,10 +109,6 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 		return err
 	}
 
-	// We can't start informers until after the resources have been requested. Now is the time.
-	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
-	dynamicInformers.Start(ctx.Done())
-
 	desiredVersion := status.VersionForOperatorFromEnv()
 	missingVersion := "0.0.1-snapshot"
 	featureGateAccessor := featuregates.NewFeatureGateAccess(
@@ -153,6 +149,11 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 	if err != nil {
 		return err
 	}
+
+	// We can't start informers until after the resources have been requested. Now is the time.
+	kubeAPIServerInformersForNamespaces.Start(ctx.Done())
+	dynamicInformers.Start(ctx.Done())
+	configInformers.Start(ctx.Done())
 
 	// FIXME: These are missing a wait group to track goroutines and handle graceful termination
 	// (@deads2k wants time to think it through)


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1869

Now that CA Bundles are created optimistically in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1812, we no longer get flooded with create/update CA bundle updates - so we can start informers again to make cert rotation work after suspend/shutdown