### PR TITLE
OCPBUGS-61038: SSL Medium Strength Cipher Suites Supported for operator

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -239,6 +239,8 @@ spec:
     args:
       - --kubeconfig
       - /etc/kubernetes/static-pod-certs/configmaps/check-endpoints-kubeconfig/kubeconfig
+      - --config
+      - /etc/kubernetes/static-pod-certs/configmaps/kube-apiserver-operator-config/config.yaml
       - --listen
       - 0.0.0.0:17697
       - --namespace

--- a/manifests/0000_20_kube-apiserver-operator_03_configmap.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_03_configmap.yaml
@@ -11,3 +11,12 @@ data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1
     kind: GenericOperatorConfig
+    servingInfo:
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      minTLSVersion: VersionTLS12

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -95,5 +95,13 @@ func NewResourceSyncController(
 		return nil, err
 	}
 
+	// this config contains the cipherSuites and minTLSVersion which is used by check-endpoints
+	if err := resourceSyncController.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.TargetNamespace, Name: "kube-apiserver-operator-config"},
+		resourcesynccontroller.ResourceLocation{Namespace: operatorclient.OperatorNamespace, Name: "kube-apiserver-operator-config"},
+	); err != nil {
+		return nil, err
+	}
+
 	return resourceSyncController, nil
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -660,6 +660,9 @@ var CertConfigMaps = []installer.UnrevisionedResource{
 
 	// kubeconfig for check-endpoints
 	{Name: "check-endpoints-kubeconfig"},
+
+	// kube-apiserver-operator-config (TLS cipherSuites/minTLSVersion for check-endpoints).
+	{Name: "kube-apiserver-operator-config"},
 }
 
 var CertSecrets = []installer.UnrevisionedResource{


### PR DESCRIPTION
The `kube-apiserver-check-endpoints` in kube-apiserver static pod which use `kube-apiserver-operator check-endpoints`, but with unsafe cipherSuites, we should use the safe cipherSuites to be compatible with the `kube-apiserver` cipherSuites

This PR try to add the `kube-apiserver-operator-config` to  the UnrevisionedResource, maybe should we add that to the RevisionedResource（I will post it in the other PR）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - kube-apiserver endpoint checks now read an operator-provided configuration file, allowing you to set the minimum TLS version and permitted cipher suites.

- Chores
  - Automatic propagation of the operator configuration to ensure endpoint checks use the latest TLS settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->