### PR TITLE
NO-JIRA: increases termination timeouts for GCP

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -44,6 +44,24 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 		//
 		// Note this is the official number we got from AWS
 		observedShutdownDelayDuration = "129s"
+	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
+		// We are receiving inconsistent information from the GCP support team.
+		// In some responses, they confirm an additional ~60s delay in traffic propagation,
+		// while in others they state that no such delay exists.
+		//
+		// Regardless of the mixed messaging, we consistently observe late requests in CI.
+		// The latest request observed arrived at 67s with the previous 70s timeout.
+		//
+		// Based on real observations, we update the timeout so that:
+		// 0.8 × NEW_LIMIT ≥ 67s.
+		//
+		// Therefore, the new timeout is set to 95s,
+		// which includes an additional 10s safety buffer to account for timing variance
+		// and ensure late requests do not cross the 80% threshold.
+		//
+		// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
+		// See: https://issues.redhat.com/browse/OCPBUGS-61674
+		observedShutdownDelayDuration = "95s"
 	default:
 		// don't override default value
 		return map[string]interface{}{}, errs
@@ -106,6 +124,15 @@ func ObserveGracefulTerminationDuration(genericListers configobserver.Listers, _
 		//   additional 60s for finishing all in-flight requests
 		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
 		observedGracefulTerminationDuration = "194"
+	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
+		// 160s is calculated as follows:
+		//   the initial 95s is reserved fo the minimal termination period - the time needed for an LB to take an instance out of rotation
+		//   additional 60s for finishing all in-flight requests
+		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
+		//
+		// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
+		// See: https://issues.redhat.com/browse/OCPBUGS-61674
+		observedGracefulTerminationDuration = "160"
 	default:
 		// don't override default value
 		return map[string]interface{}{}, errs

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -45,7 +45,7 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 
 		// scenario 3
 		{
-			name:                  "the shutdown-delay-duration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
+			name:                  "the gracefulTerminationDuration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
 			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "194"},
 			platformType:          configv1.AWSPlatformType,
@@ -53,17 +53,25 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 
 		// scenario 4
 		{
-			name:                  "sno: shutdown-delay-duration reduced to 0s",
+			name:                  "sno: gracefulTerminationDuration reduced to 0s",
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 		},
 
-		// scenario 4
+		// scenario 5
 		{
 			name:                  "sno takes precedence over platform type",
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 			platformType:          configv1.AWSPlatformType,
+		},
+
+		// scenario 6
+		{
+			name:                  "the gracefulTerminationDuration is extended due to additional delay time needed on GCP see: https://issues.redhat.com/browse/OCPBUGS-61674",
+			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "70"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "160"},
+			platformType:          configv1.GCPPlatformType,
 		},
 	}
 
@@ -177,6 +185,23 @@ func TestObserveShutdownDelayDuration(t *testing.T) {
 			},
 			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
 			platformType:         configv1.AWSPlatformType,
+		},
+
+		// scenario 6
+		{
+			name: "the shutdown-delay-duration is extended due to additional delay time needed on GCP see: https://issues.redhat.com/browse/OCPBUGS-61674",
+			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
+				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
+				if len(shutdownDurationArgs) != 1 {
+					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
+				}
+				if shutdownDurationArgs[0] != "95s" {
+					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 95s, got %v", shutdownDurationArgs[0])
+				}
+				return nil
+			},
+			existingConfig: kubecontrolplanev1.KubeAPIServerConfig{APIServerArguments: map[string]kubecontrolplanev1.Arguments{"shutdown-delay-duration": {"70s"}}},
+			platformType:   configv1.GCPPlatformType,
 		},
 	}
 


### PR DESCRIPTION
```
// We are receiving inconsistent information from the GCP support team.
// In some responses, they confirm an additional ~60s delay in traffic propagation,
// while in others they state that no such delay exists.
//
// Regardless of the mixed messaging, we consistently observe late requests in CI.
// The latest request observed arrived at 67s with the previous 70s timeout.
//
// Based on real observations, we update the timeout so that:
// 0.8 × NEW_LIMIT ≥ 67s.
//
// Therefore, the new timeout is set to 95s,
// which includes an additional 10s safety buffer to account for timing variance
// and ensure late requests do not cross the 80% threshold.
//
// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
// See: https://issues.redhat.com/browse/OCPBUGS-61674
```


in the past we had a similar change for AWS (https://github.com/openshift/cluster-kube-apiserver-operator/pull/1079)


This issue addresses https://issues.redhat.com/browse/OCPBUGS-61674. Let's merge it on the master branch first and then backport to 4.21 once we have a positive signal.
