### PR TITLE
CNTRLPLANE-3228: Implement 5.0 EUS schedule in KAS-O

### DIFF
--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
@@ -3,7 +3,6 @@ package kubeletversionskewcontroller
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -35,11 +34,27 @@ const (
 // KubeletVersionSkewController sets Upgradeable=False if the kubelet
 // version on a node prevents upgrading to a supported OpenShift version.
 //
-// For odd OpenShift versions, kubelet versions 0 or 1 minor
-// versions behind the API server version are supported.
+// For OpenShift 4.y, odd minors allow kubelet skew of one minor behind the
+// API server; even minors allow two minors behind (see minSupportedKubeletSkewForOpenShiftVersion).
 //
-// For even OpenShift versions, kubelet versions 0, 1, or 2
-// minor versions behind the API server version are supported.
+// The supported kubelet version skew is determined by how many
+// releases have elapsed since the last EUS cycle boundary. It
+// increases by one per release, reaching its maximum at the next
+// EUS boundary.
+//
+// OpenShift 4.x has a 2-release EUS cycle (4.20, 4.22, ...):
+//
+//	4.21: up to 1 version behind
+//	4.22: up to 2 versions behind
+//
+// OpenShift 5.x has a 3-release EUS cycle (5.2, 5.5, 5.8, ...):
+//
+//	5.0, 5.3: up to 1 version behind
+//	5.1, 5.4: up to 2 versions behind
+//	5.2, 5.5: up to 3 versions behind
+//
+// Note: 4.23 is the last 4.x release and is designated EUS, but
+// its supported skew is still -1 (one release from 4.22).
 type KubeletVersionSkewController interface {
 	factory.Controller
 }
@@ -68,11 +83,26 @@ func NewKubeletVersionSkewController(
 }
 
 func minSupportedKubeletSkewForOpenShiftVersion(v semver.Version) int {
-	switch v.Minor % 2 {
-	case 0: // even OpenShift versions
-		return -2
-	case 1: // odd OpenShift versions
-		return -1
+	if v.Major == 4 {
+		// 4.y uses alternating odd/even skew limits. This must stay distinct from the 5.y
+		// mod-3 rule so a branch fast-forwarded between 4.23 and 5.0/main stays correct on both.
+		switch v.Minor % 2 {
+		case 0: // 4.22, 4.24, …
+			return -2
+		case 1: // 4.23, 4.25, …
+			return -1
+		default:
+			panic("should not happen")
+		}
+	}
+	// OpenShift 5.y+: first EUS is 5.2, then 5.5, 5.8, …
+	switch v.Minor % 3 {
+	case 0: // 5.0, 5.3, etc.
+		return -1 // allow kubelets to lag by one, e.g. 5.2 kubelets vs. 5.3 control plane, but not 5.1 kubelets
+	case 1: // 5.1, 5.4, etc.
+		return -2 // allow kubelets to lag by two, e.g. 5.2 kubelets vs. 5.4 control plane, but not 5.1 kubelets
+	case 2: // 5.2, 5.5, etc.
+		return -3 // allow kubelets to lag by three, e.g. 5.2 kubelets vs. 5.5 control plane, but not 5.1 kubelets
 	default:
 		panic("should not happen")
 	}
@@ -248,8 +278,6 @@ func (n nodeKubeletInfos) version() *semver.Version {
 func nodeKubeletVersion(node *corev1.Node) (semver.Version, error) {
 	return semver.Parse(strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v"))
 }
-
-var byNodeRegexp = regexp.MustCompile(`node [^ ]*`)
 
 type byName []*corev1.Node
 

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller_test.go
@@ -15,14 +15,24 @@ import (
 )
 
 func Test_kubeletVersionSkewController_Sync(t *testing.T) {
+	minorZeroOCPVersion := "5.0.0"
+	minorZeroKubeApiVersion := "1.36.0"
 
-	evenOpenShiftVersion := "4.8.0"
-	oddOpenShiftVersion := "4.9.0"
-	apiServerVersion := "1.21.1"
-	skewedKubeletVersions := func(s ...int) []string {
+	minorOneOCPVersion := "5.1.0"
+	minorOneKubeApiVersion := "1.37.0"
+
+	minorTwoOCPVersion := "5.2.0"
+	minorTwoKubeApiVersion := "1.38.0"
+
+	evenOpenShift4 := "4.8.0"
+	oddOpenShift4 := "4.9.0"
+	apiServer4 := "1.21.0"
+
+	skewedKubeletVersions := func(base string, s ...int) []string {
+		bb := semver.MustParse(base)
 		var v []string
-		for i, skew := range s {
-			v = append(v, fmt.Sprintf("1.%d.%d", 21+skew, i))
+		for _, skew := range s {
+			v = append(v, semver.Version{Major: bb.Major, Minor: bb.Minor + uint64(skew)}.FinalizeVersion())
 		}
 		return v
 	}
@@ -30,106 +40,219 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 	testCases := []struct {
 		name             string
 		ocpVersion       string
+		apiServerVersion string
 		kubeletVersions  []string
 		expectedStatus   operatorv1.ConditionStatus
 		expectedReason   string
 		expectedMsgLines string
 	}{
 		{
-			name:             "Synced/Even",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
+			name:             "Synced/Zero",
+			ocpVersion:       minorZeroOCPVersion,
+			apiServerVersion: minorZeroKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorZeroKubeApiVersion, 0, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSyncedReason,
 			expectedMsgLines: "Kubelet and API server versions are synced.",
 		},
 		{
-			name:             "Synced/Odd",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, 0, 0),
+			name:             "Synced/One",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, 0, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSyncedReason,
+			expectedMsgLines: "Kubelet and API server versions are synced.",
+		},
+		{
+			name:             "Synced/Two",
+			ocpVersion:       minorTwoOCPVersion,
+			apiServerVersion: minorTwoKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorTwoKubeApiVersion, 0, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSyncedReason,
 			expectedMsgLines: "Kubelet and API server versions are synced.",
 		},
 		{
 			name:             "ErrorParsingKubeletVersion",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  []string{"Invalid", "1.21.2", "1.20.3"},
+			ocpVersion:       minorZeroOCPVersion,
+			apiServerVersion: minorZeroKubeApiVersion,
+			kubeletVersions:  []string{"Invalid", minorZeroKubeApiVersion, minorZeroKubeApiVersion},
 			expectedStatus:   operatorv1.ConditionUnknown,
 			expectedReason:   KubeletVersionUnknownReason,
 			expectedMsgLines: "Unable to determine the kubelet version on node test000: No Major.Minor.Patch elements found",
 		},
 		{
-			name:             "UnsupportedNextUpgrade/Even",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -1, 0),
-			expectedStatus:   operatorv1.ConditionFalse,
-			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
-			expectedMsgLines: "Kubelet version (1.20.1) on node test001 will not be supported in the next OpenShift version upgrade.",
+			name:             "SkewedButOK",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, -1, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet version (1.36.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.",
 		},
 		{
-			name:             "UnsupportedNextUpgrade/Odd",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
+			name:             "UnsupportedThisUpgrade",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, 0, -3, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported Kubelet version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.34.0) on node test001 is too far behind the target API server version (1.37.0).",
 		},
 		{
-			name:             "TwoNodesNotSynced",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -1, -1),
+			name:             "UnsupportedTwoNodes",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, -3, 0, -3),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported Kubelet versions on nodes test000 and test002 are too far behind the target API server version (1.37.0).",
+		},
+		{
+			name:             "UnsupportedAllNodes",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, -3, -3, -3),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported Kubelet versions on nodes test000, test001, and test002 are too far behind the target API server version (1.37.0).",
+		},
+		{
+			name:             "SkewedButOK/5KubeletTwoBehind",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, 0, -2, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet version (1.35.0) on node test001 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.",
+		},
+		{
+			name:             "UnsupportedNextUpgradeEUS",
+			ocpVersion:       minorTwoOCPVersion,
+			apiServerVersion: minorTwoKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorTwoKubeApiVersion, 0, -2, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet version (1.36.0) on node test001 will not be supported in the next OpenShift version upgrade.",
+		},
+		{
+			name:             "UnsupportedAhead",
+			ocpVersion:       minorOneOCPVersion,
+			apiServerVersion: minorOneKubeApiVersion,
+			kubeletVersions:  skewedKubeletVersions(minorOneKubeApiVersion, 0, -1, 1),
+			expectedStatus:   operatorv1.ConditionUnknown,
+			expectedReason:   KubeletMinorVersionAheadReason,
+			expectedMsgLines: "Unsupported Kubelet version (1.38.0) on node test002 is ahead of the target API server version (1.37.0).",
+		},
+		// OpenShift 4.y (mod-2 skew policy)
+		{
+			name:             "Synced/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSyncedReason,
+			expectedMsgLines: "Kubelet and API server versions are synced.",
+		},
+		{
+			name:             "Synced/4Odd",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, 0, 0),
+			expectedStatus:   operatorv1.ConditionTrue,
+			expectedReason:   KubeletMinorVersionSyncedReason,
+			expectedMsgLines: "Kubelet and API server versions are synced.",
+		},
+		{
+			name:             "ErrorParsingKubeletVersion/4",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  []string{"Invalid", "1.21.0", "1.20.0"},
+			expectedStatus:   operatorv1.ConditionUnknown,
+			expectedReason:   KubeletVersionUnknownReason,
+			expectedMsgLines: "Unable to determine the kubelet version on node test000: No Major.Minor.Patch elements found",
+		},
+		{
+			name:             "UnsupportedNextUpgrade/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -1, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
+			expectedMsgLines: "Kubelet version (1.20.0) on node test001 will not be supported in the next OpenShift version upgrade.",
+		},
+		{
+			name:             "Unsupported/4OddKubeletTwoBehind",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -2, 0),
+			expectedStatus:   operatorv1.ConditionFalse,
+			expectedReason:   KubeletMinorVersionUnsupportedReason,
+			expectedMsgLines: "Unsupported Kubelet version (1.19.0) on node test001 is too far behind the target API server version (1.21.0).",
+		},
+		{
+			name:             "TwoNodesNotSynced/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
 			expectedMsgLines: "Kubelet versions on nodes test001 and test002 will not be supported in the next OpenShift version upgrade.",
 		},
 		{
-			name:             "ThreeNodesNotSynced",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1),
+			name:             "ThreeNodesNotSynced/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -1, -1, -1),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
 			expectedMsgLines: "Kubelet versions on nodes test001, test002, and test003 will not be supported in the next OpenShift version upgrade.",
 		},
 		{
-			name:             "ManyNodesNotSynced",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -1, -1, -1, -1, -1, 0, 0),
+			name:             "ManyNodesNotSynced/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -1, -1, -1, -1, -1, 0, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedNextUpgradeReason,
 			expectedMsgLines: "Kubelet versions on 5 nodes will not be supported in the next OpenShift version upgrade.",
 		},
 		{
-			name:             "SkewedUnsupported/Even",
-			ocpVersion:       evenOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -3, 0),
+			name:             "SkewedUnsupported/4Even",
+			ocpVersion:       evenOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -3, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported Kubelet version (1.18.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.18.0) on node test001 is too far behind the target API server version (1.21.0).",
 		},
 		{
-			name:             "SkewedUnsupported/Odd",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -2, 0),
+			name:             "SkewedUnsupported/4Odd",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -2, 0),
 			expectedStatus:   operatorv1.ConditionFalse,
 			expectedReason:   KubeletMinorVersionUnsupportedReason,
-			expectedMsgLines: "Unsupported Kubelet version (1.19.1) on node test001 is too far behind the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.19.0) on node test001 is too far behind the target API server version (1.21.0).",
 		},
 		{
-			name:             "SkewedButOK/Odd",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(-1, 0, 0),
+			name:             "SkewedButOK/4Odd",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, -1, 0, 0),
 			expectedStatus:   operatorv1.ConditionTrue,
 			expectedReason:   KubeletMinorVersionSupportedNextUpgradeReason,
 			expectedMsgLines: "Kubelet version (1.20.0) on node test000 is behind the expected API server version; nevertheless, it will continue to be supported in the next OpenShift version upgrade.",
 		},
 		{
-			name:             "Unsupported",
-			ocpVersion:       oddOpenShiftVersion,
-			kubeletVersions:  skewedKubeletVersions(0, -1, 1),
+			name:             "UnsupportedAhead/4Odd",
+			ocpVersion:       oddOpenShift4,
+			apiServerVersion: apiServer4,
+			kubeletVersions:  skewedKubeletVersions(apiServer4, 0, -1, 1),
 			expectedStatus:   operatorv1.ConditionUnknown,
 			expectedReason:   KubeletMinorVersionAheadReason,
-			expectedMsgLines: "Unsupported Kubelet version (1.22.2) on node test002 is ahead of the target API server version (1.21.1).",
+			expectedMsgLines: "Unsupported Kubelet version (1.22.0) on node test002 is ahead of the target API server version (1.21.0).",
 		},
 	}
 	for _, tc := range testCases {
@@ -143,6 +266,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 			}
 			status := &operatorv1.StaticPodOperatorStatus{}
 			ocpVersion := semver.MustParse(tc.ocpVersion)
+			apiServerVersion := semver.MustParse(tc.apiServerVersion)
 			nextOpenShiftVersion := semver.Version{Major: ocpVersion.Major, Minor: ocpVersion.Minor + 1}
 			c := &kubeletVersionSkewController{
 				operatorClient: v1helpers.NewFakeStaticPodOperatorClient(
@@ -150,7 +274,7 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 					status, nil, nil,
 				),
 				nodeLister:                  corev1listers.NewNodeLister(indexer),
-				apiServerVersion:            semver.MustParse(apiServerVersion),
+				apiServerVersion:            apiServerVersion,
 				minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(ocpVersion),
 				minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
 			}
@@ -176,5 +300,41 @@ func Test_kubeletVersionSkewController_Sync(t *testing.T) {
 				t.Logf("Condition message: %s", condition.Message)
 			}
 		})
+	}
+}
+
+func TestMinSupportedKubeletSkewForOpenShiftVersion(t *testing.T) {
+	// 4.23 (mod-2) and 5.0 (mod-3) share the same Kubernetes base; skew limits must match
+	// so code fast-forwarded between release branches behaves identically.
+	tests := []struct {
+		ocp      string
+		expected int
+	}{
+		{"4.22.0", -2},
+		{"4.23.0", -1},
+		{"4.24.0", -2},
+		{"5.0.0", -1},
+		{"5.1.0", -2},
+		{"5.2.0", -3},
+		{"5.3.0", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ocp, func(t *testing.T) {
+			v := semver.MustParse(tt.ocp)
+			if got := minSupportedKubeletSkewForOpenShiftVersion(v); got != tt.expected {
+				t.Fatalf("minSupportedKubeletSkewForOpenShiftVersion(%v): got %d, want %d", v, got, tt.expected)
+			}
+		})
+	}
+	next := func(ocp string) int {
+		v := semver.MustParse(ocp)
+		nextV := semver.Version{Major: v.Major, Minor: v.Minor + 1}
+		return minSupportedKubeletSkewForOpenShiftVersion(nextV)
+	}
+	if got, want := next("4.23.0"), -2; got != want {
+		t.Errorf("next after 4.23: got %d, want %d", got, want)
+	}
+	if got, want := next("5.0.0"), -2; got != want {
+		t.Errorf("next after 5.0: got %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
Implements the new EUS schedule (every third release instead of every second) in the kubelet skew guard controller.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upgrade-gating logic that determines when clusters are marked non-upgradeable based on kubelet/API server minor skew, especially for upcoming 5.x releases. Incorrect skew math could incorrectly block upgrades or allow unsupported node versions.
> 
> **Overview**
> Updates the kubelet skew guard to compute minimum supported kubelet lag based on OpenShift major/minor: keeps 4.y’s odd/even (-1/-2) rules but switches 5.y+ to a *mod-3* policy (-1/-2/-3) to match the new EUS every-third-release cadence.
> 
> Reworks and expands unit tests to cover 5.0–5.2 scenarios, explicit API server version inputs, additional unsupported/edge cases (multiple nodes, ahead-of-API), and adds a dedicated test validating `minSupportedKubeletSkewForOpenShiftVersion()` across 4.22–5.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8e55a8569460ef18565af21db86b64517af1e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated kubelet compatibility thresholds per OpenShift minor: OpenShift 4.x uses an alternating -2/-1 policy, while OpenShift 5.x+ uses a -1/-2/-3 pattern; tightened next-upgrade boundary so equality is treated as unsupported.

* **Tests**
  * Expanded and reworked tests to cover varied kubelet/API server version scenarios, semver-based kubelet derivation, and to validate the new skew rules across multiple minors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->