### PR TITLE
OCPBUGS-62792: Fix self-signed serving cert using 30ns lifetime instead of 30 days

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260317165824-54a3998d81eb
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1
-	github.com/openshift/library-go v0.0.0-20260409165127-c57da2bf5720
+	github.com/openshift/library-go v0.0.0-20260413093329-d2db42c961e1
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1 h1:Hr/R38eg5ZJXfbiaHumjJIN1buDZwhsm4ys4npVCXH0=
 github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1/go.mod h1:Za51LlH76ALiQ/aKGBYJXmyJNkA//IDJ+I///30CA2M=
-github.com/openshift/library-go v0.0.0-20260409165127-c57da2bf5720 h1:ljxETzJc/vDgMJlaSB8GRryBHZOAIENA2Wo5arD8avM=
-github.com/openshift/library-go v0.0.0-20260409165127-c57da2bf5720/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
+github.com/openshift/library-go v0.0.0-20260413093329-d2db42c961e1 h1:NdVGxmPGwWoMlhSmTxMMgp2SszLtAH3nJ6AMGBpXclY=
+github.com/openshift/library-go v0.0.0-20260413093329-d2db42c961e1/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/cmd.go
@@ -3,11 +3,12 @@ package controllercmd
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/clock"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
+
+	"k8s.io/utils/clock"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -280,7 +281,7 @@ func (c *ControllerCommandConfig) AddDefaultRotationToConfig(config *operatorv1a
 			config.ServingInfo.CertFile = filepath.Join(temporaryCertDir, "tls.crt")
 			config.ServingInfo.KeyFile = filepath.Join(temporaryCertDir, "tls.key")
 			// nothing can trust this, so we don't really care about hostnames
-			servingCert, err := ca.MakeServerCert(sets.New("localhost"), 30)
+			servingCert, err := ca.MakeServerCert(sets.New("localhost"), time.Hour*24*30)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,7 +406,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260409165127-c57da2bf5720
+# github.com/openshift/library-go v0.0.0-20260413093329-d2db42c961e1
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Bump library-go to consume the changes in https://github.com/openshift/library-go/pull/2155.

Before https://github.com/openshift/cluster-kube-apiserver-operator/pull/2058, the check-endpoints container lacked the `--config` flag, causing it to fall back to library-go's self-signed certificate generated with `MakeServerCert(..., 30)` where the function signature changed from int days to time.Duration in 4.19, resulting in 30 nanoseconds (~1 second validity) instead of 30 days. This causes the certificate  generated by the `kube-apiserver-check-endpoints` container to be valid for only 1 second.                                        

This bug is suppressed in main as [PR #2058](https://github.com/openshift/cluster-kube-apiserver-operator/pull/2058) (PQC feature work) added the --config flag which loads namedCertificates including `localhost-serving-cert-certkey`, so SNI routing now serves the properly managed 12-hour/30-day certificate, completely bypassing the buggy self-signed cert code—but since #2058 won't be backported as PQC feature work, we need to backport just the check-endpoints fix to 4.19 to resolve the customer issue.   (cc: @ricardomaraschini )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped an internal library dependency to a newer release. No user-visible API or behavior changes; maintenance-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->