### PR TITLE
NO-JIRA: Add priority field to prevent early shutdown

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -288,6 +288,7 @@ spec:
       readOnlyRootFilesystem: true
   terminationGracePeriodSeconds: {{.GracefulTerminationDuration}}
   hostNetwork: true
+  priority: 2000001000
   priorityClassName: system-node-critical
   tolerations:
   - operator: "Exists"


### PR DESCRIPTION
Based on the issue described here : https://github.com/kubernetes/kubernetes/issues/133442

priorityClassName is currently ignored by Kubelet for static pod files so setting this value has no impact on the gracefulShutdown order causing the static pods to start to be killed as soon as shutdown begins.

To prevent this we must set priority explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the kube-apiserver Pod’s scheduling priority to improve reliability under node pressure and ensure critical control-plane availability.
  * No functional changes to existing settings; behavior remains the same aside from higher scheduling precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->