### PR TITLE
OCPBUGS-65807: SCC: allow image volume type for all SCCs

### DIFF
--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
@@ -39,6 +39,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
@@ -44,6 +44,7 @@ volumes:
 - emptyDir
 - ephemeral
 - hostPath
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid-v2.yaml
@@ -41,6 +41,7 @@ volumes:
 - emptyDir
 - ephemeral
 - hostPath
+- image
 - nfs
 - persistentVolumeClaim
 - projected

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
@@ -43,6 +43,7 @@ volumes:
 - emptyDir
 - ephemeral
 - hostPath
+- image
 - nfs
 - persistentVolumeClaim
 - projected

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork-v2.yaml
@@ -44,6 +44,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
@@ -42,6 +42,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nested-container.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nested-container.yaml
@@ -56,6 +56,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot-v2.yaml
@@ -45,6 +45,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
@@ -42,6 +42,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml
@@ -44,6 +44,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v3.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v3.yaml
@@ -56,6 +56,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret

--- a/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
+++ b/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted.yaml
@@ -41,6 +41,7 @@ volumes:
 - downwardAPI
 - emptyDir
 - ephemeral
+- image
 - persistentVolumeClaim
 - projected
 - secret


### PR DESCRIPTION
image volume should be safe for all, because the user could just package the image volume into their image itself at build time anyway.