### PR TITLE
CNTRLPLANE-2286:Migrating serviceaccountissuer test to ote

### DIFF
--- a/test/e2e/serviceaccountissuer.go
+++ b/test/e2e/serviceaccountissuer.go
@@ -1,0 +1,124 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	testlibrary "github.com/openshift/library-go/test/library"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	g "github.com/onsi/ginkgo/v2"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+)
+
+const (
+	saInterval       = 1 * time.Second
+	saRegularTimeout = 30 * time.Second
+)
+
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
+	g.It("[Operator][Serial] serviceaccountissuer set in authentication config results in apiserver config", func() {
+		testServiceAccountIssuerFirstIssuer(g.GinkgoTB())
+	})
+
+	g.It("[Operator][Serial] second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func() {
+		testServiceAccountIssuerSecondIssuer(g.GinkgoTB())
+	})
+
+	g.It("[Operator][Serial] no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func() {
+		testServiceAccountIssuerDefaultIssuer(g.GinkgoTB())
+	})
+})
+
+func testServiceAccountIssuerFirstIssuer(t testing.TB) {
+	kubeConfig, err := testlibrary.NewClientConfigForTest()
+	require.NoError(t, err)
+
+	kubeClient, err := clientcorev1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	authConfigClient, err := configv1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	setServiceAccountIssuer(t, authConfigClient, "https://first.foo.bar")
+	err = pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar", "https://kubernetes.default.svc"})
+	require.NoError(t, err, "pollForOperandIssuer failed")
+}
+
+func testServiceAccountIssuerSecondIssuer(t testing.TB) {
+	kubeConfig, err := testlibrary.NewClientConfigForTest()
+	require.NoError(t, err)
+
+	kubeClient, err := clientcorev1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	authConfigClient, err := configv1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	setServiceAccountIssuer(t, authConfigClient, "https://second.foo.bar")
+	err = pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar", "https://kubernetes.default.svc"})
+	require.NoError(t, err, "pollForOperandIssuer failed")
+}
+
+func testServiceAccountIssuerDefaultIssuer(t testing.TB) {
+	kubeConfig, err := testlibrary.NewClientConfigForTest()
+	require.NoError(t, err)
+
+	kubeClient, err := clientcorev1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	authConfigClient, err := configv1.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	setServiceAccountIssuer(t, authConfigClient, "")
+	err = pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc"})
+	require.NoError(t, err, "pollForOperandIssuer failed")
+}
+
+func pollForOperandIssuer(t testing.TB, client clientcorev1.CoreV1Interface, expectedIssuers []string) error {
+	return wait.PollImmediate(saInterval, saRegularTimeout, func() (done bool, err error) {
+		configMap, err := client.ConfigMaps(operatorclient.TargetNamespace).Get(context.TODO(), "config", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("failed to retrieve apiserver config configmap: %v", err)
+			return false, nil
+		}
+		// key has a .yaml extension but actual format is json
+		rawConfig := configMap.Data["config.yaml"]
+		if len(rawConfig) == 0 {
+			t.Logf("config.yaml is empty in apiserver config configmap")
+			return false, nil
+		}
+		config := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer([]byte(rawConfig))).Decode(&config); err != nil {
+			t.Errorf("error parsing config, %v", err)
+			return false, nil
+		}
+		issuers, found, err := unstructured.NestedStringSlice(config, "apiServerArguments", "service-account-issuer")
+		if !found {
+			t.Log("apiServerArguments.service-account-issuer not found in config")
+			return false, nil
+		}
+		if !found || !reflect.DeepEqual(expectedIssuers, issuers) {
+			t.Logf("expected service account issuers to be %#v, got %#v", expectedIssuers, issuers)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func setServiceAccountIssuer(t testing.TB, client configv1.ConfigV1Interface, issuer string) {
+	auth, err := client.Authentications().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	auth.Spec.ServiceAccountIssuer = issuer
+	_, err = client.Authentications().Update(context.TODO(), auth, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}

--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -1,90 +1,32 @@
 package e2e
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"reflect"
 	"testing"
-
-	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	testlibrary "github.com/openshift/library-go/test/library"
-	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/wait"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 )
 
-func TestServiceAccountIssuer(t *testing.T) {
-	kubeConfig, err := testlibrary.NewClientConfigForTest()
-	require.NoError(t, err)
-
-	kubeClient, err := clientcorev1.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-
-	authConfigClient, err := configv1.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-
-	t.Run("serviceaccountissuer set in authentication config results in apiserver config", func(t *testing.T) {
-		setServiceAccountIssuer(t, authConfigClient, "https://first.foo.bar")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
-			t.Errorf("pollForOperandIssuer failed: %v", err)
-		}
-	})
-
-	t.Run("second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func(t *testing.T) {
-		setServiceAccountIssuer(t, authConfigClient, "https://second.foo.bar")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://second.foo.bar", "https://first.foo.bar", "https://kubernetes.default.svc"}); err != nil {
-			t.Errorf("pollForOperandIssuer failed: %v", err)
-		}
-	})
-
-	t.Run("no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func(t *testing.T) {
-		setServiceAccountIssuer(t, authConfigClient, "")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc"}); err != nil {
-			t.Errorf("pollForOperandIssuer failed: %v", err)
-		}
-	})
-
-}
-func pollForOperandIssuer(t *testing.T, client clientcorev1.CoreV1Interface, expectedIssuers []string) error {
-	return wait.PollImmediate(interval, regularTimeout, func() (done bool, err error) {
-		configMap, err := client.ConfigMaps(operatorclient.TargetNamespace).Get(context.TODO(), "config", metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("failed to retrieve apiserver config configmap: %v", err)
-			return false, nil
-		}
-		// key has a .yaml extension but actual format is json
-		rawConfig := configMap.Data["config.yaml"]
-		if len(rawConfig) == 0 {
-			t.Logf("config.yaml is empty in apiserver config configmap")
-			return false, nil
-		}
-		config := map[string]interface{}{}
-		if err := json.NewDecoder(bytes.NewBuffer([]byte(rawConfig))).Decode(&config); err != nil {
-			t.Errorf("error parsing config, %v", err)
-			return false, nil
-		}
-		issuers, found, err := unstructured.NestedStringSlice(config, "apiServerArguments", "service-account-issuer")
-		if !found {
-			t.Log("apiServerArguments.service-account-issuer not found in config")
-			return false, nil
-		}
-		if !found || !reflect.DeepEqual(expectedIssuers, issuers) {
-			t.Logf("expected service account issuers to be %#v, got %#v", expectedIssuers, issuers)
-			return false, nil
-		}
-		return true, nil
-	})
+// This test calls the shared  function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
+func TestServiceAccountIssuerFirstIssuer(t *testing.T) {
+	testServiceAccountIssuerFirstIssuer(t)
 }
 
-func setServiceAccountIssuer(t *testing.T, client configv1.ConfigV1Interface, issuer string) {
-	auth, err := client.Authentications().Get(context.TODO(), "cluster", metav1.GetOptions{})
-	require.NoError(t, err)
-	auth.Spec.ServiceAccountIssuer = issuer
-	_, err = client.Authentications().Update(context.TODO(), auth, metav1.UpdateOptions{})
-	require.NoError(t, err)
+// This test calls the shared  function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
+func TestServiceAccountIssuerSecondIssuer(t *testing.T) {
+	testServiceAccountIssuerSecondIssuer(t)
+}
+
+// This test calls the shared  function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
+func TestServiceAccountIssuerDefaultIssuer(t *testing.T) {
+	testServiceAccountIssuerDefaultIssuer(t)
 }


### PR DESCRIPTION
[CNTRLPLANE-2286](https://issues.redhat.com//browse/CNTRLPLANE-2286):Migrating serviceaccountissuer test to ote