### PR TITLE
OCPBUGS-65626: update library-go to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260302174620-dcac36b908db
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260302182750-20813ce71ca6
-	github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6
+	github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260302182750-20813ce71ca6 h1:wJv4Ia+R4OxoaJcTUyvMtBc5rWFvfTiEA8d5f1MBPqI=
 github.com/openshift/client-go v0.0.0-20260302182750-20813ce71ca6/go.mod h1:3lkVff575BlbDUUhMsrD1IyvfkZ+oKUB7iZuVy1m0W0=
-github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6 h1:xjqy0OolrFdJ+ofI/aD0+2k9+MSk5anP5dXifFt539Q=
-github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6/go.mod h1:D797O/ssKTNglbrGchjIguFq+DbyRYdeds5w4/VTrKM=
+github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58 h1:3RQXdeYCfbQazMJ/iRr3DL81IGPh/OTN6nGLNsFeRfA=
+github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58/go.mod h1:K3FoNLgNBFYbFuG+Kr8usAnQxj1w84XogyUp2M8rK8k=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/guard_controller.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,6 +47,8 @@ type GuardController struct {
 	podGetter  corev1client.PodsGetter
 	pdbGetter  policyclientv1.PodDisruptionBudgetsGetter
 	pdbLister  policylisterv1.PodDisruptionBudgetLister
+	saLister   corelisterv1.ServiceAccountLister
+	saGetter   corev1client.ServiceAccountsGetter
 
 	// installerPodImageFn returns the image name for the installer pod
 	installerPodImageFn   func() string
@@ -70,6 +71,7 @@ func NewGuardController(
 	operatorClient operatorv1helpers.StaticPodOperatorClient,
 	podGetter corev1client.PodsGetter,
 	pdbGetter policyclientv1.PodDisruptionBudgetsGetter,
+	saGetter corev1client.ServiceAccountsGetter,
 	eventRecorder events.Recorder,
 	createConditionalFunc func() (bool, bool, error),
 	extraNodeSelector labels.Selector,
@@ -102,6 +104,8 @@ func NewGuardController(
 		podGetter:                     podGetter,
 		pdbGetter:                     pdbGetter,
 		pdbLister:                     kubeInformersForTargetNamespace.Policy().V1().PodDisruptionBudgets().Lister(),
+		saGetter:                      saGetter,
+		saLister:                      kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Lister(),
 		installerPodImageFn:           getInstallerPodImageFromEnv,
 		createConditionalFunc:         createConditionalFunc,
 		extraNodeSelector:             extraNodeSelector,
@@ -116,6 +120,7 @@ func NewGuardController(
 		WithInformers(
 			kubeInformersForTargetNamespace.Core().V1().Pods().Informer(),
 			kubeInformersClusterScoped.Core().V1().Nodes().Informer(),
+			kubeInformersForTargetNamespace.Core().V1().ServiceAccounts().Informer(),
 		).
 		WithSync(c.sync).
 		WithSyncDegradedOnError(operatorClient).
@@ -178,6 +183,9 @@ var pdbTemplate []byte
 //go:embed manifests/guard-pod.yaml
 var podTemplate []byte
 
+//go:embed manifests/guard-pod-sa.yaml
+var serviceAccountTemplate []byte
+
 func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	klog.V(5).Info("Syncing guards")
 
@@ -227,10 +235,25 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 			for _, pod := range pods {
 				_, _, err = resourceapply.DeletePod(ctx, c.podGetter, syncCtx.Recorder(), pod)
 				if err != nil {
-					klog.Errorf("Unable to delete Pod: %v", err)
+					klog.Errorf("unable to delete Pod: %v", err)
 					errs = append(errs, err)
 				}
 			}
+		}
+
+		// delete the guard service account
+		serviceAccount := resourceread.ReadServiceAccountV1OrDie(serviceAccountTemplate)
+		serviceAccount.Namespace = c.targetNamespace
+
+		// Check if the service account exists using the lister to avoid unnecessary API calls
+		_, err = c.saLister.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name)
+		if err == nil {
+			_, _, err = resourceapply.DeleteServiceAccount(ctx, c.saGetter, syncCtx.Recorder(), serviceAccount)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		} else if !apierrors.IsNotFound(err) {
+			errs = append(errs, err)
 		}
 	} else {
 		nodes, err := c.nodeLister.List(c.masterNodesSelector)
@@ -275,7 +298,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 					return fmt.Errorf("Unable to apply PodDisruptionBudget changes: %v", err)
 				}
 			}
-		} else if errors.IsNotFound(err) {
+		} else if apierrors.IsNotFound(err) {
 			_, _, err = resourceapply.ApplyPodDisruptionBudget(ctx, c.pdbGetter, syncCtx.Recorder(), pdb)
 			if err != nil {
 				klog.Errorf("Unable to create PodDisruptionBudget: %v", err)
@@ -289,6 +312,24 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		operands := map[string]*corev1.Pod{}
 		for _, pod := range pods {
 			operands[pod.Spec.NodeName] = pod
+		}
+
+		// Create the guard service account once for all guard pods
+		serviceAccount := resourceread.ReadServiceAccountV1OrDie(serviceAccountTemplate)
+		serviceAccount.Namespace = c.targetNamespace
+
+		// Check if the service account exists using the lister to avoid unnecessary API calls
+		// There are no secrets, no image pull secrets, no annotations.
+		// The guard pod uses automountServiceAccountToken: false.
+		// There's nothing meaningful to update. So update logic isn't needed right now.
+		_, err = c.saLister.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name)
+		if apierrors.IsNotFound(err) {
+			_, _, err = resourceapply.ApplyServiceAccount(ctx, c.saGetter, syncCtx.Recorder(), serviceAccount)
+			if err != nil {
+				return fmt.Errorf("unable to create service account %v for Guard Pods: %w", serviceAccount.Name, err)
+			}
+		} else if err != nil {
+			return err
 		}
 
 		for _, node := range nodes {
@@ -328,6 +369,7 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 			pod.Spec.NodeName = node.Name
 			pod.Spec.Containers[0].Image = c.installerPodImageFn()
 			pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Host = operands[node.Name].Status.PodIP
+			pod.Spec.ServiceAccountName = serviceAccount.Name
 			// The readyz port as string type is expected to be convertible into int!!!
 			readyzPort, err := strconv.Atoi(c.readyzPort)
 			if err != nil {
@@ -362,6 +404,10 @@ func (c *GuardController) sync(ctx context.Context, syncCtx factory.SyncContext)
 				}
 				if actual.Status.Phase != "" && actual.Status.Phase != corev1.PodPending && actual.Status.Phase != corev1.PodRunning {
 					klog.V(5).Infof("Pod phase is neither pending nor running, deleting %v so the guard can be re-created", pod.Name)
+					delete = true
+				}
+				if actual.Spec.ServiceAccountName != pod.Spec.ServiceAccountName {
+					klog.V(5).Infof("Service Account changed, deleting %v so the guard can be re-created", pod.Name)
 					delete = true
 				}
 				if delete {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod-sa.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: # Value set by operator
+  name: guard-sa
+  labels:
+    app: guard

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controller/guard/manifests/guard-pod.yaml
@@ -9,6 +9,8 @@ metadata:
     app: guard
   ownerReferences: # Value set by operator
 spec:
+  serviceAccountName: # Value set by operator
+  automountServiceAccountToken: false
   affinity: # Value set by operator
   priorityClassName: "system-cluster-critical"
   terminationGracePeriodSeconds: 3

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -242,6 +242,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 	podClient := b.kubeClient.CoreV1()
 	eventsClient := b.kubeClient.CoreV1()
 	pdbClient := b.kubeClient.PolicyV1()
+	saClient := b.kubeClient.CoreV1()
 	operandInformers := b.kubeNamespaceInformers.InformersFor(b.operandNamespace)
 	clusterInformers := b.kubeClusterInformers
 	infraInformers := b.configInformers.Config().V1().Infrastructures()
@@ -398,6 +399,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			b.staticPodOperatorClient,
 			podClient,
 			pdbClient,
+			saClient,
 			eventRecorder,
 			b.guardCreateConditionalFunc,
 			b.extraNodeSelector,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,8 +406,8 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6
-## explicit; go 1.25.0
+# github.com/openshift/library-go v0.0.0-20260304110309-c56f4c30de58
+## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
This PR updates `library-go` with changes from https://github.com/openshift/library-go/pull/2076 . 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to use a forked version of a core library.
  * Builds will now fetch and use that fork for dependency resolution.
  * No other code changes or public API behavior were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->