### PR TITLE
Testing Only

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -44,24 +44,6 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 		//
 		// Note this is the official number we got from AWS
 		observedShutdownDelayDuration = "129s"
-	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
-		// We are receiving inconsistent information from the GCP support team.
-		// In some responses, they confirm an additional ~60s delay in traffic propagation,
-		// while in others they state that no such delay exists.
-		//
-		// Regardless of the mixed messaging, we consistently observe late requests in CI.
-		// The latest request observed arrived at 67s with the previous 70s timeout.
-		//
-		// Based on real observations, we update the timeout so that:
-		// 0.8 × NEW_LIMIT ≥ 67s.
-		//
-		// Therefore, the new timeout is set to 95s,
-		// which includes an additional 10s safety buffer to account for timing variance
-		// and ensure late requests do not cross the 80% threshold.
-		//
-		// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
-		// See: https://issues.redhat.com/browse/OCPBUGS-61674
-		observedShutdownDelayDuration = "95s"
 	default:
 		// don't override default value
 		return map[string]interface{}{}, errs
@@ -124,15 +106,6 @@ func ObserveGracefulTerminationDuration(genericListers configobserver.Listers, _
 		//   additional 60s for finishing all in-flight requests
 		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
 		observedGracefulTerminationDuration = "194"
-	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
-		// 160s is calculated as follows:
-		//   the initial 95s is reserved fo the minimal termination period - the time needed for an LB to take an instance out of rotation
-		//   additional 60s for finishing all in-flight requests
-		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
-		//
-		// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
-		// See: https://issues.redhat.com/browse/OCPBUGS-61674
-		observedGracefulTerminationDuration = "160"
 	default:
 		// don't override default value
 		return map[string]interface{}{}, errs

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -45,7 +45,7 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 
 		// scenario 3
 		{
-			name:                  "the gracefulTerminationDuration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
+			name:                  "the shutdown-delay-duration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
 			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "194"},
 			platformType:          configv1.AWSPlatformType,
@@ -53,25 +53,17 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 
 		// scenario 4
 		{
-			name:                  "sno: gracefulTerminationDuration reduced to 0s",
+			name:                  "sno: shutdown-delay-duration reduced to 0s",
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 		},
 
-		// scenario 5
+		// scenario 4
 		{
 			name:                  "sno takes precedence over platform type",
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "15"},
 			controlPlaneTopology:  configv1.SingleReplicaTopologyMode,
 			platformType:          configv1.AWSPlatformType,
-		},
-
-		// scenario 6
-		{
-			name:                  "the gracefulTerminationDuration is extended due to additional delay time needed on GCP see: https://issues.redhat.com/browse/OCPBUGS-61674",
-			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "70"},
-			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "160"},
-			platformType:          configv1.GCPPlatformType,
 		},
 	}
 
@@ -185,23 +177,6 @@ func TestObserveShutdownDelayDuration(t *testing.T) {
 			},
 			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
 			platformType:         configv1.AWSPlatformType,
-		},
-
-		// scenario 6
-		{
-			name: "the shutdown-delay-duration is extended due to additional delay time needed on GCP see: https://issues.redhat.com/browse/OCPBUGS-61674",
-			validateKubeAPIConfigFn: func(actualKasConfig kubecontrolplanev1.KubeAPIServerConfig) error {
-				shutdownDurationArgs := actualKasConfig.APIServerArguments["shutdown-delay-duration"]
-				if len(shutdownDurationArgs) != 1 {
-					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
-				}
-				if shutdownDurationArgs[0] != "95s" {
-					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 95s, got %v", shutdownDurationArgs[0])
-				}
-				return nil
-			},
-			existingConfig: kubecontrolplanev1.KubeAPIServerConfig{APIServerArguments: map[string]kubecontrolplanev1.Arguments{"shutdown-delay-duration": {"70s"}}},
-			platformType:   configv1.GCPPlatformType,
 		},
 	}
 


### PR DESCRIPTION
Reverts openshift/cluster-kube-apiserver-operator#1982


After the revert and backport to 4.21 for the issues tracked in [OCPBUGS-66420](https://issues.redhat.com/browse/OCPBUGS-66420) we still see some of the [disruption](https://sippy.dptools.openshift.org/sippy-ng/job_runs/2000034077717041152/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-upgrade-fips/intervals?end=2025-12-14T05%3A56%3A58Z&filterText=&intervalFile=e2e-timelines_spyglass_20251214-044204.json&overrideDisplayFlag=0&selectedSources=OperatorAvailable&selectedSources=OperatorProgressing&selectedSources=OperatorDegraded&selectedSources=KubeletLog&selectedSources=EtcdLog&selectedSources=EtcdLeadership&selectedSources=Disruption&selectedSources=E2EFailed&selectedSources=APIServerGracefulShutdown&selectedSources=KubeEvent&selectedSources=NodeState&selectedSources=CPUMonitor&selectedSources=E2EPassed&start=2025-12-14T05%3A42%3A43Z) in 4.22 and not 4.21.  We also see [66 minute intervals](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-upgrade-fips/2000817329109209088) of `APIServerGracefulShutdown` 

Looking at the [diff](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2025-12-14-223107?from=4.21.0-0.nightly-2025-12-15-125449) between 4.22 and 4.21 this PR is interesting enough that we want to `/payload` test against the revert.