### PR TITLE
NO-JIRA:Refactor serviceaccountissuer ginkgo test

### DIFF
--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -14,15 +14,15 @@ import (
 // This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
 // Eventually all tests will be run only as part of the OTE framework.
 func TestServiceAccountIssuer(t *testing.T) {
-	t.Run("serviceaccountissuer set in authentication config results in apiserver config", func(t *testing.T) {
+	t.Run("set a custom serviceAccountIssuer and expect it plus the default in kas config", func(t *testing.T) {
 		testServiceAccountIssuerFirstIssuer(t)
 	})
 
-	t.Run("second serviceaccountissuer set in authentication config results in apiserver config with two issuers", func(t *testing.T) {
+	t.Run("set a second custom issuer and expect both custom issuers plus the default in kas config", func(t *testing.T) {
 		testServiceAccountIssuerSecondIssuer(t)
 	})
 
-	t.Run("no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func(t *testing.T) {
+	t.Run("clear serviceAccountIssuer and expect only the default issuer in kas config", func(t *testing.T) {
 		testServiceAccountIssuerDefaultIssuer(t)
 	})
 }


### PR DESCRIPTION
Summary of Changes to serviceaccountissuer.go

 New Pattern

  g.Describe("serviceaccountissuer", g.Serial, g.Ordered, func() {
      // 1. Setup once in BeforeAll
      var kubeClient, authConfigClient ...
      g.BeforeAll(func() {
          // Initialize clients once
      })

      // 2. Define test cases as data
      testCases := []struct{
          name string
          issuer string
          expectedIssuers []string
      }{
          {name: "first test", issuer: "...", expectedIssuers: ...},
          {name: "second test", issuer: "...", expectedIssuers: ...},
          {name: "third test", issuer: "...", expectedIssuers: ...},
      }

      // 3. Loop to dynamically create g.It() blocks
      for _, tc := range testCases {
          tc := tc // capture range variable
          g.It(tc.name, func() {
              // Test logic using tc.issuer and tc.expectedIssuers
          })
      }
  })

  Benefits

  -3 separate test cases in output (not just 1)
  - Shared setup via BeforeAll (runs once)
  - Sequential execution via g.Serial + g.Ordered
  - 
  What Changed

  1. Removed the 3 separate helper functions (testServiceAccountIssuerFirstIssuer, etc.)
  2. Added BeforeAll for shared client setup
  3. Added test cases array with data-driven approach
  4. Loop dynamically generates g.It() blocks for each test case
  5. Inline test logic directly in the g.It() using test case data