### PR TITLE
OCPBUGS-66136: certregenerationcontroller: Add cache sync timeout

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cabundlesyncer.go
+++ b/pkg/cmd/certregenerationcontroller/cabundlesyncer.go
@@ -86,7 +86,12 @@ func (c *CABundleController) Run(ctx context.Context) {
 		klog.Info("CA bundle controller shut down")
 	}()
 
-	if !cache.WaitForNamedCacheSync("CABundleController", ctx.Done(), c.cachesToSync...) {
+	syncCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	if !cache.WaitForNamedCacheSync("CABundleController", syncCtx.Done(), c.cachesToSync...) {
+		if ctx.Err() == nil {
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
 		return
 	}
 

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes"
@@ -920,13 +919,16 @@ func newCertRotationController(
 	return ret, nil
 }
 
-func (c *CertRotationController) WaitForReady(stopCh <-chan struct{}) {
+func (c *CertRotationController) mustWaitForReady(ctx context.Context) {
 	klog.Infof("Waiting for CertRotation")
 	defer klog.Infof("Finished waiting for CertRotation")
 
-	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
-		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
-		return
+	syncCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	if !cache.WaitForNamedCacheSync("CertRotationController", syncCtx.Done(), c.cachesToSync...) {
+		if ctx.Err() == nil {
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
 	}
 
 	// need to sync at least once before beginning.  if we fail, we cannot start rotating certificates
@@ -958,7 +960,8 @@ func (c *CertRotationController) RunOnce() error {
 func (c *CertRotationController) Run(ctx context.Context, workers int) {
 	klog.Infof("Starting CertRotation")
 	defer klog.Infof("Shutting down CertRotation")
-	c.WaitForReady(ctx.Done())
+
+	c.mustWaitForReady(ctx)
 
 	go wait.Until(c.runServiceHostnames, time.Second, ctx.Done())
 	go wait.Until(c.runExternalLoadBalancerHostnames, time.Second, ctx.Done())


### PR DESCRIPTION
This critical controller can get stuck on cache sync when the 
certificates expire. Crashing when the initial cache sync times out 
should improve the situation.

There is now a hard-coded 2-minute timeout after which the controllers call `os.Exit(1)` from within their `Run` functions when caches don't manage to sync in time. This also improves the visibility of the issue as the container doesn't seem to be running just fine.

---

This change is based on seeing a client case where the recovery controller got stuck for 16 days before it got terminated.