### PR TITLE
update cert injection annotations to beta

### DIFF
--- a/manifests/0000_20_kube-apiserver-operator_02_service.yaml
+++ b/manifests/0000_20_kube-apiserver-operator_02_service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
+    service.beta.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
     exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: kube-apiserver-operator


### PR DESCRIPTION
- the serving-cert-secret  description can be found in https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/security_and_compliance/configuring-certificates#add-service-certificate_service-serving-certificate
- this is the change of beta version in service ca operator : https://github.com/openshift/service-ca-operator/commit/9820fea69bd7c38dc24861bd7b1354e341dc4088#diff-81a43fd4d98d3cb6bac44c7a083efc4f5ad81887646dce6ea0c744dc786369b7
- this is kind of cleanup :
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    exclude.release.openshift.io/internal-openshift-hosted: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
    service.alpha.openshift.io/serving-cert-secret-name: kube-apiserver-operator-serving-cert
    service.alpha.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1770628411
    service.beta.openshift.io/serving-cert-signed-by: openshift-service-serving-signer@1770628411
```