### PR TITLE
Adding new suite for KMS

### DIFF
--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -96,6 +96,16 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		},
 	})
 
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-apiserver-operator/encryption-kms/disruptive",
+		Parents:     []string{"openshift/encryption-kms/operator/disruptive"},
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[KMS]") && name.contains("[Disruptive]")`,
+		},
+		ClusterStability: oteextension.ClusterStabilityDisruptive,
+	})
+
 	specs, err := oteginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build extension test specs from ginkgo: %w", err)

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -12,246 +12,93 @@ import (
 	library "github.com/openshift/library-go/test/library/encryption"
 	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type operatorTestConfig struct {
-	name                       string
-	namespace                  string
-	labelSelector              string
-	encryptionConfigSecretName string
-	operatorNamespace          string
-	targetGRs                  []schema.GroupResource
-	assertFunc                 func(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string)
-	createResourceFunc         func(t testing.TB, clientSet library.ClientSet, namespace string) runtime.Object
-	assertEncryptedFunc        func(t testing.TB, clientSet library.ClientSet, resource runtime.Object)
-	assertNotEncryptedFunc     func(t testing.TB, clientSet library.ClientSet, resource runtime.Object)
-	resourceFunc               func(t testing.TB, namespace string) runtime.Object
-	resourceName               string
-}
-
-var allOperators = []operatorTestConfig{
-	{
-		name:                       "KASO",
-		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		labelSelector:              "encryption.apiserver.operator.openshift.io/component=" + operatorclient.TargetNamespace,
-		encryptionConfigSecretName: fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-		operatorNamespace:          operatorclient.OperatorNamespace,
-		targetGRs:                  operatorencryption.DefaultTargetGRs,
-		assertFunc:                 operatorencryption.AssertSecretsAndConfigMaps,
-		createResourceFunc:         operatorencryption.CreateAndStoreSecretOfLife,
-		assertEncryptedFunc:        operatorencryption.AssertSecretOfLifeEncrypted,
-		assertNotEncryptedFunc:     operatorencryption.AssertSecretOfLifeNotEncrypted,
-		resourceFunc:               operatorencryption.SecretOfLife,
-		resourceName:               "SecretOfLife",
-	},
-	{
-		name:                       "OASO",
-		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		labelSelector:              operatorencryption.OASLabelSelector,
-		encryptionConfigSecretName: operatorencryption.OASEncryptionConfigSecretName,
-		operatorNamespace:          operatorencryption.OASOperatorNamespace,
-		targetGRs:                  operatorencryption.OASTargetGRs,
-		assertFunc:                 operatorencryption.AssertOASSecretsAndConfigMaps,
-		createResourceFunc:         operatorencryption.CreateAndStoreOASSecretOfLife,
-		assertEncryptedFunc:        operatorencryption.AssertOASSecretOfLifeEncrypted,
-		assertNotEncryptedFunc:     operatorencryption.AssertOASSecretOfLifeNotEncrypted,
-		resourceFunc:               operatorencryption.OASSecretOfLife,
-		resourceName:               "OASSecretOfLife",
-	},
-	{
-		name:                       "AuthO",
-		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		labelSelector:              operatorencryption.AuthLabelSelector,
-		encryptionConfigSecretName: operatorencryption.AuthEncryptionConfigSecretName,
-		operatorNamespace:          operatorencryption.AuthOperatorNamespace,
-		targetGRs:                  operatorencryption.AuthTargetGRs,
-		assertFunc:                 operatorencryption.AssertOAuthTokens,
-		createResourceFunc:         operatorencryption.CreateAndStoreOAuthTokenOfLife,
-		assertEncryptedFunc:        operatorencryption.AssertOAuthTokenOfLifeEncrypted,
-		assertNotEncryptedFunc:     operatorencryption.AssertOAuthTokenOfLifeNotEncrypted,
-		resourceFunc:               operatorencryption.OAuthTokenOfLife,
-		resourceName:               "OAuthTokenOfLife",
-	},
-}
-
-// setEncryptionAndWaitForAllOperators sets the encryption type once (cluster-wide)
-// and waits for all operators to complete key migration.
-func setEncryptionAndWaitForAllOperators(t *testing.T, encryptionType configv1.EncryptionType) {
+// assertAllOperatorsEncryptionState checks that all operators (KAS-O, OAS-O, Auth-O)
+// have the expected encryption mode applied.
+func assertAllOperatorsEncryptionState(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
 	t.Helper()
-	for _, op := range allOperators {
-		t.Run("WaitFor_"+op.name, func(t *testing.T) {
-			library.SetAndWaitForEncryptionType(t, encryptionType, op.targetGRs, op.namespace, op.labelSelector)
-			op.assertFunc(t, library.GetClients(t), encryptionType, op.namespace, op.labelSelector)
-		})
-	}
+
+	// KAS-O
+	operatorencryption.AssertSecretsAndConfigMaps(t, clientSet, expectedMode, namespace, labelSelector)
+
+	// OAS-O
+	operatorencryption.AssertOASRoutes(t, clientSet, expectedMode,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace, operatorencryption.OASLabelSelector)
+
+	// Auth-O
+	operatorencryption.AssertOAuthTokens(t, clientSet, expectedMode,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace, operatorencryption.AuthLabelSelector)
 }
 
-// TestKMSEncryptionOnOff tests KMS encryption on/off for the entire platform.
-// It sets encryption once and verifies all operators (KAS-O, OAS-O, Auth-O)
-// encrypted/decrypted their resources correctly, avoiding redundant on/off cycles.
+// createAllResources creates test resources for all operators and returns the KAS-O secret.
+func createAllResources(t testing.TB, clientSet library.ClientSet, namespace string) runtime.Object {
+	t.Helper()
+
+	// OAS-O
+	operatorencryption.CreateAndStoreOASRouteOfLife(t, clientSet, operatorclient.GlobalMachineSpecifiedConfigNamespace)
+
+	// Auth-O
+	operatorencryption.CreateAndStoreOAuthTokenOfLife(t, clientSet, operatorclient.GlobalMachineSpecifiedConfigNamespace)
+
+	// KAS-O (returned as the primary resource)
+	return operatorencryption.CreateAndStoreSecretOfLife(t, clientSet, namespace)
+}
+
+// assertAllResourcesEncrypted checks that test resources from all operators are encrypted.
+func assertAllResourcesEncrypted(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
+	t.Helper()
+	operatorencryption.AssertSecretOfLifeEncrypted(t, clientSet, resource)
+	operatorencryption.AssertOASRouteOfLifeEncrypted(t, clientSet, nil)
+	operatorencryption.AssertOAuthTokenOfLifeEncrypted(t, clientSet, nil)
+}
+
+// assertAllResourcesNotEncrypted checks that test resources from all operators are NOT encrypted.
+func assertAllResourcesNotEncrypted(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
+	t.Helper()
+	operatorencryption.AssertSecretOfLifeNotEncrypted(t, clientSet, resource)
+	operatorencryption.AssertOASRouteOfLifeNotEncrypted(t, clientSet, nil)
+	operatorencryption.AssertOAuthTokenOfLifeNotEncrypted(t, clientSet, nil)
+}
+
 func TestKMSEncryptionOnOff(t *testing.T) {
 	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
-	e := library.NewE(t)
-	clientSet := library.GetClients(e)
-
-	// Step 1: Create test resources for all operators
-	t.Run("CreateResources", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.createResourceFunc(t, clientSet, op.namespace)
-			})
-		}
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 2: Enable KMS encryption (one toggle for the whole platform)
-	t.Run("EnableKMS", func(t *testing.T) {
-		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeKMS)
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 3: Verify all resources are encrypted
-	t.Run("AssertEncrypted", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-			})
-		}
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 4: Disable encryption (one toggle for the whole platform)
-	t.Run("DisableEncryption", func(t *testing.T) {
-		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 5: Verify all resources are NOT encrypted
-	t.Run("AssertNotEncrypted", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-			})
-		}
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 6: Re-enable KMS encryption
-	t.Run("ReEnableKMS", func(t *testing.T) {
-		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeKMS)
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 7: Verify all resources are encrypted again
-	t.Run("AssertEncryptedAgain", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-			})
-		}
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 8: Disable encryption again
-	t.Run("DisableEncryptionAgain", func(t *testing.T) {
-		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 9: Verify all resources are NOT encrypted again
-	t.Run("AssertNotEncryptedAgain", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-			})
-		}
+	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      assertAllOperatorsEncryptionState,
+		},
+		CreateResourceFunc:             createAllResources,
+		AssertResourceEncryptedFunc:    assertAllResourcesEncrypted,
+		AssertResourceNotEncryptedFunc: assertAllResourcesNotEncrypted,
+		ResourceFunc:                   operatorencryption.SecretOfLife,
+		ResourceName:                   "SecretOfLife",
+		EncryptionProvider:             configv1.EncryptionTypeKMS,
 	})
 }
 
-// TestKMSEncryptionProvidersMigration tests migration between KMS and a randomly
-// selected AES encryption provider for the entire platform. It sets encryption once
-// per provider and verifies all operators migrated correctly.
 func TestKMSEncryptionProvidersMigration(t *testing.T) {
 	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-
-	e := library.NewE(t)
-	clientSet := library.GetClients(e)
-
-	providers := library.ShuffleEncryptionProviders([]configv1.EncryptionType{
-		configv1.EncryptionTypeKMS,
-		library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
-	})
-
-	// Step 1: Create test resources for all operators
-	t.Run("CreateResources", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.createResourceFunc(t, clientSet, op.namespace)
-			})
-		}
-	})
-	if t.Failed() {
-		return
-	}
-
-	// Step 2: Migrate through each provider in sequence
-	for i, provider := range providers {
-		prefix := "EncryptWith"
-		if i > 0 {
-			prefix = "MigrateTo"
-		}
-		stepName := fmt.Sprintf("%s_%s", prefix, string(provider))
-
-		t.Run(stepName, func(t *testing.T) {
-			setEncryptionAndWaitForAllOperators(t, provider)
-		})
-		if t.Failed() {
-			return
-		}
-
-		t.Run(fmt.Sprintf("AssertEncrypted_%s", string(provider)), func(t *testing.T) {
-			for _, op := range allOperators {
-				t.Run(op.name, func(t *testing.T) {
-					op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-				})
-			}
-		})
-		if t.Failed() {
-			return
-		}
-	}
-
-	// Step 3: Disable encryption and verify all resources are not encrypted
-	t.Run("DisableEncryption", func(t *testing.T) {
-		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
-	})
-	if t.Failed() {
-		return
-	}
-
-	t.Run("AssertNotEncrypted", func(t *testing.T) {
-		for _, op := range allOperators {
-			t.Run(op.name, func(t *testing.T) {
-				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
-			})
-		}
+	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      assertAllOperatorsEncryptionState,
+		},
+		CreateResourceFunc:             createAllResources,
+		AssertResourceEncryptedFunc:    assertAllResourcesEncrypted,
+		AssertResourceNotEncryptedFunc: assertAllResourcesNotEncrypted,
+		ResourceFunc:                   operatorencryption.SecretOfLife,
+		ResourceName:                   "SecretOfLife",
+		EncryptionProviders:            library.ShuffleEncryptionProviders([]configv1.EncryptionType{configv1.EncryptionTypeKMS, library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))]}),
 	})
 }

--- a/test/e2e-encryption-kms/encryption_kms_test.go
+++ b/test/e2e-encryption-kms/encryption_kms_test.go
@@ -11,69 +11,247 @@ import (
 	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
 	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TestKMSEncryptionOnOff tests KMS encryption on/off cycle.
-// This test:
-// 1. Deploys the mock KMS plugin
-// 2. Creates a test secret (SecretOfLife)
-// 3. Enables KMS encryption
-// 4. Verifies secret is encrypted
-// 5. Disables encryption (Identity)
-// 6. Verifies secret is NOT encrypted
-// 7. Re-enables KMS encryption
-// 8. Verifies secret is encrypted again
-// 9. Disables encryption (Identity) again
-// 10. Verifies secret is NOT encrypted again
+type operatorTestConfig struct {
+	name                       string
+	namespace                  string
+	labelSelector              string
+	encryptionConfigSecretName string
+	operatorNamespace          string
+	targetGRs                  []schema.GroupResource
+	assertFunc                 func(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string)
+	createResourceFunc         func(t testing.TB, clientSet library.ClientSet, namespace string) runtime.Object
+	assertEncryptedFunc        func(t testing.TB, clientSet library.ClientSet, resource runtime.Object)
+	assertNotEncryptedFunc     func(t testing.TB, clientSet library.ClientSet, resource runtime.Object)
+	resourceFunc               func(t testing.TB, namespace string) runtime.Object
+	resourceName               string
+}
+
+var allOperators = []operatorTestConfig{
+	{
+		name:                       "KASO",
+		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		labelSelector:              "encryption.apiserver.operator.openshift.io/component=" + operatorclient.TargetNamespace,
+		encryptionConfigSecretName: fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+		operatorNamespace:          operatorclient.OperatorNamespace,
+		targetGRs:                  operatorencryption.DefaultTargetGRs,
+		assertFunc:                 operatorencryption.AssertSecretsAndConfigMaps,
+		createResourceFunc:         operatorencryption.CreateAndStoreSecretOfLife,
+		assertEncryptedFunc:        operatorencryption.AssertSecretOfLifeEncrypted,
+		assertNotEncryptedFunc:     operatorencryption.AssertSecretOfLifeNotEncrypted,
+		resourceFunc:               operatorencryption.SecretOfLife,
+		resourceName:               "SecretOfLife",
+	},
+	{
+		name:                       "OASO",
+		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		labelSelector:              operatorencryption.OASLabelSelector,
+		encryptionConfigSecretName: operatorencryption.OASEncryptionConfigSecretName,
+		operatorNamespace:          operatorencryption.OASOperatorNamespace,
+		targetGRs:                  operatorencryption.OASTargetGRs,
+		assertFunc:                 operatorencryption.AssertOASSecretsAndConfigMaps,
+		createResourceFunc:         operatorencryption.CreateAndStoreOASSecretOfLife,
+		assertEncryptedFunc:        operatorencryption.AssertOASSecretOfLifeEncrypted,
+		assertNotEncryptedFunc:     operatorencryption.AssertOASSecretOfLifeNotEncrypted,
+		resourceFunc:               operatorencryption.OASSecretOfLife,
+		resourceName:               "OASSecretOfLife",
+	},
+	{
+		name:                       "AuthO",
+		namespace:                  operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		labelSelector:              operatorencryption.AuthLabelSelector,
+		encryptionConfigSecretName: operatorencryption.AuthEncryptionConfigSecretName,
+		operatorNamespace:          operatorencryption.AuthOperatorNamespace,
+		targetGRs:                  operatorencryption.AuthTargetGRs,
+		assertFunc:                 operatorencryption.AssertOAuthTokens,
+		createResourceFunc:         operatorencryption.CreateAndStoreOAuthTokenOfLife,
+		assertEncryptedFunc:        operatorencryption.AssertOAuthTokenOfLifeEncrypted,
+		assertNotEncryptedFunc:     operatorencryption.AssertOAuthTokenOfLifeNotEncrypted,
+		resourceFunc:               operatorencryption.OAuthTokenOfLife,
+		resourceName:               "OAuthTokenOfLife",
+	},
+}
+
+// setEncryptionAndWaitForAllOperators sets the encryption type once (cluster-wide)
+// and waits for all operators to complete key migration.
+func setEncryptionAndWaitForAllOperators(t *testing.T, encryptionType configv1.EncryptionType) {
+	t.Helper()
+	for _, op := range allOperators {
+		t.Run("WaitFor_"+op.name, func(t *testing.T) {
+			library.SetAndWaitForEncryptionType(t, encryptionType, op.targetGRs, op.namespace, op.labelSelector)
+			op.assertFunc(t, library.GetClients(t), encryptionType, op.namespace, op.labelSelector)
+		})
+	}
+}
+
+// TestKMSEncryptionOnOff tests KMS encryption on/off for the entire platform.
+// It sets encryption once and verifies all operators (KAS-O, OAS-O, Auth-O)
+// encrypted/decrypted their resources correctly, avoiding redundant on/off cycles.
 func TestKMSEncryptionOnOff(t *testing.T) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
 	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
-		},
-		CreateResourceFunc:             operatorencryption.CreateAndStoreSecretOfLife,
-		AssertResourceEncryptedFunc:    operatorencryption.AssertSecretOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
-		ResourceFunc:                   operatorencryption.SecretOfLife,
-		ResourceName:                   "SecretOfLife",
-		EncryptionProvider:             configv1.EncryptionTypeKMS,
+
+	e := library.NewE(t)
+	clientSet := library.GetClients(e)
+
+	// Step 1: Create test resources for all operators
+	t.Run("CreateResources", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.createResourceFunc(t, clientSet, op.namespace)
+			})
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 2: Enable KMS encryption (one toggle for the whole platform)
+	t.Run("EnableKMS", func(t *testing.T) {
+		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeKMS)
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 3: Verify all resources are encrypted
+	t.Run("AssertEncrypted", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+			})
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 4: Disable encryption (one toggle for the whole platform)
+	t.Run("DisableEncryption", func(t *testing.T) {
+		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 5: Verify all resources are NOT encrypted
+	t.Run("AssertNotEncrypted", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+			})
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 6: Re-enable KMS encryption
+	t.Run("ReEnableKMS", func(t *testing.T) {
+		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeKMS)
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 7: Verify all resources are encrypted again
+	t.Run("AssertEncryptedAgain", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+			})
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 8: Disable encryption again
+	t.Run("DisableEncryptionAgain", func(t *testing.T) {
+		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 9: Verify all resources are NOT encrypted again
+	t.Run("AssertNotEncryptedAgain", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+			})
+		}
 	})
 }
 
-// TestKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
-// This test:
-// 1. Deploys the mock KMS plugin
-// 2. Creates a test secret (SecretOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies secret is correctly encrypted after each migration
+// TestKMSEncryptionProvidersMigration tests migration between KMS and a randomly
+// selected AES encryption provider for the entire platform. It sets encryption once
+// per provider and verifies all operators migrated correctly.
 func TestKMSEncryptionProvidersMigration(t *testing.T) {
 	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
-	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       operatorencryption.DefaultTargetGRs,
-			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
-		},
-		CreateResourceFunc:             operatorencryption.CreateAndStoreSecretOfLife,
-		AssertResourceEncryptedFunc:    operatorencryption.AssertSecretOfLifeEncrypted,
-		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
-		ResourceFunc:                   operatorencryption.SecretOfLife,
-		ResourceName:                   "SecretOfLife",
-		EncryptionProviders:            library.ShuffleEncryptionProviders([]configv1.EncryptionType{configv1.EncryptionTypeKMS, library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))]}),
+
+	e := library.NewE(t)
+	clientSet := library.GetClients(e)
+
+	providers := library.ShuffleEncryptionProviders([]configv1.EncryptionType{
+		configv1.EncryptionTypeKMS,
+		library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
+	})
+
+	// Step 1: Create test resources for all operators
+	t.Run("CreateResources", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.createResourceFunc(t, clientSet, op.namespace)
+			})
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Step 2: Migrate through each provider in sequence
+	for i, provider := range providers {
+		prefix := "EncryptWith"
+		if i > 0 {
+			prefix = "MigrateTo"
+		}
+		stepName := fmt.Sprintf("%s_%s", prefix, string(provider))
+
+		t.Run(stepName, func(t *testing.T) {
+			setEncryptionAndWaitForAllOperators(t, provider)
+		})
+		if t.Failed() {
+			return
+		}
+
+		t.Run(fmt.Sprintf("AssertEncrypted_%s", string(provider)), func(t *testing.T) {
+			for _, op := range allOperators {
+				t.Run(op.name, func(t *testing.T) {
+					op.assertEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+				})
+			}
+		})
+		if t.Failed() {
+			return
+		}
+	}
+
+	// Step 3: Disable encryption and verify all resources are not encrypted
+	t.Run("DisableEncryption", func(t *testing.T) {
+		setEncryptionAndWaitForAllOperators(t, configv1.EncryptionTypeIdentity)
+	})
+	if t.Failed() {
+		return
+	}
+
+	t.Run("AssertNotEncrypted", func(t *testing.T) {
+		for _, op := range allOperators {
+			t.Run(op.name, func(t *testing.T) {
+				op.assertNotEncryptedFunc(t, clientSet, op.resourceFunc(t, op.namespace))
+			})
+		}
 	})
 }

--- a/test/library/encryption/auth_helpers.go
+++ b/test/library/encryption/auth_helpers.go
@@ -1,0 +1,142 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorlibrary "github.com/openshift/cluster-kube-apiserver-operator/test/library"
+	library "github.com/openshift/library-go/test/library/encryption"
+)
+
+const (
+	AuthTargetNamespace   = "openshift-oauth-apiserver"
+	AuthOperatorNamespace = "openshift-authentication-operator"
+	oauthTokenName        = "sha256~test-oauth-token-of-life"
+)
+
+var AuthTargetGRs = []schema.GroupResource{
+	{Group: "oauth.openshift.io", Resource: "oauthaccesstokens"},
+}
+
+var AuthLabelSelector = "encryption.apiserver.operator.openshift.io/component=" + AuthTargetNamespace
+var AuthEncryptionConfigSecretName = fmt.Sprintf("encryption-config-%s", AuthTargetNamespace)
+
+var oauthAccessTokenGVR = schema.GroupVersionResource{
+	Group:    "oauth.openshift.io",
+	Version:  "v1",
+	Resource: "oauthaccesstokens",
+}
+
+func getDynamicClient(t testing.TB) dynamic.Interface {
+	t.Helper()
+	kubeConfig, err := operatorlibrary.NewClientConfigForTest()
+	require.NoError(t, err)
+	dynClient, err := dynamic.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	return dynClient
+}
+
+func GetRawOAuthTokenOfLife(t testing.TB, clientSet library.ClientSet, _ string) string {
+	t.Helper()
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	prefix := fmt.Sprintf("/openshift.io/oauthaccesstokens/%s", oauthTokenName)
+	resp, err := clientSet.Etcd.Get(timeout, prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	if len(resp.Kvs) != 1 {
+		t.Errorf("Expected to get a single key from etcd for OAuthAccessToken, got %d", len(resp.Kvs))
+	}
+	return string(resp.Kvs[0].Value)
+}
+
+func CreateAndStoreOAuthTokenOfLife(t testing.TB, clientSet library.ClientSet, _ string) runtime.Object {
+	t.Helper()
+	dynClient := getDynamicClient(t)
+	tokenClient := dynClient.Resource(oauthAccessTokenGVR)
+
+	_, err := tokenClient.Get(context.TODO(), oauthTokenName, metav1.GetOptions{})
+	if err == nil {
+		t.Log("The OAuthAccessToken already exists, removing it first")
+		err := tokenClient.Delete(context.TODO(), oauthTokenName, metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Failed to delete OAuthAccessToken %s: %v", oauthTokenName, err)
+		}
+	} else if !errors.IsNotFound(err) {
+		t.Errorf("Failed to check if OAuthAccessToken exists: %v", err)
+	}
+
+	t.Logf("Creating OAuthAccessToken %q", oauthTokenName)
+	token := OAuthTokenOfLife(t, "")
+	created, err := tokenClient.Create(context.TODO(), token.(*unstructured.Unstructured), metav1.CreateOptions{})
+	require.NoError(t, err)
+	return created
+}
+
+func OAuthTokenOfLife(t testing.TB, _ string) runtime.Object {
+	t.Helper()
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "oauth.openshift.io/v1",
+			"kind":       "OAuthAccessToken",
+			"metadata": map[string]interface{}{
+				"name": oauthTokenName,
+			},
+			"clientName":               "openshift-browser-client",
+			"userName":                 "test-user",
+			"userUID":                  "test-uid",
+			"redirectURI":              "https://oauth-openshift.example.com/oauth/token/display",
+			"scopes":                   []interface{}{"user:full"},
+			"expiresIn":                86400,
+			"authorizeToken":           "",
+			"inactivityTimeoutSeconds": 0,
+		},
+	}
+}
+
+func AssertOAuthTokenOfLifeEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
+	t.Helper()
+	rawValue := GetRawOAuthTokenOfLife(t, clientSet, "")
+	if strings.Contains(rawValue, "test-user") {
+		t.Errorf("The OAuthAccessToken in etcd contains plain text 'test-user', content: %s", rawValue)
+	}
+}
+
+func AssertOAuthTokenOfLifeNotEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
+	t.Helper()
+	rawValue := GetRawOAuthTokenOfLife(t, clientSet, "")
+	if !strings.Contains(rawValue, "test-user") {
+		t.Errorf("The OAuthAccessToken in etcd doesn't have 'test-user', content: %s", rawValue)
+	}
+}
+
+func AssertOAuthTokens(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+	t.Helper()
+	assertOAuthAccessTokens(t, clientSet.Etcd, string(expectedMode))
+	library.AssertLastMigratedKey(t, clientSet.Kube, AuthTargetGRs, namespace, labelSelector)
+}
+
+func assertOAuthAccessTokens(t testing.TB, etcdClient library.EtcdClient, expectedMode string) {
+	t.Logf("Checking if all OAuthAccessTokens were encrypted/decrypted for %q mode", expectedMode)
+	total, err := library.VerifyResources(t, etcdClient, "/openshift.io/oauthaccesstokens/", expectedMode, true)
+	t.Logf("Verified %d OAuthAccessTokens", total)
+	require.NoError(t, err)
+}
+
+// Ensure getDynamicClient uses the kubernetes.Interface when needed.
+var _ kubernetes.Interface = (*kubernetes.Clientset)(nil)

--- a/test/library/encryption/auth_helpers.go
+++ b/test/library/encryption/auth_helpers.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorlibrary "github.com/openshift/cluster-kube-apiserver-operator/test/library"
@@ -26,11 +25,12 @@ import (
 const (
 	AuthTargetNamespace   = "openshift-oauth-apiserver"
 	AuthOperatorNamespace = "openshift-authentication-operator"
-	oauthTokenName        = "sha256~test-oauth-token-of-life"
+	oauthTokenName        = "sha256~token-aaaaaaaa-of-aaaaaaaa-life-aaaaaaaa"
 )
 
 var AuthTargetGRs = []schema.GroupResource{
 	{Group: "oauth.openshift.io", Resource: "oauthaccesstokens"},
+	{Group: "oauth.openshift.io", Resource: "oauthauthorizetokens"},
 }
 
 var AuthLabelSelector = "encryption.apiserver.operator.openshift.io/component=" + AuthTargetNamespace
@@ -42,7 +42,7 @@ var oauthAccessTokenGVR = schema.GroupVersionResource{
 	Resource: "oauthaccesstokens",
 }
 
-func getDynamicClient(t testing.TB) dynamic.Interface {
+func getAuthDynamicClient(t testing.TB) dynamic.Interface {
 	t.Helper()
 	kubeConfig, err := operatorlibrary.NewClientConfigForTest()
 	require.NoError(t, err)
@@ -56,18 +56,16 @@ func GetRawOAuthTokenOfLife(t testing.TB, clientSet library.ClientSet, _ string)
 	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	prefix := fmt.Sprintf("/openshift.io/oauthaccesstokens/%s", oauthTokenName)
+	prefix := fmt.Sprintf("/openshift.io/oauth/accesstokens/%s", oauthTokenName)
 	resp, err := clientSet.Etcd.Get(timeout, prefix, clientv3.WithPrefix())
 	require.NoError(t, err)
-	if len(resp.Kvs) != 1 {
-		t.Errorf("Expected to get a single key from etcd for OAuthAccessToken, got %d", len(resp.Kvs))
-	}
+	require.Equalf(t, 1, len(resp.Kvs), "Expected to get a single key from etcd for OAuthAccessToken, got %d", len(resp.Kvs))
 	return string(resp.Kvs[0].Value)
 }
 
 func CreateAndStoreOAuthTokenOfLife(t testing.TB, clientSet library.ClientSet, _ string) runtime.Object {
 	t.Helper()
-	dynClient := getDynamicClient(t)
+	dynClient := getAuthDynamicClient(t)
 	tokenClient := dynClient.Resource(oauthAccessTokenGVR)
 
 	_, err := tokenClient.Get(context.TODO(), oauthTokenName, metav1.GetOptions{})
@@ -92,15 +90,13 @@ func OAuthTokenOfLife(t testing.TB, _ string) runtime.Object {
 	t.Helper()
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "oauth.openshift.io/v1",
-			"kind":       "OAuthAccessToken",
-			"metadata": map[string]interface{}{
-				"name": oauthTokenName,
-			},
-			"clientName":               "openshift-browser-client",
-			"userName":                 "test-user",
-			"userUID":                  "test-uid",
-			"redirectURI":              "https://oauth-openshift.example.com/oauth/token/display",
+			"apiVersion":               "oauth.openshift.io/v1",
+			"kind":                     "OAuthAccessToken",
+			"metadata":                 map[string]interface{}{"name": oauthTokenName},
+			"clientName":               "console",
+			"userName":                 "kube:admin",
+			"userUID":                  "non-existing-user-id",
+			"redirectURI":              "redirect.me.to.token.of.life",
 			"scopes":                   []interface{}{"user:full"},
 			"expiresIn":                86400,
 			"authorizeToken":           "",
@@ -112,31 +108,36 @@ func OAuthTokenOfLife(t testing.TB, _ string) runtime.Object {
 func AssertOAuthTokenOfLifeEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
 	t.Helper()
 	rawValue := GetRawOAuthTokenOfLife(t, clientSet, "")
-	if strings.Contains(rawValue, "test-user") {
-		t.Errorf("The OAuthAccessToken in etcd contains plain text 'test-user', content: %s", rawValue)
+	if strings.Contains(rawValue, "kube:admin") {
+		t.Errorf("The OAuthAccessToken in etcd contains plain text 'kube:admin', content: %s", rawValue)
 	}
 }
 
 func AssertOAuthTokenOfLifeNotEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
 	t.Helper()
 	rawValue := GetRawOAuthTokenOfLife(t, clientSet, "")
-	if !strings.Contains(rawValue, "test-user") {
-		t.Errorf("The OAuthAccessToken in etcd doesn't have 'test-user', content: %s", rawValue)
+	if !strings.Contains(rawValue, "kube:admin") {
+		t.Errorf("The OAuthAccessToken in etcd doesn't have 'kube:admin', content: %s", rawValue)
 	}
 }
 
 func AssertOAuthTokens(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
 	t.Helper()
 	assertOAuthAccessTokens(t, clientSet.Etcd, string(expectedMode))
+	assertOAuthAuthorizeTokens(t, clientSet.Etcd, string(expectedMode))
 	library.AssertLastMigratedKey(t, clientSet.Kube, AuthTargetGRs, namespace, labelSelector)
 }
 
 func assertOAuthAccessTokens(t testing.TB, etcdClient library.EtcdClient, expectedMode string) {
 	t.Logf("Checking if all OAuthAccessTokens were encrypted/decrypted for %q mode", expectedMode)
-	total, err := library.VerifyResources(t, etcdClient, "/openshift.io/oauthaccesstokens/", expectedMode, true)
+	total, err := library.VerifyResources(t, etcdClient, "/openshift.io/oauth/accesstokens/", expectedMode, true)
 	t.Logf("Verified %d OAuthAccessTokens", total)
 	require.NoError(t, err)
 }
 
-// Ensure getDynamicClient uses the kubernetes.Interface when needed.
-var _ kubernetes.Interface = (*kubernetes.Clientset)(nil)
+func assertOAuthAuthorizeTokens(t testing.TB, etcdClient library.EtcdClient, expectedMode string) {
+	t.Logf("Checking if all OAuthAuthorizeTokens were encrypted/decrypted for %q mode", expectedMode)
+	total, err := library.VerifyResources(t, etcdClient, "/openshift.io/oauth/authorizetokens/", expectedMode, true)
+	t.Logf("Verified %d OAuthAuthorizeTokens", total)
+	require.NoError(t, err)
+}

--- a/test/library/encryption/oas_helpers.go
+++ b/test/library/encryption/oas_helpers.go
@@ -1,0 +1,108 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configv1 "github.com/openshift/api/config/v1"
+	library "github.com/openshift/library-go/test/library/encryption"
+)
+
+const (
+	OASTargetNamespace   = "openshift-apiserver"
+	OASOperatorNamespace = "openshift-apiserver-operator"
+)
+
+var OASTargetGRs = []schema.GroupResource{
+	{Group: "", Resource: "secrets"},
+	{Group: "", Resource: "configmaps"},
+}
+
+var OASLabelSelector = "encryption.apiserver.operator.openshift.io/component=openshift-apiserver"
+var OASEncryptionConfigSecretName = fmt.Sprintf("encryption-config-%s", OASTargetNamespace)
+
+func GetRawOASSecretOfLife(t testing.TB, clientSet library.ClientSet, namespace string) string {
+	t.Helper()
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	prefix := fmt.Sprintf("/kubernetes.io/secrets/%s/%s", namespace, "oas-secret-of-life")
+	resp, err := clientSet.Etcd.Get(timeout, prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	if len(resp.Kvs) != 1 {
+		t.Errorf("Expected to get a single key from etcd, got %d", len(resp.Kvs))
+	}
+	return string(resp.Kvs[0].Value)
+}
+
+func CreateAndStoreOASSecretOfLife(t testing.TB, clientSet library.ClientSet, namespace string) runtime.Object {
+	t.Helper()
+
+	oldSecret, err := clientSet.Kube.CoreV1().Secrets(namespace).Get(context.TODO(), "oas-secret-of-life", metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		t.Errorf("Failed to check if the secret already exists: %v", err)
+	}
+	if len(oldSecret.Name) > 0 {
+		t.Log("The OAS secret already exists, removing it first")
+		err := clientSet.Kube.CoreV1().Secrets(namespace).Delete(context.TODO(), oldSecret.Name, metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Failed to delete %s: %v", oldSecret.Name, err)
+		}
+	}
+
+	t.Logf("Creating %q in %s namespace", "oas-secret-of-life", namespace)
+	raw := OASSecretOfLife(t, namespace)
+	secret, err := clientSet.Kube.CoreV1().Secrets(namespace).Create(context.TODO(), raw.(*corev1.Secret), metav1.CreateOptions{})
+	require.NoError(t, err)
+	return secret
+}
+
+func OASSecretOfLife(t testing.TB, namespace string) runtime.Object {
+	t.Helper()
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oas-secret-of-life",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"quote": []byte("The only way to do great work is to love what you do"),
+		},
+	}
+}
+
+func AssertOASSecretOfLifeEncrypted(t testing.TB, clientSet library.ClientSet, raw runtime.Object) {
+	t.Helper()
+	secret := raw.(*corev1.Secret)
+	rawValue := GetRawOASSecretOfLife(t, clientSet, secret.Namespace)
+	if strings.Contains(rawValue, string(secret.Data["quote"])) {
+		t.Errorf("The OAS secret in etcd contains plain text %q, content: %s", string(secret.Data["quote"]), rawValue)
+	}
+}
+
+func AssertOASSecretOfLifeNotEncrypted(t testing.TB, clientSet library.ClientSet, raw runtime.Object) {
+	t.Helper()
+	secret := raw.(*corev1.Secret)
+	rawValue := GetRawOASSecretOfLife(t, clientSet, secret.Namespace)
+	if !strings.Contains(rawValue, string(secret.Data["quote"])) {
+		t.Errorf("The OAS secret in etcd doesn't have %q, content: %s", string(secret.Data["quote"]), rawValue)
+	}
+}
+
+func AssertOASSecretsAndConfigMaps(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+	t.Helper()
+	assertSecrets(t, clientSet.Etcd, string(expectedMode))
+	assertConfigMaps(t, clientSet.Etcd, string(expectedMode))
+	library.AssertLastMigratedKey(t, clientSet.Kube, OASTargetGRs, namespace, labelSelector)
+}

--- a/test/library/encryption/oas_helpers.go
+++ b/test/library/encryption/oas_helpers.go
@@ -10,99 +10,130 @@ import (
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorlibrary "github.com/openshift/cluster-kube-apiserver-operator/test/library"
 	library "github.com/openshift/library-go/test/library/encryption"
 )
 
 const (
 	OASTargetNamespace   = "openshift-apiserver"
 	OASOperatorNamespace = "openshift-apiserver-operator"
+	oasRouteName         = "route-of-life"
+	oasRouteNamespace    = "openshift-apiserver"
 )
 
 var OASTargetGRs = []schema.GroupResource{
-	{Group: "", Resource: "secrets"},
-	{Group: "", Resource: "configmaps"},
+	{Group: "route.openshift.io", Resource: "routes"},
 }
 
-var OASLabelSelector = "encryption.apiserver.operator.openshift.io/component=openshift-apiserver"
+var OASLabelSelector = "encryption.apiserver.operator.openshift.io/component=" + OASTargetNamespace
 var OASEncryptionConfigSecretName = fmt.Sprintf("encryption-config-%s", OASTargetNamespace)
 
-func GetRawOASSecretOfLife(t testing.TB, clientSet library.ClientSet, namespace string) string {
+var routeGVR = schema.GroupVersionResource{
+	Group:    "route.openshift.io",
+	Version:  "v1",
+	Resource: "routes",
+}
+
+func getOASDynamicClient(t testing.TB) dynamic.Interface {
 	t.Helper()
-	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	kubeConfig, err := operatorlibrary.NewClientConfigForTest()
+	require.NoError(t, err)
+	dynClient, err := dynamic.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	return dynClient
+}
+
+func GetRawOASRouteOfLife(t testing.TB, clientSet library.ClientSet, namespace string) string {
+	t.Helper()
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	prefix := fmt.Sprintf("/kubernetes.io/secrets/%s/%s", namespace, "oas-secret-of-life")
+	prefix := fmt.Sprintf("/openshift.io/routes/%s/%s", namespace, oasRouteName)
 	resp, err := clientSet.Etcd.Get(timeout, prefix, clientv3.WithPrefix())
 	require.NoError(t, err)
-	if len(resp.Kvs) != 1 {
-		t.Errorf("Expected to get a single key from etcd, got %d", len(resp.Kvs))
-	}
+	require.Equalf(t, 1, len(resp.Kvs), "Expected to get a single key from etcd for Route, got %d", len(resp.Kvs))
 	return string(resp.Kvs[0].Value)
 }
 
-func CreateAndStoreOASSecretOfLife(t testing.TB, clientSet library.ClientSet, namespace string) runtime.Object {
+func CreateAndStoreOASRouteOfLife(t testing.TB, clientSet library.ClientSet, _ string) runtime.Object {
 	t.Helper()
+	dynClient := getOASDynamicClient(t)
+	routeClient := dynClient.Resource(routeGVR).Namespace(oasRouteNamespace)
 
-	oldSecret, err := clientSet.Kube.CoreV1().Secrets(namespace).Get(context.TODO(), "oas-secret-of-life", metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		t.Errorf("Failed to check if the secret already exists: %v", err)
-	}
-	if len(oldSecret.Name) > 0 {
-		t.Log("The OAS secret already exists, removing it first")
-		err := clientSet.Kube.CoreV1().Secrets(namespace).Delete(context.TODO(), oldSecret.Name, metav1.DeleteOptions{})
+	_, err := routeClient.Get(context.TODO(), oasRouteName, metav1.GetOptions{})
+	if err == nil {
+		t.Log("The OAS Route already exists, removing it first")
+		err := routeClient.Delete(context.TODO(), oasRouteName, metav1.DeleteOptions{})
 		if err != nil {
-			t.Errorf("Failed to delete %s: %v", oldSecret.Name, err)
+			t.Errorf("Failed to delete Route %s: %v", oasRouteName, err)
 		}
+	} else if !errors.IsNotFound(err) {
+		t.Errorf("Failed to check if Route exists: %v", err)
 	}
 
-	t.Logf("Creating %q in %s namespace", "oas-secret-of-life", namespace)
-	raw := OASSecretOfLife(t, namespace)
-	secret, err := clientSet.Kube.CoreV1().Secrets(namespace).Create(context.TODO(), raw.(*corev1.Secret), metav1.CreateOptions{})
+	t.Logf("Creating Route %q in %s namespace", oasRouteName, oasRouteNamespace)
+	route := OASRouteOfLife(t, oasRouteNamespace)
+	created, err := routeClient.Create(context.TODO(), route.(*unstructured.Unstructured), metav1.CreateOptions{})
 	require.NoError(t, err)
-	return secret
+	return created
 }
 
-func OASSecretOfLife(t testing.TB, namespace string) runtime.Object {
+func OASRouteOfLife(t testing.TB, namespace string) runtime.Object {
 	t.Helper()
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "oas-secret-of-life",
-			Namespace: namespace,
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "route.openshift.io/v1",
+			"kind":       "Route",
+			"metadata": map[string]interface{}{
+				"name":      oasRouteName,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"host": "devcluster.openshift.io",
+				"port": map[string]interface{}{
+					"targetPort": float64(2014),
+				},
+				"to": map[string]interface{}{
+					"name": "dummyroute",
+				},
+			},
 		},
-		Data: map[string][]byte{
-			"quote": []byte("The only way to do great work is to love what you do"),
-		},
 	}
 }
 
-func AssertOASSecretOfLifeEncrypted(t testing.TB, clientSet library.ClientSet, raw runtime.Object) {
+func AssertOASRouteOfLifeEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
 	t.Helper()
-	secret := raw.(*corev1.Secret)
-	rawValue := GetRawOASSecretOfLife(t, clientSet, secret.Namespace)
-	if strings.Contains(rawValue, string(secret.Data["quote"])) {
-		t.Errorf("The OAS secret in etcd contains plain text %q, content: %s", string(secret.Data["quote"]), rawValue)
+	rawValue := GetRawOASRouteOfLife(t, clientSet, oasRouteNamespace)
+	if strings.Contains(rawValue, "dummyroute") {
+		t.Errorf("Route not encrypted, route received from etcd has %q (plain text), raw content in etcd is %s", "dummyroute", rawValue)
 	}
 }
 
-func AssertOASSecretOfLifeNotEncrypted(t testing.TB, clientSet library.ClientSet, raw runtime.Object) {
+func AssertOASRouteOfLifeNotEncrypted(t testing.TB, clientSet library.ClientSet, _ runtime.Object) {
 	t.Helper()
-	secret := raw.(*corev1.Secret)
-	rawValue := GetRawOASSecretOfLife(t, clientSet, secret.Namespace)
-	if !strings.Contains(rawValue, string(secret.Data["quote"])) {
-		t.Errorf("The OAS secret in etcd doesn't have %q, content: %s", string(secret.Data["quote"]), rawValue)
+	rawValue := GetRawOASRouteOfLife(t, clientSet, oasRouteNamespace)
+	if !strings.Contains(rawValue, "dummyroute") {
+		t.Errorf("Route received from etcd doesn't have %q (plain text), raw content in etcd is %s", "dummyroute", rawValue)
 	}
 }
 
-func AssertOASSecretsAndConfigMaps(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
+func AssertOASRoutes(t testing.TB, clientSet library.ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string) {
 	t.Helper()
-	assertSecrets(t, clientSet.Etcd, string(expectedMode))
-	assertConfigMaps(t, clientSet.Etcd, string(expectedMode))
+	assertRoutes(t, clientSet.Etcd, string(expectedMode))
 	library.AssertLastMigratedKey(t, clientSet.Kube, OASTargetGRs, namespace, labelSelector)
+}
+
+func assertRoutes(t testing.TB, etcdClient library.EtcdClient, expectedMode string) {
+	t.Logf("Checking if all Routes were encrypted/decrypted for %q mode", expectedMode)
+	totalRoutes, err := library.VerifyResources(t, etcdClient, "/openshift.io/routes/", expectedMode, false)
+	t.Logf("Verified %d Routes", totalRoutes)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Adds a new OTE (Operator Test Extension) suite openshift/encryption-kms/operator/disruptive in cmd/cluster-kube-apiserver-operator-tests-ext/main.go. The suite:

Runs with parallelism of 1 (serial execution)
Qualifies tests matching [Suite:KMS]
Marked as ClusterStabilityDisruptive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a disruptive KMS encryption test suite to expand disruptive coverage alongside existing suites.
  * Enhanced encryption e2e tests to run per-operator variants, exercising encryption on/off and provider-migration scenarios across operators.
  * Added helpers to create, store, read, and assert encryption state for OAuth tokens and OAS secrets in e2e tests.

* **Refactor**
  * Consolidated test configuration to drive per-operator subtests instead of a single hard-coded scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->