### PR TITLE
CNTRLPLANE-2563: update wording for major upgrades

### DIFF
--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
@@ -35,10 +35,10 @@ const (
 // KubeletVersionSkewController sets Upgradeable=False if the kubelet
 // version on a node prevents upgrading to a supported OpenShift version.
 //
-// For odd OpenShift minor versions, kubelet versions 0 or 1 minor
+// For odd OpenShift versions, kubelet versions 0 or 1 minor
 // versions behind the API server version are supported.
 //
-// For even OpenShift minor versions, kubelet versions 0, 1, or 2
+// For even OpenShift versions, kubelet versions 0, 1, or 2
 // minor versions behind the API server version are supported.
 type KubeletVersionSkewController interface {
 	factory.Controller
@@ -118,8 +118,8 @@ func (c *kubeletVersionSkewController) sync(ctx context.Context, _ factory.SyncC
 			continue
 		}
 		skew := int(kubeletVersion.Minor - c.apiServerVersion.Minor)
-		// Assume that an OpenShift minor version upgrade also bumps to the next kube minor version. Revisit
-		// this in the future if an OpenShift minor version upgrade ever skips or repeats a kube minor version.
+		// Assume that an OpenShift version upgrade also bumps to the next kube version. Revisit
+		// this in the future if an OpenShift version upgrade ever skips or repeats a kube version.
 		skewNextVersion := skew - 1
 		switch {
 		case skew == 0:
@@ -148,22 +148,22 @@ func (c *kubeletVersionSkewController) sync(ctx context.Context, _ factory.SyncC
 		condition.Status = operatorv1.ConditionFalse
 		switch len(skewedUnsupported) {
 		case 1:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor version (%v) on node %s is too far behind the target API server version (%v).", skewedUnsupported.version(), skewedUnsupported.nodes(), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet version (%v) on node %s is too far behind the target API server version (%v).", skewedUnsupported.version(), skewedUnsupported.nodes(), c.apiServerVersion)
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on nodes %s are too far behind the target API server version (%v).", skewedUnsupported.nodes(), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet versions on nodes %s are too far behind the target API server version (%v).", skewedUnsupported.nodes(), c.apiServerVersion)
 		default:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on %d nodes are too far behind the target API server version (%v).", len(skewedUnsupported), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet versions on %d nodes are too far behind the target API server version (%v).", len(skewedUnsupported), c.apiServerVersion)
 		}
 	case len(unsupported) > 0:
 		condition.Reason = KubeletMinorVersionAheadReason
 		condition.Status = operatorv1.ConditionUnknown
 		switch len(unsupported) {
 		case 1:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor version (%v) on node %s is ahead of the target API server version (%v).", unsupported.version(), unsupported.nodes(), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet version (%v) on node %s is ahead of the target API server version (%v).", unsupported.version(), unsupported.nodes(), c.apiServerVersion)
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on nodes %s are ahead of the target API server version (%v).", unsupported.nodes(), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet versions on nodes %s are ahead of the target API server version (%v).", unsupported.nodes(), c.apiServerVersion)
 		default:
-			condition.Message = fmt.Sprintf("Unsupported kubelet minor versions on %d nodes are ahead of the target API server version (%v).", len(unsupported), c.apiServerVersion)
+			condition.Message = fmt.Sprintf("Unsupported Kubelet versions on %d nodes are ahead of the target API server version (%v).", len(unsupported), c.apiServerVersion)
 		}
 	case len(errors) > 0:
 		condition.Reason = KubeletVersionUnknownReason
@@ -181,27 +181,27 @@ func (c *kubeletVersionSkewController) sync(ctx context.Context, _ factory.SyncC
 		condition.Status = operatorv1.ConditionFalse
 		switch len(skewedLimit) {
 		case 1:
-			condition.Message = fmt.Sprintf("Kubelet minor version (%v) on node %s will not be supported in the next OpenShift minor version upgrade.", skewedLimit.version(), skewedLimit.nodes())
+			condition.Message = fmt.Sprintf("Kubelet version (%v) on node %s will not be supported in the next OpenShift version upgrade.", skewedLimit.version(), skewedLimit.nodes())
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Kubelet minor versions on nodes %s will not be supported in the next OpenShift minor version upgrade.", skewedLimit.nodes())
+			condition.Message = fmt.Sprintf("Kubelet versions on nodes %s will not be supported in the next OpenShift version upgrade.", skewedLimit.nodes())
 		default:
-			condition.Message = fmt.Sprintf("Kubelet minor versions on %d nodes will not be supported in the next OpenShift minor version upgrade.", len(skewedLimit))
+			condition.Message = fmt.Sprintf("Kubelet versions on %d nodes will not be supported in the next OpenShift version upgrade.", len(skewedLimit))
 		}
 	case len(skewedButOK) > 0:
 		condition.Reason = KubeletMinorVersionSupportedNextUpgradeReason
 		condition.Status = operatorv1.ConditionTrue
 		switch len(skewedButOK) {
 		case 1:
-			condition.Message = fmt.Sprintf("Kubelet minor version (%v) on node %s is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift minor version upgrade.", skewedButOK.version(), skewedButOK.nodes())
+			condition.Message = fmt.Sprintf("Kubelet version (%v) on node %s is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.", skewedButOK.version(), skewedButOK.nodes())
 		case 2, 3:
-			condition.Message = fmt.Sprintf("Kubelet minor versions on nodes %s are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift minor version upgrade.", skewedButOK.nodes())
+			condition.Message = fmt.Sprintf("Kubelet versions on nodes %s are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade.", skewedButOK.nodes())
 		default:
-			condition.Message = fmt.Sprintf("Kubelet minor versions on %d nodes are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift minor version upgrade.", len(skewedButOK))
+			condition.Message = fmt.Sprintf("Kubelet versions on %d nodes are behind the expected API server version; nevertheless, they will continue to be supported in the next OpenShift version upgrade.", len(skewedButOK))
 		}
 	default:
 		condition.Reason = KubeletMinorVersionSyncedReason
 		condition.Status = operatorv1.ConditionTrue
-		condition.Message = "Kubelet and API server minor versions are synced."
+		condition.Message = "Kubelet and API server versions are synced."
 	}
 
 	_, _, err = v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(condition))

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
@@ -41,7 +41,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSyncedReason,
-			expectedMsgLines: "Kubelet and API server minor versions are synced.",
+			expectedMsgLines: "Kubelet and API server versions are synced.",
 		},
 		{
 			name:             "Synced/Odd",
@@ -49,7 +49,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSyncedReason,
-			expectedMsgLines: "Kubelet and API server minor versions are synced.",
+			expectedMsgLines: "Kubelet and API server versions are synced.",
 		},
 		{
 			name:             "ErrorParsingKubeletVersion",
@@ -65,7 +65,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet minor version (1.20.1) on node test001 will not be supported in the next OpenShift minor version upgrade.",
+			expectedMsgLines: "Kubelet version (1.20.1) on node test001 will not be supported in the next OpenShift version upgrade.",
 		},
 		{
 			name:             "UnsupportedNextUpgrade/Odd",
@@ -73,7 +73,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported kubelet minor version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
 		},
 		{
 			name:             "TwoNodesNotSynced",
@@ -81,7 +81,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet minor versions on nodes test001 and test002 will not be supported in the next OpenShift minor version upgrade.",
+			expectedMsgLines: "Kubelet versions on nodes test001 and test002 will not be supported in the next OpenShift version upgrade.",
 		},
 		{
 			name:             "ThreeNodesNotSynced",
@@ -89,7 +89,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet minor versions on nodes test001, test002, and test003 will not be supported in the next OpenShift minor version upgrade.",
+			expectedMsgLines: "Kubelet versions on nodes test001, test002, and test003 will not be supported in the next OpenShift version upgrade.",
 		},
 		{
 			name:             "ManyNodesNotSynced",
@@ -97,7 +97,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1, -1, -1, 0, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet minor versions on 5 nodes will not be supported in the next OpenShift minor version upgrade.",
+			expectedMsgLines: "Kubelet versions on 5 nodes will not be supported in the next OpenShift version upgrade.",
 		},
 		{
 			name:             "SkewedUnsupported/Even",
@@ -105,7 +105,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -3, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported kubelet minor version (1.18.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.18.1) on node test001 is too far behind the target API server version (1.21.1).",
 		},
 		{
 			name:             "SkewedUnsupported/Odd",
@@ -113,7 +113,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported kubelet minor version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
 		},
 		{
 			name:             "SkewedButOK/Odd",
@@ -121,7 +121,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(-1, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet minor version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift minor version upgrade.",
+			expectedMsgLines: "Kubelet version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.",
 		},
 		{
 			name:             "Unsupported",
@@ -129,7 +129,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			kubeletVersions:  skewedKubeletVersions(0, -1, 1),
 			expectedStatus:   operatorv1.ConditionUnknown,
 			expectedReason:   KubeletMinorVersionAheadReason,
-			expectedMsgLines: "Unsupported kubelet minor version (1.22.2) on node test002 is ahead of the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.22.2) on node test002 is ahead of the target API server version (1.21.1).",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This removes the minor version mention, because it also applies to the next major upgrade.
    
Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates user-facing and comment wording in `kubelet_version_skew_controller` to remove "minor" qualifiers so guidance applies to major upgrades as well.
> 
> - Adjusts condition messages to say "OpenShift version upgrade" and capitalizes "Kubelet"; "Kubelet and API server versions are synced" message updated
> - Clarifies internal comments to refer to OpenShift/kube "versions" rather than "minor versions"
> - Updates tests to match new messages
> 
> No functional/logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6a1c91112ab774865c872170d823e3c125f9ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->