### PR TITLE
NO-ISSUE: pkg/operator/kubeletversionskewcontroller: Explicit next OpenShift version in skew message

### DIFF
--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
@@ -59,6 +59,7 @@ func NewKubeletVersionSkewController(
 		apiServerVersion:            semver.MustParse(status.VersionForOperandFromEnv()),
 		minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(openShiftVersion),
 		minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
+		nextOpenShiftVersion:        nextOpenShiftVersion,
 	}
 	c.Controller = factory.New().
 		WithSync(c.sync).
@@ -85,6 +86,7 @@ type kubeletVersionSkewController struct {
 	apiServerVersion            semver.Version
 	minSupportedSkew            int
 	minSupportedSkewNextVersion int
+	nextOpenShiftVersion        semver.Version
 }
 
 func (c *kubeletVersionSkewController) sync(ctx context.Context, _ factory.SyncContext) error {
@@ -181,22 +183,22 @@ func (c *kubeletVersionSkewController) sync(ctx context.Context, _ factory.SyncC
 		condition.Status = operatorv1.ConditionFalse
 		switch len(skewedLimit) {
 		case 1:
-			condition.Message = fmt.Sprintf("Kubelet version (%v) on node %s will not be supported in the next OpenShift version upgrade.", skewedLimit.version(), skewedLimit.nodes())
+			condition.Message = fmt.Sprintf("Kubelet minor version (%v) on node %s will not be supported in the next OpenShift version upgrade to %d.%d.", skewedLimit.version(), skewedLimit.nodes(), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Kubelet versions on nodes %s will not be supported in the next OpenShift version upgrade.", skewedLimit.nodes())
+			condition.Message = fmt.Sprintf("Kubelet minor versions on nodes %s will not be supported in the next OpenShift version upgrade to %d.%d.", skewedLimit.nodes(), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		default:
-			condition.Message = fmt.Sprintf("Kubelet versions on %d nodes will not be supported in the next OpenShift version upgrade.", len(skewedLimit))
+			condition.Message = fmt.Sprintf("Kubelet minor versions on %d nodes will not be supported in the next OpenShift version upgrade to %d.%d.", len(skewedLimit), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		}
 	case len(skewedButOK) > 0:
 		condition.Reason = KubeletMinorVersionSupportedNextUpgradeReason
 		condition.Status = operatorv1.ConditionTrue
 		switch len(skewedButOK) {
 		case 1:
-			condition.Message = fmt.Sprintf("Kubelet version (%v) on node %s is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.", skewedButOK.version(), skewedButOK.nodes())
+			condition.Message = fmt.Sprintf("Kubelet version (%v) on node %s is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade to %d.%d.", skewedButOK.version(), skewedButOK.nodes(), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Kubelet versions on nodes %s are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade.", skewedButOK.nodes())
+			condition.Message = fmt.Sprintf("Kubelet versions on nodes %s are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade to %d.%d.", skewedButOK.nodes(), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		default:
-			condition.Message = fmt.Sprintf("Kubelet versions on %d nodes are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade.", len(skewedButOK))
+			condition.Message = fmt.Sprintf("Kubelet versions on %d nodes are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade to %d.%d.", len(skewedButOK), c.nextOpenShiftVersion.Major, c.nextOpenShiftVersion.Minor)
 		}
 	default:
 		condition.Reason = KubeletMinorVersionSyncedReason

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
@@ -65,7 +65,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet version (1.20.1) on node test001 will not be supported in the next OpenShift version upgrade.",
+			expectedMsgLines: "Kubelet minor version (1.20.1) on node test001 will not be supported in the next OpenShift version upgrade to 4.9.",
 		},
 		{
 			name:             "UnsupportedNextUpgrade/Odd",
@@ -81,7 +81,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet versions on nodes test001 and test002 will not be supported in the next OpenShift version upgrade.",
+			expectedMsgLines: "Kubelet minor versions on nodes test001 and test002 will not be supported in the next OpenShift version upgrade to 4.9.",
 		},
 		{
 			name:             "ThreeNodesNotSynced",
@@ -89,7 +89,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet versions on nodes test001, test002, and test003 will not be supported in the next OpenShift version upgrade.",
+			expectedMsgLines: "Kubelet minor versions on nodes test001, test002, and test003 will not be supported in the next OpenShift version upgrade to 4.9.",
 		},
 		{
 			name:             "ManyNodesNotSynced",
@@ -97,7 +97,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1, -1, -1, 0, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet versions on 5 nodes will not be supported in the next OpenShift version upgrade.",
+			expectedMsgLines: "Kubelet minor versions on 5 nodes will not be supported in the next OpenShift version upgrade to 4.9.",
 		},
 		{
 			name:             "SkewedUnsupported/Even",
@@ -121,7 +121,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(-1, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.",
+			expectedMsgLines: "Kubelet version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade to 4.10.",
 		},
 		{
 			name:             "Unsupported",
@@ -153,6 +153,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 				apiServerVersion:            semver.MustParse(apiServerVersion),
 				minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(ocpVersion),
 				minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
+				nextOpenShiftVersion:        semver.Version{Major: ocpVersion.Major, Minor: ocpVersion.Minor + 1},
 			}
 			err := c.sync(nil, nil)
 			if err != nil {


### PR DESCRIPTION
Explicitly name the next OpenShift version, to reduce the chances that cluster administrators think the message applies to a currently in-progress update, when `Upgradeable` is only talking about future updates.