### PR TITLE
OCPBUGS-38661: configure degraded inertia

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -373,7 +374,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		versionRecorder,
 		controllerContext.EventRecorder,
 		controllerContext.Clock,
-	)
+	).WithDegradedInertia(status.MustNewInertia(
+		2*time.Minute, // 2m is the default on the StatusController as well
+		status.InertiaCondition{
+			// to avoid degrading the operator on static pod rollouts, we give the NodeController more time
+			ConditionTypeMatcher: regexp.MustCompile("^NodeControllerDegraded$"),
+			Duration:             3 * time.Minute,
+		},
+	).Inertia)
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
 		kubeClient,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts operator degraded reporting behavior by adding inertia delays, which can change when cluster health flips to Degraded during rollouts. Low code churn, but impacts status/alerting semantics for a core control-plane operator.
> 
> **Overview**
> Configures the `ClusterOperatorStatusController` to use **degraded inertia** so transient issues don’t immediately mark `kube-apiserver` as Degraded.
> 
> Adds a default 2-minute inertia window and a special-case 3-minute delay for `NodeControllerDegraded` (matched via regex) to reduce false degradation during static pod rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062b7a69bbe6fcdebb324d0c1fa71c4292d163bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->