### PR TITLE
CNTRLPLANE-2622: config tls on check-endpoints container

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -239,6 +239,8 @@ spec:
     args:
       - --kubeconfig
       - /etc/kubernetes/static-pod-certs/configmaps/check-endpoints-kubeconfig/kubeconfig
+      - --config
+      - /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
       - --listen
       - 0.0.0.0:17697
       - --namespace


### PR DESCRIPTION
Create and add `check-endpoints-config` ConfigMap to revisioned resources and merge observed configuration from the APIServer CR. The config file provides `minTLSVersion` and `cipherSuites` to the `check-endpoints` container in the `kube-apiserver` Pod.

This ensures the `check-endpoints` HTTPS server listening on port 17697 uses the same TLS profile as the main `kube-apiserver` container.