### PR TITLE
OCPBUGS-59626: operator: don't react to events from all namespaces

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -129,7 +129,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		"openshift-etcd",
 		"openshift-apiserver",
 	)
-	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
+	// OCPBUGS-59626: Use cluster-level informers only, don't watch all namespaces
+	// Remove empty namespace ("") parameter to prevent watching ALL namespaces
+	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient)
 
 	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
 	operatorClient, dynamicInformersForAllNamespaces, err := genericoperatorclient.NewStaticPodOperatorClient(


### PR DESCRIPTION
An informer for an empty namespace will list resources from all namespaces and cluster level. This may be undesirable, as this makes the controller react to events from different namespaces, while we're only interested in cluster-level events for clusterInformers.

This prevents kas-operator from becoming degraded when unrelated namespace secrets are corrupted, which was causing false positive degradations.

The fix removes the empty string namespace parameter that was causing the operator to watch ALL namespaces, and instead uses cluster-level only informers as intended by library-go#1985.

Fixes: OCPBUGS-59626
Related: library-go#1985