### PR TITLE
[release-4.20] OCPBUGS-62057: OpenShift cluster got degraded after rotating the kube-apiserver-service-network-signer cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
-	github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+	github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e h1:xYT+P++PSc9G+Y47pIcU9fm8IDV/tg6tMi3i+0m23pU=
-github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc h1:g9BJ/p4ZLgb253FwnWvWEzl2vYSDSvvUZ6s42weVKpM=
+github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -164,6 +164,11 @@ func needNewTargetCertKeyPair(secret *corev1.Secret, signer *crypto.CA, caBundle
 		return reason
 	}
 
+	// Exit early if we're only refreshing when expired and the certificate does not need an update
+	if refreshOnlyWhenExpired {
+		return ""
+	}
+
 	// check the signer common name against all the common names in our ca bundle so we don't refresh early
 	signerCommonName := annotations[CertificateIssuer]
 	if len(signerCommonName) == 0 {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -147,7 +147,7 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyNetworkPolicy(ctx, clients.kubeClient.NetworkingV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyNetworkPolicy(ctx, clients.kubeClient.NetworkingV1(), recorder, t, cache)
 			}
 		case *rbacv1.ClusterRole:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/networking.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/networking.go
@@ -15,27 +15,36 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
-// ApplyClusterRole merges objectmeta, does not worry about anything else
-func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPoliciesGetter, recorder events.Recorder, required *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, bool, error) {
+// ApplyNetworkPolicy merges objectmeta and requires spec
+func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPoliciesGetter, recorder events.Recorder, required *networkingv1.NetworkPolicy, cache ResourceCache) (*networkingv1.NetworkPolicy, bool, error) {
 	existing, err := client.NetworkPolicies(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
 		actual, err := client.NetworkPolicies(required.Namespace).Create(
 			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*networkingv1.NetworkPolicy), metav1.CreateOptions{})
 		resourcehelper.ReportCreateEvent(recorder, required, err)
+		cache.UpdateCachedResourceMetadata(required, actual)
 		return actual, true, err
 	}
 	if err != nil {
 		return nil, false, err
 	}
 
+	if cache.SafeToSkipApply(required, existing) {
+		return existing, false, nil
+	}
+
 	modified := false
 	existingCopy := existing.DeepCopy()
 
 	resourcemerge.EnsureObjectMeta(&modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec) && !modified {
+	specContentSame := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+	if specContentSame && !modified {
+		cache.UpdateCachedResourceMetadata(required, existingCopy)
 		return existingCopy, false, nil
 	}
+
+	existingCopy.Spec = required.Spec
 
 	if klog.V(2).Enabled() {
 		klog.Infof("NetworkPolicy %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
@@ -43,6 +52,7 @@ func ApplyNetworkPolicy(ctx context.Context, client networkingclientv1.NetworkPo
 
 	actual, err := client.NetworkPolicies(existingCopy.Namespace).Update(ctx, existingCopy, metav1.UpdateOptions{})
 	resourcehelper.ReportUpdateEvent(recorder, required, err)
+	cache.UpdateCachedResourceMetadata(required, actual)
 	return actual, true, err
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -142,6 +142,9 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 	if required.Annotations == nil {
 		required.Annotations = map[string]string{}
 	}
+	if required.Labels == nil {
+		required.Labels = map[string]string{}
+	}
 	if err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec); err != nil {
 		return nil, false, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func ReadNetworkPolicyV1OrDie(objBytes []byte) *networkingv1.NetworkPolicy {
-	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(netCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -400,7 +400,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20250729191057-91376e1b394e
+# github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/cluster-kube-apiserver-operator/pull/1928.
Simply a bump of library-go.