### PR TITLE
WIP OCPBUGS-59626: core_getters: use namespaced listers in staticpod controllers

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -237,12 +237,12 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 
 	// ensure that all controllers that need the secret/configmap informer-based clients
 	// need to wait for their synchronization before starting using WithInformer
-	configMapClient := v1helpers.CachedConfigMapGetter(b.kubeClient.CoreV1(), b.kubeNamespaceInformers)
-	secretClient := v1helpers.CachedSecretGetter(b.kubeClient.CoreV1(), b.kubeNamespaceInformers)
+	operandInformers := b.kubeNamespaceInformers.InformersFor(b.operandNamespace)
+	configMapClient := v1helpers.NewNamespacedCachedConfigMapGetter(b.kubeClient.CoreV1(), operandInformers, b.operandNamespace)
+	secretClient := v1helpers.NewNamespacedCachedSecretGetter(b.kubeClient.CoreV1(), operandInformers, b.operandNamespace)
 	podClient := b.kubeClient.CoreV1()
 	eventsClient := b.kubeClient.CoreV1()
 	pdbClient := b.kubeClient.PolicyV1()
-	operandInformers := b.kubeNamespaceInformers.InformersFor(b.operandNamespace)
 	clusterInformers := b.kubeClusterInformers
 	infraInformers := b.configInformers.Config().V1().Infrastructures()
 


### PR DESCRIPTION
configmap/secret getters in staticpod controller are using global namespace listers, although all operations are limited to the namespace. This introduces namespaced cached getters, which fall back to the live calls if its requested to use a different namespace. The benefit is that invalid etcd data in any namespace doesn't break pod installation