### PR TITLE
OCPBUGS-70298: remove kube-apiserver user from crb

### DIFF
--- a/bindata/bootkube/manifests/cluster-role-binding-kube-apiserver.yaml
+++ b/bindata/bootkube/manifests/cluster-role-binding-kube-apiserver.yaml
@@ -9,7 +9,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: kube-apiserver
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
   name: system:kube-apiserver


### PR DESCRIPTION
### What has changed
The `kube-apiserver` user (not system::user) is removed from the ClusterRoleBinding. It was shown that someone could create this user, and gain all the privileges from this ClusterRoleBinding, which is probably not its intended use case.

### How to verify

1. Spin up OpenShift cluster (any cluster 4.14-4.22) . 
2. Create a user (I used htpassword) called `kube-apiserver`. 
3. Log out of cluster and log in with `kube-apiserver` user . 
4. Log out of cluster and log back in with admin account.
5. Check user `kube-apiserver` under `Users`. They have `kube-apiserver` CRB attached.
6. Delete user and identity provider.
7. Apply new CRB from PR to cluster using `oc apply -f <filename>` . 
8. Repeat steps 2 - 5 . This time, `kube-apiserver` user does not have `kube-apiserver` CRB attached !