### PR TITLE
OCPBUGS-79663: Allow setting the oauthMetadata when auth type is None

### DIFF
--- a/pkg/operator/configobservation/auth/auth_metadata.go
+++ b/pkg/operator/configobservation/auth/auth_metadata.go
@@ -104,8 +104,13 @@ func (o *oauthMetadataObserver) ObserveAuthMetadata(genericListers configobserve
 		}
 
 	case configv1.AuthenticationTypeNone:
-		// no oauth metadata is served; do not set anything as source
-		// in order to delete the configmap and unset oauthMetadataFile
+		// spec.oauthMetadata is allowed when type is None; use it as the
+		// source if set, otherwise leave source empty to delete the configmap
+		// and unset oauthMetadataFile
+		if len(authConfig.Spec.OAuthMetadata.Name) > 0 {
+			sourceConfigMap = authConfig.Spec.OAuthMetadata.Name
+			sourceNamespace = configNamespace
+		}
 
 	case configv1.AuthenticationTypeOIDC:
 		// When the ExternalOIDCExternalClaimsSourcing feature gate is not enabled the

--- a/pkg/operator/configobservation/auth/auth_metadata_test.go
+++ b/pkg/operator/configobservation/auth/auth_metadata_test.go
@@ -20,18 +20,18 @@ import (
 )
 
 var (
-	unprunedBaseAuthMetadataConfig = map[string]interface{}{
-		"apiServerArguments": map[string]interface{}{
+	unprunedBaseAuthMetadataConfig = map[string]any{
+		"apiServerArguments": map[string]any{
 			"authentication-token-webhook-config-file": webhookTokenAuthenticatorFile,
 			"authentication-token-webhook-version":     webhookTokenAuthenticatorVersion,
 		},
-		"authConfig": map[string]interface{}{
+		"authConfig": map[string]any{
 			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
 		},
 	}
 
-	prunedBaseAuthMetadataConfig = map[string]interface{}{
-		"authConfig": map[string]interface{}{
+	prunedBaseAuthMetadataConfig = map[string]any{
+		"authConfig": map[string]any{
 			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
 		},
 	}
@@ -44,13 +44,13 @@ func TestObserveAuthMetadata(t *testing.T) {
 		authIndexer cache.Indexer
 		cmIndexer   cache.Indexer
 
-		existingConfig     map[string]interface{}
+		existingConfig     map[string]any
 		authConfigMap      *corev1.ConfigMap
 		authSpec           *configv1.AuthenticationSpec
 		statusMetadataName string
 		syncerError        error
 
-		expectedConfig map[string]interface{}
+		expectedConfig map[string]any
 		expectedSynced map[string]string
 		expectErrors   bool
 
@@ -59,7 +59,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 		{
 			name:           "auth resource not found",
 			authSpec:       nil,
-			expectedConfig: map[string]interface{}{},
+			expectedConfig: map[string]any{},
 			expectedSynced: nil,
 			expectErrors:   false,
 			gates: featuregates.NewHardcodedFeatureGateAccess(
@@ -183,6 +183,25 @@ func TestObserveAuthMetadata(t *testing.T) {
 				Type: configv1.AuthenticationTypeNone,
 				OAuthMetadata: configv1.ConfigMapNameReference{
 					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     prunedBaseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+			gates: featuregates.NewHardcodedFeatureGateAccess(
+				[]configv1.FeatureGateName{},
+				[]configv1.FeatureGateName{features.FeatureGateExternalOIDCExternalClaimsSourcing},
+			),
+		},
+		{
+			name: "empty auth metadata with auth type None",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeNone,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
 				},
 			},
 			statusMetadataName: "metadata-from-status",
@@ -431,7 +450,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 			eventRecorder := events.NewInMemoryRecorder("authmetadatatest", clock.RealClock{})
 
 			if tt.authIndexer == nil {
-				tt.authIndexer = cache.NewIndexer(func(obj interface{}) (string, error) {
+				tt.authIndexer = cache.NewIndexer(func(obj any) (string, error) {
 					return "cluster", nil
 				}, cache.Indexers{})
 			}


### PR DESCRIPTION
https://github.com/openshift/cluster-kube-apiserver-operator/pull/1760 introduced a regression where setting the oauthMetadata was completely ignored when auth type is `None`; however setting `spec.oauthMetadata.Name` under `None` is a valid use-case when a custom OAuth system must be configured (as stated also in the respective [API doc](https://github.com/openshift/api/blob/master/config/v1/types_authentication.go#L146-L149)).

This PR fixes this in order to allow configuring the kube-apiserver with custom oauth metadata when auth type is `None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication metadata handling for "None" type now uses a specified OAuth metadata ConfigMap when a name is provided, instead of always clearing the metadata, allowing metadata to be synced into the destination.
* **Tests**
  * Test coverage updated to reflect the conditional ConfigMap behavior and adjusted expectations for the "None" auth type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->