### PR TITLE
OCPBUGS-62051: targetconfigcontroller: don't create extra events on confict

### DIFF
--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -412,6 +412,10 @@ func ManageClientCABundle(ctx context.Context, lister corev1listers.ConfigMapLis
 		return caBundleConfigMap, true, nil
 	} else if updateRequired {
 		caBundleConfigMap, err = client.ConfigMaps(operatorclient.TargetNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			// ignore error if its attempting to update outdated version of the resource
+			return nil, false, nil
+		}
 		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
 		if err != nil {
 			return nil, false, err
@@ -474,6 +478,10 @@ func manageKubeAPIServerCABundle(ctx context.Context, lister corev1listers.Confi
 		return caBundleConfigMap, true, nil
 	} else if updateRequired {
 		caBundleConfigMap, err := client.ConfigMaps(operatorclient.TargetNamespace).Update(ctx, requiredConfigMap, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			// ignore error if its attempting to update outdated version of the resource
+			return nil, false, nil
+		}
 		resourcehelper.ReportUpdateEvent(recorder, caBundleConfigMap, err)
 		if err != nil {
 			return nil, false, err


### PR DESCRIPTION
When update has returned a conflict error don't emit an event for this, as it may happen due to two replicas working on the same resource