### PR TITLE
OCPBUGS-78016: Disable serving in check-endpoints to fix startup race condition in the kube-apiserver pod

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -241,8 +241,6 @@ spec:
       - /etc/kubernetes/static-pod-certs/configmaps/check-endpoints-kubeconfig/kubeconfig
       - --config
       - /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml
-      - --listen
-      - '{{.CheckEndpointsBindIP}}:17697'
       - --namespace
       - $(POD_NAMESPACE)
       - --v
@@ -263,25 +261,6 @@ spec:
         name: cert-dir
       - mountPath: /tmp
         name: tmp-dir
-    ports:
-      - name: check-endpoints
-        hostPort: 17697
-        containerPort: 17697
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        scheme: HTTPS
-        port: 17697
-        path: healthz
-      initialDelaySeconds: 10
-      timeoutSeconds: 10
-    readinessProbe:
-      httpGet:
-        scheme: HTTPS
-        port: 17697
-        path: healthz
-      initialDelaySeconds: 10
-      timeoutSeconds: 10
     resources:
       requests:
         memory: 50Mi

--- a/pkg/cmd/checkendpoints/cmd.go
+++ b/pkg/cmd/checkendpoints/cmd.go
@@ -102,6 +102,15 @@ func NewCheckEndpointsCommand() *cobra.Command {
 		<-ctx.Done()
 		return nil
 	}, clock.RealClock{})
+
+	// Disable serving as it introduces a dependency on kube-system::extension-apiserver-authentication
+	// configmap which prevents startup when kube-apiserver is not yet serving (startup race condition).
+	// For static pod sidecars, liveness probes cause restarts (the problem we're fixing),
+	// and readiness probes are meaningless. Metrics loss acceptable as feature is rarely enabled.
+	// TODO: Remove when the internal logic can start serving without extension-apiserver-authentication
+	//       and live reload extension-apiserver-authentication after it is available
+	config.DisableServing = true
+
 	config.DisableLeaderElection = true
 	cmd := config.NewCommandWithContext(context.Background())
 	cmd.Use = "check-endpoints"


### PR DESCRIPTION
- Set DisableServing=true and remove liveness/readiness probes to avoid circular dependency on kube-system::extension-apiserver-authentication. Matches the pattern used by cert-regeneration-controller.

### Problem      
                                                                                                                                                     
  The `kube-apiserver-check-endpoints` container experiences startup failures, causing 2-4 restarts per boot on master nodes.

**Symptoms:**                                                                                                                                      
  - Container exits with error code 255
  - Logs show: "Unable to get configmap/extension-apiserver-authentication in kube-system"                                                           
  - Liveness probe failures at port 17697                                                                                                            
  - Test failures: `[Monitor:kubelet-container-restarts][sig-architecture] platform pods in ns/openshift-kube-apiserver should not exit an excessive amount of times`

**Example failure:**   
```                                                                                                                            
Mar 09 12:43:49.110990124: non-zero exit code/255 reason/ContainerExit
F0309 12:43:48.191544 1 cmd.go:182 error initializing delegating authentication: unable to load configmap based request-header-client-ca-file
```

 ### Root Cause   
                                                                                                                                                     
  The check-endpoints container requires the `kube-system::extension-apiserver-authentication` ConfigMap to initialize its delegated authentication  
  for serving metrics/healthz endpoints. However:
                                                                                                                                                     
  1. Circular dependency: check-endpoints runs as a sidecar in the same static pod as kube-apiserver                                             
  2. Startup race: check-endpoints tries to fetch the ConfigMap via API before kube-apiserver is ready to serve requests

 **Why it fails:**                                                                                                                                  
  check-endpoints starts                                                                                                                             
    → library-go ToServerConfig() blocks on extension-apiserver-authentication fetch                                                                 
      → API call to kube-apiserver (same pod, different container)                  
        → kube-apiserver not ready yet                                                                                                               
          → Connection refused / Forbidden                                                                                                           
            → Container exits                                                                                                                        
              → Liveness probe fails                                                                                                                 
                → Kubelet restarts container 

 ### Solution                                                                                                                                        
                                                                                                                                                     
  Disable serving in the check-endpoints container by setting `DisableServing = true`.                                                               
                  
  **This change:**                                                                                                                                   
  1. Eliminates the dependency on `extension-apiserver-authentication` ConfigMap
  2. Prevents the startup race condition                                                                                                             
  3. Follows the [existing pattern used by `cert-regeneration-controller`](https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/pkg/cmd/certregenerationcontroller/cmd.go#L58-L62) (same pod, same issue)

**Why is it okay to disable serving**
- The serving on port 17697 provides two things:
     - [/healthz endpoint](https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/bindata/assets/kube-apiserver/pod.yaml#L267-L284) — used by liveness/readiness probes so kubelet restarts the container if it gets stuck
     - [Prometheus metrics](https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/pkg/cmd/checkendpoints/controller/metrics.go#L20-L40) — pod_network_connectivity_check_count, pod_network_connectivity_check_tcp_connect_latency_gauge, and pod_network_connectivity_check_dns_resolve_latency_gauge

- Its okay to remove them because:
  - `Liveness probes` is counterproductive-   pod.yaml has `initialDelaySeconds: 10` which means if check-endpoints hasn't started serving in 10s then liveness fails and kubelet restarts the container - they cause more restarts (the very problem being investigated)
  - `Readiness probes` are meaningless — static pods don't back a Service, so readiness gates nothing
  - For the metrics, 
    - The PodNetworkConnectivityCheck feature is [disabled by default](https://github.com/openshift/cluster-kube-apiserver-operator/blob/main/pkg/operator/connectivitycheckcontroller/connectivity_check_controller.go#L59) since https://github.com/openshift/cluster-kube-apiserver-operator/pull/943 
    - When disabled, no check CRs exist, so metrics remain at zero
    - With DisableServing=true, metrics can't be scraped anyway
    - CR status provides similar information for recent checks when the feature is enabled
