### PR TITLE
OCPBUGS-65755: Stop serving VolumeAttributesClass v1beta1

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -28,7 +28,6 @@ var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVers
 		{KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.35.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}},
 		{KubeVersionRange: semver.MustParseRange(">=1.34.0 <1.35.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}},
 	},
-	"VolumeAttributesClass": {{GroupVersion: schema.GroupVersion{Group: "storage.k8s.io", Version: "v1beta1"}}},
 }
 
 type groupVersionByOpenshiftVersion struct {


### PR DESCRIPTION
Version v1 is available in Kubernetes 1.34.

/assign @benluddy 