### PR TITLE
NO-JIRA: Update the deprecated API usage alerts for 1.34

### DIFF
--- a/bindata/assets/alerts/api-usage.yaml
+++ b/bindata/assets/alerts/api-usage.yaml
@@ -16,7 +16,7 @@ spec:
               a successful upgrade to the next cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: >-
-            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release="1.34"})
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release="1.35"})
             * on (group,version,resource) group_left ()
             sum by (group,version,resource) (
             rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])
@@ -34,7 +34,7 @@ spec:
               a successful upgrade to the next EUS cluster version with Kubernetes {{ $labels.removed_release }}.
               Refer to `oc get apirequestcounts {{ $labels.resource }}.{{ $labels.version }}.{{ $labels.group }} -o yaml` to identify the workload.
           expr: >-
-            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release=~"1.3[45]"})
+            group by (group,version,resource,removed_release) (apiserver_requested_deprecated_apis{removed_release=~"1.35"})
             * on (group,version,resource) group_left ()
             sum by (group,version,resource) (
             rate(apiserver_request_total{system_client!="kube-controller-manager",system_client!="cluster-policy-controller"}[4h])


### PR DESCRIPTION
OpenShift 4.21 is an EUS release based on Kubernetes 1.34, so the EUS alert needs to fire for Kubernetes 1.35 and 1.36 removals.

Based on https://github.com/openshift/cluster-kube-apiserver-operator/commit/75a86cc8ced1e255b5a6fe493cab0e833b40a9e1