### PR TITLE
CNTRLPLANE-1544: scc: Grant authenticated users use of restricted-v3

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_crb-systemauthenticated-scc-restricted-v3.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_crb-systemauthenticated-scc-restricted-v3.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: system:openshift:scc:restricted-v3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:restricted-v3
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated


### PR DESCRIPTION
Taking over https://github.com/openshift/cluster-kube-apiserver-operator/pull/1935

There is a missing `ClusterRoleBinding` that should have been added with `restricted-v3`.

Related tests change: https://github.com/openshift/origin/pull/30384