### PR TITLE
OCPBUGS-46086: Always set service-account-jwks-uri to LB URL even with custom issuer

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -128,20 +128,14 @@ func observedConfig(existingConfig map[string]interface{},
 	// If the issuer is not set in KAS, we rely on the config-overrides.yaml to set both
 	// the issuer and the api-audiences but configure the jwks-uri to point to
 	// the LB so that it does not default to KAS IP which is not included in the serving certs
-	if observedActiveIssuer == defaultServiceAccountIssuerValue {
-		infrastructureConfig, err := getInfrastructureConfig("cluster")
-		if err != nil {
-			return existingConfig, append(errs, err)
-		}
-		if apiServerExternalURL := infrastructureConfig.Status.APIServerURL; len(apiServerExternalURL) == 0 {
-			return existingConfig, append(errs, fmt.Errorf("APIServerURL missing from infrastructure/cluster"))
-		} else {
-			apiServerArguments["service-account-jwks-uri"] = []interface{}{apiServerExternalURL + "/openid/v1/jwks"}
-		}
+	infrastructureConfig, err := getInfrastructureConfig("cluster")
+	if err != nil {
+		return existingConfig, append(errs, err)
 	}
-
+	if apiServerExternalURL := infrastructureConfig.Status.APIServerURL; len(apiServerExternalURL) == 0 {
+		return existingConfig, append(errs, fmt.Errorf("APIServerURL missing from infrastructure/cluster"))
+	}
 	return map[string]interface{}{"apiServerArguments": apiServerArguments}, errs
-
 }
 
 // issuersChanged compares the command line flags used for KAS and the operator status service account issuers.


### PR DESCRIPTION
Previously, when a custom service account issuer was set, the
service-account-jwks-uri argument was not configured in the KubeAPIServer,
causing the JWKS URI to default to the node IP. This led to TLS errors
because the node IP is not included in the certificate SAN.

This commit updates observedConfig to always set
service-account-jwks-uri to the API LB URL regardless of whether the
issuer is default or custom. Unit tests have been updated to validate
this behavior.

Fixes: TLS SAN issues for clients accessing JWKS URI with custom issuers.