### PR TITLE
CNTRLPLANE-2247: Add empty KMS encryption test case for CI job validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,14 @@ test-e2e-sno-disruptive: GO_TEST_FLAGS += -p 1
 test-e2e-sno-disruptive: test-unit
 .PHONY: test-e2e-sno-disruptive
 
+# KMS encryption tests
+test-e2e-encryption-kms: GO_TEST_PACKAGES :=./test/e2e-encryption-kms/...
+test-e2e-encryption-kms: GO_TEST_FLAGS += -v
+test-e2e-encryption-kms: GO_TEST_FLAGS += -timeout 4h
+test-e2e-encryption-kms: GO_TEST_FLAGS += -p 1
+test-e2e-encryption-kms: test-unit
+.PHONY: test-e2e-encryption-kms
+
 clean:
 	$(RM) ./cluster-kube-apiserver-operator
 .PHONY: clean

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -1,0 +1,20 @@
+package e2e_encryption_kms
+
+import (
+	"testing"
+)
+
+// TestKMSEncryptionOnOff tests KMS encryption on/off cycle.
+// This test:
+// 1. Deploys the mock KMS plugin
+// 2. Enables KMS encryption
+// 3. Verifies secrets are encrypted
+// 4. Disables encryption (Identity)
+// 5. Verifies secrets are not encrypted
+// 6. Re-enables KMS encryption
+// 7. Cleans up
+//
+// TODO: Implement full KMS encryption test once the CI job is validated.
+func TestKMSEncryptionOnOff(t *testing.T) {
+	t.Log("KMS encryption on/off test placeholder - CI job validation")
+}

--- a/test/e2e-encryption-kms/main_test.go
+++ b/test/e2e-encryption-kms/main_test.go
@@ -1,0 +1,31 @@
+package e2e_encryption_kms
+
+import (
+	"math/rand"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestMain(m *testing.M) {
+	randomizeTestOrder(m)
+	os.Exit(m.Run())
+}
+
+func randomizeTestOrder(m *testing.M) {
+	pointerVal := reflect.ValueOf(m)
+	val := reflect.Indirect(pointerVal)
+
+	testsMember := val.FieldByName("tests")
+	ptrToTests := unsafe.Pointer(testsMember.UnsafeAddr())
+	realPtrToTests := (*[]testing.InternalTest)(ptrToTests)
+
+	tests := *realPtrToTests
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
+
+	*realPtrToTests = tests
+}


### PR DESCRIPTION
[CNTRLPLANE-2247](https://issues.redhat.com//browse/CNTRLPLANE-2247): Add empty KMS encryption test case for CI job validation