### PR TITLE
OCPBUGS-77004: scc: restricted-v3: Fix runAsUser range

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v3.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v3.yaml
@@ -37,9 +37,8 @@ requiredDropCapabilities:
 - ALL
 runAsUser:
   type: MustRunAsRange
-  ranges:
-  - min: 1000
-    max: 65534
+  uidRangeMin: 1000
+  uidRangeMax: 65534
 seLinuxContext:
   type: MustRunAs
 seccompProfiles:


### PR DESCRIPTION
## Issue

`restricted-v3` is made for user namespaces, which require UID to be between 1000 and 65534. Yet:

```
 message: 'pods "sleep-94cf4ff7d-" is forbidden: unable to validate against any
        security context constraint: provider restricted-v3: .containers[0].runAsUser:
        Invalid value: 1000: must be in the ranges: [1000740000, 1000749999]'
```

## Fix

`runAsUser` does not use `ranges.min` and `ranges.max`,
rather the right keys are `uidRangeMin` and `uidRangeMax`.

```
$ k explain scc.runAsUser     
GROUP:      security.openshift.io
KIND:       SecurityContextConstraints
VERSION:    v1

FIELD: runAsUser <RunAsUserStrategyOptions>


DESCRIPTION:
    RunAsUser is the strategy that will dictate what RunAsUser is used in the
    SecurityContext.
    RunAsUserStrategyOptions defines the strategy type and any options used to
    create the strategy.
    
FIELDS:
  type  <string>
    Type is the strategy that will dictate what RunAsUser is used in the
    SecurityContext.

  uid   <integer>
    UID is the user id that containers must run as.  Required for the MustRunAs
    strategy if not using namespace/service account allocated uids.

  uidRangeMax   <integer>
    UIDRangeMax defines the max value for a strategy that allocates by range.

  uidRangeMin   <integer>
    UIDRangeMin defines the min value for a strategy that allocates by range.

```

## Testing

Tested this manually on a ClusterBot cluster.