### PR TITLE
[release-4.22] OCPBUGS-83770: Allow setting the oauthMetadata when auth type is None

### DIFF
--- a/pkg/operator/configobservation/auth/auth_metadata.go
+++ b/pkg/operator/configobservation/auth/auth_metadata.go
@@ -84,8 +84,13 @@ func ObserveAuthMetadata(genericListers configobserver.Listers, recorder events.
 		}
 
 	case configv1.AuthenticationTypeNone:
-		// no oauth metadata is served; do not set anything as source
-		// in order to delete the configmap and unset oauthMetadataFile
+		// spec.oauthMetadata is allowed when type is None; use it as the
+		// source if set, otherwise leave source empty to delete the configmap
+		// and unset oauthMetadataFile
+		if len(authConfig.Spec.OAuthMetadata.Name) > 0 {
+			sourceConfigMap = authConfig.Spec.OAuthMetadata.Name
+			sourceNamespace = configNamespace
+		}
 
 	case configv1.AuthenticationTypeOIDC:
 		if _, err := listers.ConfigmapLister_.ConfigMaps(operatorclient.TargetNamespace).Get(AuthConfigCMName); errors.IsNotFound(err) {

--- a/pkg/operator/configobservation/auth/auth_metadata_test.go
+++ b/pkg/operator/configobservation/auth/auth_metadata_test.go
@@ -18,18 +18,18 @@ import (
 )
 
 var (
-	unprunedBaseAuthMetadataConfig = map[string]interface{}{
-		"apiServerArguments": map[string]interface{}{
+	unprunedBaseAuthMetadataConfig = map[string]any{
+		"apiServerArguments": map[string]any{
 			"authentication-token-webhook-config-file": webhookTokenAuthenticatorFile,
 			"authentication-token-webhook-version":     webhookTokenAuthenticatorVersion,
 		},
-		"authConfig": map[string]interface{}{
+		"authConfig": map[string]any{
 			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
 		},
 	}
 
-	prunedBaseAuthMetadataConfig = map[string]interface{}{
-		"authConfig": map[string]interface{}{
+	prunedBaseAuthMetadataConfig = map[string]any{
+		"authConfig": map[string]any{
 			"oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata",
 		},
 	}
@@ -43,20 +43,20 @@ func TestObserveAuthMetadata(t *testing.T) {
 		authIndexer cache.Indexer
 		cmIndexer   cache.Indexer
 
-		existingConfig     map[string]interface{}
+		existingConfig     map[string]any
 		authConfigMap      *corev1.ConfigMap
 		authSpec           *configv1.AuthenticationSpec
 		statusMetadataName string
 		syncerError        error
 
-		expectedConfig map[string]interface{}
+		expectedConfig map[string]any
 		expectedSynced map[string]string
 		expectErrors   bool
 	}{
 		{
 			name:           "auth resource not found",
 			authSpec:       nil,
-			expectedConfig: map[string]interface{}{},
+			expectedConfig: map[string]any{},
 			expectedSynced: nil,
 			expectErrors:   false,
 		},
@@ -152,6 +152,21 @@ func TestObserveAuthMetadata(t *testing.T) {
 				Type: configv1.AuthenticationTypeNone,
 				OAuthMetadata: configv1.ConfigMapNameReference{
 					Name: "metadata-from-spec",
+				},
+			},
+			statusMetadataName: "metadata-from-status",
+			expectedConfig:     prunedBaseAuthMetadataConfig,
+			expectedSynced: map[string]string{
+				"configmap/oauth-metadata.openshift-kube-apiserver": "configmap/metadata-from-spec.openshift-config",
+			},
+			expectErrors: false,
+		},
+		{
+			name: "empty auth metadata with auth type None",
+			authSpec: &configv1.AuthenticationSpec{
+				Type: configv1.AuthenticationTypeNone,
+				OAuthMetadata: configv1.ConfigMapNameReference{
+					Name: "",
 				},
 			},
 			statusMetadataName: "metadata-from-status",
@@ -280,7 +295,7 @@ func TestObserveAuthMetadata(t *testing.T) {
 			eventRecorder := events.NewInMemoryRecorder("authmetadatatest", clock.RealClock{})
 
 			if tt.authIndexer == nil {
-				tt.authIndexer = cache.NewIndexer(func(obj interface{}) (string, error) {
+				tt.authIndexer = cache.NewIndexer(func(obj any) (string, error) {
 					return "cluster", nil
 				}, cache.Indexers{})
 			}


### PR DESCRIPTION
Manual cherry-pick of #2105

Replaces #2111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed accelerated certificate rotation behavior; certificates now rotate on standard schedule.

* **New Features**
  * OAuth metadata configuration is now optional when authentication type is set to None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->