### PR TITLE
OCPBUGS-55670: revert dev cert rotation

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -120,9 +120,6 @@ func newCertRotationController(
 	foreverRefreshPeriod := 8 * 365 * 24 * time.Hour
 
 	rotationDay := 24 * time.Hour
-	// for the development cycle, make the rotation 60 times faster (every twelve hours or so).
-	// This must be reverted before we ship
-	rotationDay = rotationDay / 60
 
 	// Some certificates should not be affected by development cycle rotation
 	devRotationExceptionDay := 24 * time.Hour


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored certificate rotation intervals to standard real-time durations (daily/monthly/yearly), eliminating unintended accelerated rotation and improving stability and predictability.
  * Reduces unnecessary rotation churn and related logging noise.
  * No configuration changes required; existing deployments automatically adopt the corrected schedule on upgrade.
  * No changes to APIs or permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->