### PR TITLE
CNTRLPLANE-2648:Migrating user_cors_test to OTE

### DIFF
--- a/test/e2e/user_cors.go
+++ b/test/e2e/user_cors.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+
+	g "github.com/onsi/ginkgo/v2"
+	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
+)
+
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
+	g.It("[Operator][Serial] validates CORS with single additional origin", func() {
+		testCORSWithSingleOrigin(g.GinkgoTB())
+	})
+
+	g.It("[Operator][Serial] validates CORS with multiple additional origins", func() {
+		testCORSWithMultipleOrigins(g.GinkgoTB())
+	})
+
+	g.It("[Operator][Serial] validates CORS clearing to defaults", func() {
+		testCORSClearToDefaults(g.GinkgoTB())
+	})
+})
+
+func testCORSWithSingleOrigin(t testing.TB) {
+	additionalCORS := []string{"//valid.domain.com(:|$)"}
+	expectedConfigCORS := []string{
+		`//127\.0\.0\.1(:|$)`,
+		`//localhost(:|$)`,
+		`//valid.domain.com(:|$)`,
+	}
+	testCORSConfiguration(t, additionalCORS, expectedConfigCORS)
+}
+
+func testCORSWithMultipleOrigins(t testing.TB) {
+	additionalCORS := []string{"//something.*.now(:|$)", "//domain.foreign.it(:|$)"}
+	expectedConfigCORS := []string{
+		`//127\.0\.0\.1(:|$)`,
+		`//domain.foreign.it(:|$)`,
+		`//localhost(:|$)`,
+		`//something.*.now(:|$)`,
+	}
+	testCORSConfiguration(t, additionalCORS, expectedConfigCORS)
+}
+
+func testCORSClearToDefaults(t testing.TB) {
+	var additionalCORS []string // nil
+	expectedConfigCORS := []string{
+		`//127\.0\.0\.1(:|$)`,
+		`//localhost(:|$)`,
+	}
+	testCORSConfiguration(t, additionalCORS, expectedConfigCORS)
+}
+
+// testCORSConfiguration is a common test function that sets the additional CORS
+// origins and verifies that the expected CORS configuration is applied.
+func testCORSConfiguration(t testing.TB, additionalCORS, expectedConfigCORS []string) {
+	// initialize clients
+	kubeConfig, err := test.NewClientConfigForTest()
+	require.NoError(t, err)
+	configClient, err := configclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	operatorClient, err := operatorclient.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	kubeAPIServerOperatorClient := operatorClient.KubeAPIServers()
+
+	updateAPIServerClusterConfigSpec(configClient, func(apiserver *configv1.APIServer) {
+		apiserver.Spec.AdditionalCORSAllowedOrigins = additionalCORS
+	})
+
+	var currentCORS []string
+	err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		currentCORS = getKubeAPIServerConfigOrFail(t, kubeAPIServerOperatorClient)
+		if !equality.Semantic.DeepEqual(currentCORS, expectedConfigCORS) {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "expected %#v, got %#v", expectedConfigCORS, currentCORS)
+}
+
+func getKubeAPIServerConfigOrFail(t testing.TB, operatorClient operatorclient.KubeAPIServerInterface) []string {
+	operatorConfig, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var unstructuredConfig map[string]interface{}
+	err = yaml.Unmarshal(operatorConfig.Spec.ObservedConfig.Raw, &unstructuredConfig)
+	require.NoError(t, err)
+	cors, _, err := unstructured.NestedStringSlice(unstructuredConfig, "corsAllowedOrigins")
+	require.NoError(t, err)
+	return cors
+}

--- a/test/e2e/user_cors_test.go
+++ b/test/e2e/user_cors_test.go
@@ -1,108 +1,24 @@
 package e2e
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/ghodss/yaml"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	configv1 "github.com/openshift/api/config/v1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	operatorclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
-
-	test "github.com/openshift/cluster-kube-apiserver-operator/test/library"
 )
 
-var clusterDefaultCORSALlowedOrigins = []string{
-	`//127\.0\.0\.1(:|$)`,
-	`//localhost(:|$)`,
-}
-
+// This test calls the shared test functions which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestAdditionalCORSAllowedOrigins(t *testing.T) {
-	// initialize clients
-	kubeConfig, err := test.NewClientConfigForTest()
-	require.NoError(t, err)
-	configClient, err := configclient.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	operatorClient, err := operatorclient.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	kubeAPIServerOperatorClient := operatorClient.KubeAPIServers()
+	t.Run("CORS with single additional origin", func(t *testing.T) {
+		testCORSWithSingleOrigin(t)
+	})
 
-	// Check the cluster defaults
-	defaultConfig := getKubeAPIServerConfigOrFail(t, kubeAPIServerOperatorClient)
-	assert.Equal(t, clusterDefaultCORSALlowedOrigins, defaultConfig)
+	t.Run("CORS with multiple additional origins", func(t *testing.T) {
+		testCORSWithMultipleOrigins(t)
+	})
 
-	t.Logf("Cluster default CORSAllowedOrigins: %v", defaultConfig)
-
-	testCases := []struct {
-		additionalCORS     []string
-		expectedConfigCORS []string
-	}{
-		{
-			additionalCORS: []string{"//valid.domain.com(:|$)"},
-			expectedConfigCORS: []string{
-				`//127\.0\.0\.1(:|$)`,
-				`//localhost(:|$)`,
-				`//valid.domain.com(:|$)`,
-			},
-		},
-		{
-			additionalCORS: []string{"//something.*.now(:|$)", "//domain.foreign.it(:|$)"},
-			expectedConfigCORS: []string{
-				`//127\.0\.0\.1(:|$)`,
-				`//domain.foreign.it(:|$)`,
-				`//localhost(:|$)`,
-				`//something.*.now(:|$)`,
-			},
-		},
-		{
-			expectedConfigCORS: []string{
-				`//127\.0\.0\.1(:|$)`,
-				`//localhost(:|$)`,
-			},
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%v", tc.additionalCORS), func(t *testing.T) {
-			updateAPIServerClusterConfigSpec(configClient, func(apiserver *configv1.APIServer) {
-				apiserver.Spec.AdditionalCORSAllowedOrigins = tc.additionalCORS
-			})
-
-			var currentCORS []string
-			err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
-				currentCORS = getKubeAPIServerConfigOrFail(t, kubeAPIServerOperatorClient)
-				if !equality.Semantic.DeepEqual(currentCORS, tc.expectedConfigCORS) {
-					return false, nil
-				}
-				return true, nil
-			})
-			if err != nil {
-				t.Errorf("test %d failed: expected %#v, got %#v", i, tc.expectedConfigCORS, currentCORS)
-			}
-		})
-	}
-
-}
-
-func getKubeAPIServerConfigOrFail(t *testing.T, operatorClient operatorclient.KubeAPIServerInterface) []string {
-	operatorConfig, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
-	require.NoError(t, err)
-
-	var unstructuredConfig map[string]interface{}
-	err = yaml.Unmarshal(operatorConfig.Spec.ObservedConfig.Raw, &unstructuredConfig)
-	require.NoError(t, err)
-	cors, _, err := unstructured.NestedStringSlice(unstructuredConfig, "corsAllowedOrigins")
-	require.NoError(t, err)
-	return cors
+	t.Run("CORS clearing to defaults", func(t *testing.T) {
+		testCORSClearToDefaults(t)
+	})
 }


### PR DESCRIPTION
Migrating user_cors_test to OTE