### PR TITLE
[WIP]: OCPBUGS-39241: Rate-limit RequiredInstallerResourcesMissing events in InstallerController to prevent SNO upgrade test failures

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,25 @@
+diff --no-dereference -N -r current/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go updated/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+10d9
+< 	"sort"
+122d120
+< 	lastMissingEvent         map[string]time.Time
+1124,1140c1122
+< 	sort.Strings(eventMessages)
+< 	key := strings.Join(eventMessages, ",")
+< 
+< 	if c.lastMissingEvent == nil {
+< 		c.lastMissingEvent = make(map[string]time.Time)
+< 	}
+< 
+< 	now := time.Now()
+< 	if c.now != nil {
+< 		now = c.now()
+< 	}
+< 
+< 	if lastTime, exists := c.lastMissingEvent[key]; !exists || now.Sub(lastTime) > 30*time.Second {
+< 		c.eventRecorder.Warningf("RequiredInstallerResourcesMissing", strings.Join(eventMessages, ", "))
+< 		c.lastMissingEvent[key] = now
+< 	}
+< 
+---
+> 	c.eventRecorder.Warningf("RequiredInstallerResourcesMissing", strings.Join(eventMessages, ", "))

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/installer/installer_controller.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -118,6 +119,7 @@ type InstallerController struct {
 	podOperatorStatusApplied bool
 	// resource version of the last StaticPodOperatorStatus applied
 	lastPodOperatorAppliedRV uint64
+	lastMissingEvent         map[string]time.Time
 }
 
 // InstallerPodMutationFunc is a function that has a chance at changing the installer pod before it is created
@@ -1119,7 +1121,23 @@ func (c InstallerController) ensureRequiredResourcesExist(ctx context.Context, r
 	for _, err := range aggregatedErr.Errors() {
 		eventMessages = append(eventMessages, err.Error())
 	}
-	c.eventRecorder.Warningf("RequiredInstallerResourcesMissing", strings.Join(eventMessages, ", "))
+	sort.Strings(eventMessages)
+	key := strings.Join(eventMessages, ",")
+
+	if c.lastMissingEvent == nil {
+		c.lastMissingEvent = make(map[string]time.Time)
+	}
+
+	now := time.Now()
+	if c.now != nil {
+		now = c.now()
+	}
+
+	if lastTime, exists := c.lastMissingEvent[key]; !exists || now.Sub(lastTime) > 30*time.Second {
+		c.eventRecorder.Warningf("RequiredInstallerResourcesMissing", strings.Join(eventMessages, ", "))
+		c.lastMissingEvent[key] = now
+	}
+
 	return fmt.Errorf("missing required resources: %v", aggregatedErr)
 }
 


### PR DESCRIPTION
rate-limit RequiredInstallerResourcesMissing events in InstallerController

During SNO upgrades, the installer would emit a flood of
RequiredInstallerResourcesMissing events for transient missing secrets
and configmaps, causing the [bz-etcd] pathological test to fail.

This patch adds a 30-second rate-limit per unique set of missing resources:
- Events for the same missing set are only emitted once per 30 seconds.
- Aggregated errors are still returned to trigger retries.
- Uses InstallerController.now() for testable timestamps.
- lastMissingEvent map tracks last emission times per missing resource set.

This prevents event spam while preserving retry logic and ensures
transient missing resources are still detected correctly.