### PR TITLE
[WIP] KMS: add a post check function to revision controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,3 +136,5 @@ require (
 )
 
 replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+
+replace github.com/openshift/library-go => github.com/bertinatto/library-go v0.0.0-20260618191728-9261746c2746

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfT
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bertinatto/library-go v0.0.0-20260618191728-9261746c2746 h1:KXRsBhgKnGyTfuZugVXRbwHpm+LfX8348AB5op6Z3Gk=
+github.com/bertinatto/library-go v0.0.0-20260618191728-9261746c2746/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -165,8 +167,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b h1:fmTTzoHLhRf4QsMKw4cEbnvUeUcgcaNesh5mueWnaVs=
-github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/kms/postcondition.go
+++ b/pkg/operator/kms/postcondition.go
@@ -59,7 +59,7 @@ func kmsRevisionPostcondition(ctx context.Context, kubeClient kubernetes.Interfa
 		return fmt.Errorf("kms revision post-check: failed to get kube-apiserver-pod for revision %d: %w", revision, err)
 	}
 
-	expectedSidecars, err := buildExpectedKMSSidecars(encryptionSecret)
+	expectedSidecars, err := buildExpectedKMSSidecars("encryption-config", encryptionSecret)
 	if err != nil {
 		return fmt.Errorf("kms revision post-check: failed to build expected sidecars for revision %d: %w", revision, err)
 	}
@@ -73,15 +73,15 @@ func kmsRevisionPostcondition(ctx context.Context, kubeClient kubernetes.Interfa
 	sortContainersByName(actualSidecars)
 
 	if !equality.Semantic.DeepEqual(expectedSidecars, actualSidecars) {
-		return fmt.Errorf("kms revision post-check: revision %d has inconsistent KMS sidecars: expected=%v actual=%v",
-			revision, containerNames(expectedSidecars), containerNames(actualSidecars))
+		return fmt.Errorf("kms revision post-check: revision %d has inconsistent KMS sidecars: expected=%+v actual=%+v",
+			revision, expectedSidecars, actualSidecars)
 	}
 
 	klog.V(4).Infof("kms revision post-check passed for revision %d: sidecars=%v", revision, containerNames(expectedSidecars))
 	return nil
 }
 
-func buildExpectedKMSSidecars(encryptionSecret *corev1.Secret) ([]corev1.Container, error) {
+func buildExpectedKMSSidecars(encryptionConfigSecretName string, encryptionSecret *corev1.Secret) ([]corev1.Container, error) {
 	cfg, err := encryptiondata.FromSecret(encryptionSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionSecret.Namespace, encryptionSecret.Name, err)
@@ -94,8 +94,11 @@ func buildExpectedKMSSidecars(encryptionSecret *corev1.Secret) ([]corev1.Contain
 		Containers: []corev1.Container{{Name: "kube-apiserver"}},
 	}
 
+	// Use the non-revisioned secret name so the builder generates the same
+	// file paths (e.g. -approle-secret-id-path, -tls-ca-file) that the
+	// target config controller used when it originally built the pod spec.
 	if err := kmspluginlifecycle.NewKMSPluginBuilder().
-		FromEncryptionConfig(encryptionSecret.Name, cfg).
+		FromEncryptionConfig(encryptionConfigSecretName, cfg).
 		AsStaticPod().
 		Apply(podSpec, "kube-apiserver"); err != nil {
 		return nil, err

--- a/pkg/operator/kms/postcondition.go
+++ b/pkg/operator/kms/postcondition.go
@@ -1,0 +1,158 @@
+package kms
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/openshift/api/features"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	kmspluginlifecycle "github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle"
+	"github.com/openshift/library-go/pkg/operator/revisioncontroller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+func KMSRevisionPostcondition(kubeClient kubernetes.Interface, featureGateAccessor featuregates.FeatureGateAccess) revisioncontroller.PostconditionFunc {
+	return func(ctx context.Context, revision int32) (bool, error) {
+		err := kmsRevisionPostcondition(ctx, kubeClient, featureGateAccessor, revision)
+		return err == nil, err
+	}
+}
+
+func kmsRevisionPostcondition(ctx context.Context, kubeClient kubernetes.Interface, featureGateAccessor featuregates.FeatureGateAccess, revision int32) error {
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
+	}
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return nil
+	}
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
+		return nil
+	}
+
+	revSuffix := fmt.Sprintf("-%d", revision)
+
+	encryptionSecretName := "encryption-config" + revSuffix
+	encryptionSecret, err := kubeClient.CoreV1().Secrets(operatorclient.TargetNamespace).Get(ctx, encryptionSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("kms revision post-check: failed to get encryption-config for revision %d: %w", revision, err)
+	}
+
+	podCM, err := kubeClient.CoreV1().ConfigMaps(operatorclient.TargetNamespace).Get(ctx, "kube-apiserver-pod"+revSuffix, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("kms revision post-check: failed to get kube-apiserver-pod for revision %d: %w", revision, err)
+	}
+
+	expectedSidecars, err := buildExpectedKMSSidecars(encryptionSecret)
+	if err != nil {
+		return fmt.Errorf("kms revision post-check: failed to build expected sidecars for revision %d: %w", revision, err)
+	}
+
+	actualSidecars, err := extractKMSSidecarsFromPod(podCM)
+	if err != nil {
+		return fmt.Errorf("kms revision post-check: failed to extract sidecars from pod for revision %d: %w", revision, err)
+	}
+
+	sortContainersByName(expectedSidecars)
+	sortContainersByName(actualSidecars)
+
+	if !equality.Semantic.DeepEqual(expectedSidecars, actualSidecars) {
+		return fmt.Errorf("kms revision post-check: revision %d has inconsistent KMS sidecars: expected=%v actual=%v",
+			revision, containerNames(expectedSidecars), containerNames(actualSidecars))
+	}
+
+	klog.V(4).Infof("kms revision post-check passed for revision %d: sidecars=%v", revision, containerNames(expectedSidecars))
+	return nil
+}
+
+func buildExpectedKMSSidecars(encryptionSecret *corev1.Secret) ([]corev1.Container, error) {
+	cfg, err := encryptiondata.FromSecret(encryptionSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionSecret.Namespace, encryptionSecret.Name, err)
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "kube-apiserver"}},
+	}
+
+	if err := kmspluginlifecycle.NewKMSPluginBuilder().
+		FromEncryptionConfig(encryptionSecret.Name, cfg).
+		AsStaticPod().
+		Apply(podSpec, "kube-apiserver"); err != nil {
+		return nil, err
+	}
+
+	return podSpec.InitContainers, nil
+}
+
+// extractKMSSidecarsFromPod parses the kube-apiserver-pod ConfigMap and returns
+// only the init containers that are KMS plugin sidecars.
+func extractKMSSidecarsFromPod(podCM *corev1.ConfigMap) ([]corev1.Container, error) {
+	podJSON, ok := podCM.Data["pod.yaml"]
+	if !ok {
+		return nil, nil
+	}
+
+	var pod corev1.Pod
+	if err := json.Unmarshal([]byte(podJSON), &pod); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pod spec: %w", err)
+	}
+
+	var sidecars []corev1.Container
+	for _, c := range pod.Spec.InitContainers {
+		if isKMSSidecar(c.Name) {
+			sidecars = append(sidecars, c)
+		}
+	}
+	return sidecars, nil
+}
+
+// isKMSSidecar returns true if the container name matches the naming convention
+// used by any known KMS sidecar provider ({provider-base}-{keyID}).
+// TODO(bertinatto): move naming convention to library-go's pluginlifecycle
+// package so this operator and the sidecar injection share a single source of truth.
+func isKMSSidecar(containerName string) bool {
+	for _, prefix := range kmsSidecarPrefixes {
+		if strings.HasPrefix(containerName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+var kmsSidecarPrefixes = []string{
+	"vault-kms-plugin-",
+}
+
+func sortContainersByName(containers []corev1.Container) {
+	sort.Slice(containers, func(i, j int) bool {
+		return containers[i].Name < containers[j].Name
+	})
+}
+
+func containerNames(containers []corev1.Container) []string {
+	names := make([]string, len(containers))
+	for i, c := range containers {
+		names[i] = c.Name
+	}
+	return names
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/node"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/connectivitycheckcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/highcpuusagealertcontroller"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/kms"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/kubeletversionskewcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/nodekubeconfigcontroller"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
@@ -351,6 +352,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			},
 		).
 		WithOperandPodLabelSelector(labels.Set{"apiserver": "true"}.AsSelector()).
+		WithRevisionControllerPostcondition(kms.KMSRevisionPostcondition(kubeClient, featureGateAccessor)).
 		ToControllers()
 	if err != nil {
 		return err

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -432,6 +432,8 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 // kmsProviderConfig abstracts provider-specific KMS logic so that every
 // provider-type switch lives in a single factory (newKMSProviderConfig).
 type kmsProviderConfig interface {
+	// sourceConfig returns the provider-specific API configuration.
+	sourceConfig() interface{}
 	// referencedSecretName returns the name of the secret referenced by the KMS plugin
 	// config and the specific data keys to carry from that secret. Only the listed keys
 	// are copied into the Key Secret; any other data in the referenced secret is ignored.
@@ -453,6 +455,10 @@ func newKMSProviderConfig(plugin configv1.KMSPluginConfig) (kmsProviderConfig, e
 
 type vaultProviderConfig struct {
 	vault configv1.VaultKMSPluginConfig
+}
+
+func (v *vaultProviderConfig) sourceConfig() interface{} {
+	return v.vault
 }
 
 func (v *vaultProviderConfig) referencedSecretName() (string, []string, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -1,0 +1,269 @@
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type kmsConfigHasher struct {
+	provider   kmsProviderConfig
+	coreClient corev1client.CoreV1Interface
+	namespace  string
+}
+
+// newKMSConfigHasher creates a hasher for a KMS provider config and its referenced resources.
+// namespace is the namespace where the referenced Secrets and ConfigMaps are stored (e.g., openshift-config).
+func newKMSConfigHasher(provider kmsProviderConfig, coreClient corev1client.CoreV1Interface, namespace string) *kmsConfigHasher {
+	return &kmsConfigHasher{provider: provider, coreClient: coreClient, namespace: namespace}
+}
+
+// hash computes a deterministic hash over the provider config and the specific data keys
+// from its referenced Secret and ConfigMap. Uses FNV-32, JSON encoding, and base64 URL
+// encoding, consistent with resourcehash.GetSecretHash and resourcehash.GetConfigMapHash.
+func (h *kmsConfigHasher) hash(ctx context.Context) (string, error) {
+	hasher := fnv.New32()
+
+	if err := json.NewEncoder(hasher).Encode(h.provider.sourceConfig()); err != nil {
+		return "", fmt.Errorf("failed to hash provider config: %w", err)
+	}
+
+	if err := h.hashReferencedSecret(ctx, hasher); err != nil {
+		return "", err
+	}
+	if err := h.hashReferencedConfigMap(ctx, hasher); err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func (h *kmsConfigHasher) hashReferencedSecret(ctx context.Context, hasher hash.Hash) error {
+	name, keys, err := h.provider.referencedSecretName()
+	if err != nil {
+		return fmt.Errorf("failed to get referenced secret name: %w", err)
+	}
+	if name == "" {
+		return nil
+	}
+
+	secret, err := h.coreClient.Secrets(h.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get secret %s/%s: %w", h.namespace, name, err)
+	}
+
+	// Write each key name before its value to prevent collisions when bytes
+	// shift between adjacent values (e.g. role-id="ab",secret-id="cd" vs
+	// role-id="abc",secret-id="d" would otherwise both hash as "abcd").
+	sort.Strings(keys)
+	for _, k := range keys {
+		v, ok := secret.Data[k]
+		if !ok {
+			return fmt.Errorf("key %q not found in secret %s/%s", k, h.namespace, name)
+		}
+		if _, err := hasher.Write([]byte(k)); err != nil {
+			return fmt.Errorf("failed to hash key %q: %w", k, err)
+		}
+		if _, err := hasher.Write(v); err != nil {
+			return fmt.Errorf("failed to hash key %q: %w", k, err)
+		}
+	}
+	return nil
+}
+
+func (h *kmsConfigHasher) hashReferencedConfigMap(ctx context.Context, hasher hash.Hash) error {
+	name, keys, err := h.provider.referencedConfigMapName()
+	if err != nil {
+		return fmt.Errorf("failed to get referenced configmap name: %w", err)
+	}
+	if name == "" {
+		return nil
+	}
+
+	cm, err := h.coreClient.ConfigMaps(h.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get configmap %s/%s: %w", h.namespace, name, err)
+	}
+
+	sort.Strings(keys)
+	for _, k := range keys {
+		v, ok := cm.Data[k]
+		if !ok {
+			return fmt.Errorf("key %q not found in configmap %s/%s", k, h.namespace, name)
+		}
+		if _, err := hasher.Write([]byte(k)); err != nil {
+			return fmt.Errorf("failed to hash key %q: %w", k, err)
+		}
+		if _, err := hasher.Write([]byte(v)); err != nil {
+			return fmt.Errorf("failed to hash key %q: %w", k, err)
+		}
+	}
+	return nil
+}
+
+type kmsPreflightController struct {
+	controllerInstanceName string
+
+	operatorClient  operatorv1helpers.OperatorClient
+	apiServerClient configv1client.APIServerInterface
+
+	provider                 Provider
+	preconditionsFulfilledFn preconditionsFulfilled
+}
+
+// NewKMSPreflightController validates KMS configuration before a key is created.
+//
+// Coordination with the key-controller:
+//
+// The key-controller writes a hash of the current KMS config to operator status
+// as the EncryptionKMSPreflightRequired condition (hash in the message).
+// This controller reads that hash, runs preflight checks, and on success sets
+// the EncryptionKMSPreflightSucceeded condition (same hash in the message).
+// The key-controller waits for the two hashes to match before creating a key.
+//
+// This is the same pattern used by the revision and installer controllers:
+// the revision controller writes LatestAvailableRevision, the installer
+// controller reads it and acts.
+//
+// Without this protocol the following race can occur:
+//  1. Preflight passes for config A, hash A written to operator status.
+//  2. Key-controller reads hash A, starts creating a key for config A.
+//  3. Config changes to B.
+//  4. Preflight controller syncs, sees config B, does not yet see the key
+//     for A (key-controller is in the process of creating the key),
+//     runs preflight for B, overwrites status with hash B.
+//  5. The key created in step 2 was for config A but status now says B.
+//
+// Letting the key-controller own EncryptionKMSPreflightRequired and this
+// controller own EncryptionKMSPreflightSucceeded solves this. If the config
+// changes mid-flight the key-controller posts a new hash and the preflight
+// controller sees the mismatch and waits.
+//
+// Example 1: config changes before key is created
+//  1. User creates KMS config A.
+//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
+//  3. Preflight controller sees required=A, starts checking A.
+//  4. User changes config to A2 (minor variation, different hash).
+//  5. Key-controller computes hash A2, writes EncryptionKMSPreflightRequired=A2.
+//  6. Preflight controller sees required=A2, starts checking A2.
+//  7. Key-controller does not create a key until succeeded=A2.
+//
+// Example 2: config changes after key is created
+//  1. User creates KMS config A.
+//  2. Key-controller computes hash A, writes EncryptionKMSPreflightRequired=A.
+//  3. Preflight controller checks A, succeeds, writes EncryptionKMSPreflightSucceeded=A.
+//  4. Key-controller sees required=A matches succeeded=A, creates key for A.
+//  5. User changes config to A2 (or B).
+//  6. Key-controller waits until the key for A completes the full cycle
+//     (read, write, migrated) before creating a new key. No preflight done
+//     at this stage.
+//
+// Preflight workload:
+//
+// A deployer interface abstracts the workload creation. Each operator provides
+// its own implementation that knows how to install, get status, clean up the
+// preflight workload, and wire the credentials needed to update pod status.
+// The workload type matches the API server it validates (static pod for kas-o,
+// Deployment for aggregated API servers).
+//
+// When an existing KMS plugin is already configured, the checker runs the new
+// plugin alongside the existing one to catch co-existence issues (e.g., metric
+// port collisions). When no plugin is configured yet, it runs the new plugin alone.
+// The sync method reads existing encryption key secrets to determine whether
+// a plugin is already configured.
+//
+// The pod uses readiness gates to post check results back to the controller.
+// To set the readiness gate condition, the pod PATCHes its own status using
+// credentials wired by the deployer.
+// The controller reads these enhanced pod statuses to update its own operator
+// status, which is propagated to end users.
+//
+// After a successful check the preflight pod is kept for a short period (e.g. 1h)
+// so that its logs can be inspected, then cleaned up by a subsequent sync.
+func NewKMSPreflightController(
+	instanceName string,
+	provider Provider,
+	preconditionsFulfilledFn preconditionsFulfilled,
+	operatorClient operatorv1helpers.OperatorClient,
+	apiServerClient configv1client.APIServerInterface,
+	apiServerInformer configv1informers.APIServerInformer,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &kmsPreflightController{
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "EncryptionKMSPreflight"),
+
+		operatorClient:  operatorClient,
+		apiServerClient: apiServerClient,
+
+		provider:                 provider,
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithControllerInstanceName(c.controllerInstanceName).
+		ResyncEvery(time.Minute).
+		WithInformers(
+			apiServerInformer.Informer(),
+			operatorClient.Informer(),
+		).ToController(
+		c.controllerInstanceName,
+		eventRecorder.WithComponentSuffix("encryption-kms-preflight-controller"),
+	)
+}
+
+func (c *kmsPreflightController) sync(ctx context.Context, syncCtx factory.SyncContext) (err error) {
+	degradedCondition := applyoperatorv1.OperatorCondition().WithType("EncryptionKMSPreflightControllerDegraded")
+
+	defer func() {
+		if degradedCondition == nil {
+			return
+		}
+		status := applyoperatorv1.OperatorStatus().WithConditions(degradedCondition)
+		if applyError := c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, status); applyError != nil {
+			err = applyError
+		}
+	}()
+
+	if ready, err := shouldRunEncryptionController(c.operatorClient, c.preconditionsFulfilledFn, c.provider.ShouldRunEncryptionControllers); err != nil || !ready {
+		if err != nil {
+			degradedCondition = nil
+		} else {
+			degradedCondition = degradedCondition.WithStatus(operatorv1.ConditionFalse)
+		}
+		return err // we will get re-kicked when the operator status updates
+	}
+
+	preflightErr := c.runPreflightChecks(ctx)
+	if preflightErr != nil {
+		degradedCondition = degradedCondition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("Error").
+			WithMessage(preflightErr.Error())
+	} else {
+		degradedCondition = degradedCondition.
+			WithStatus(operatorv1.ConditionFalse)
+	}
+	return preflightErr
+}
+
+func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) error {
+	return fmt.Errorf("implement me")
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -1,0 +1,163 @@
+package pluginlifecycle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+)
+
+// KMSPluginBuilder constructs KMS plugin pod spec contributions for injection
+// into API server pods.
+type KMSPluginBuilder struct {
+	encryptionConfig           *encryptiondata.Config
+	encryptionConfigSecretName string
+	staticPod                  bool
+}
+
+// NewKMSPluginBuilder creates a builder that defaults to deployment mode.
+func NewKMSPluginBuilder() *KMSPluginBuilder {
+	return &KMSPluginBuilder{}
+}
+
+// FromEncryptionConfig loads all KMS plugins from a parsed encryption config.
+// The encryptionConfigSecretName identifies the Secret the config was parsed
+// from; it is used for volume configuration in both deployment and static pod
+// modes.
+func (b *KMSPluginBuilder) FromEncryptionConfig(encryptionConfigSecretName string, cfg *encryptiondata.Config) *KMSPluginBuilder {
+	b.encryptionConfigSecretName = encryptionConfigSecretName
+	b.encryptionConfig = cfg
+	return b
+}
+
+// AsStaticPod switches the builder to static pod mode. Sidecars will reference
+// data from the resource-dir volume and run as root (UID 0).
+func (b *KMSPluginBuilder) AsStaticPod() *KMSPluginBuilder {
+	b.staticPod = true
+	return b
+}
+
+// Apply mutates the given pod spec by injecting KMS plugin sidecars, volumes,
+// and volume mounts. containerName identifies the API server container that
+// needs the socket volume mount.
+//
+// It is a no-op (returns nil error) when no KMS plugins are found.
+// It is idempotent.
+func (b *KMSPluginBuilder) Apply(podSpec *corev1.PodSpec, containerName string) error {
+	if podSpec == nil {
+		return fmt.Errorf("pod spec cannot be nil")
+	}
+	if containerName == "" {
+		return fmt.Errorf("container name cannot be empty")
+	}
+
+	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(b.encryptionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get KMS configurations: %w", err)
+	}
+	if len(kmsConfigurations) == 0 {
+		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
+		return nil
+	}
+
+	var refDataVolumeName, refDataMountPath, referenceDataDir string
+	if b.staticPod {
+		refDataVolumeName = resourceDirVolumeName
+		refDataMountPath = resourcesDir
+		referenceDataDir = filepath.Join(resourcesDir, "secrets", b.encryptionConfigSecretName)
+	} else {
+		refDataVolumeName = referenceDataVolumeName
+		refDataMountPath = referenceDataMountPath
+		referenceDataDir = referenceDataMountPath
+	}
+
+	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
+
+	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
+	refDataVolumeMount := corev1.VolumeMount{Name: refDataVolumeName, MountPath: refDataMountPath, ReadOnly: true}
+
+	for _, kmsConfiguration := range kmsConfigurations {
+		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
+		keyID := kmsConfiguration.Name
+
+		pluginConfig, ok := b.encryptionConfig.KMSPlugins[keyID]
+		if !ok {
+			return fmt.Errorf("missing plugin config for keyID %s", keyID)
+		}
+
+		refData := &referenceDataResolver{
+			pluginsSecretData:    b.encryptionConfig.KMSPluginsSecretData,
+			pluginsConfigMapData: b.encryptionConfig.KMSPluginsConfigMapData,
+			referenceDataDir:     referenceDataDir,
+			keyID:                keyID,
+		}
+
+		provider, err := newSidecarProvider(keyID, kmsConfiguration.Endpoint, pluginConfig, refData)
+		if err != nil {
+			return fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
+		}
+
+		if err := ensureSidecarContainer(podSpec, provider); err != nil {
+			return err
+		}
+
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), socketVolumeMount); err != nil {
+			return err
+		}
+
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), refDataVolumeMount); err != nil {
+			return err
+		}
+
+		if b.staticPod {
+			if err := setRunAsRoot(podSpec.InitContainers, provider.Name()); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
+		return err
+	}
+
+	if err := ensureSocketVolume(podSpec); err != nil {
+		return err
+	}
+
+	if !b.staticPod {
+		if err := ensureReferenceDataVolume(podSpec, b.encryptionConfigSecretName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter) (*encryptiondata.Config, error) {
+	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	if encryptionConfig == nil {
+		return nil, fmt.Errorf("encryption configuration is required in %s/%s secret", encryptionConfigNamespace, encryptionConfigSecretName)
+	}
+
+	return encryptionConfig, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,18 +3,13 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
 
@@ -58,30 +53,29 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
-	referenceDataDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
-
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataDir)
-	if err != nil {
-		return err
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
 	}
-
-	// Don't touch the pod spec further when there are no sidecars.
-	if len(sidecarNames) == 0 {
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return fmt.Errorf("failed to get feature gates: %w", err)
+	}
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
 		return nil
 	}
 
-	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: resourceDirVolumeName, MountPath: resourcesDir, ReadOnly: true}
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
-			return err
-		}
-		if err := setRunAsRoot(podSpec.InitContainers, name); err != nil {
-			return err
-		}
+	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return nil
 	}
 
-	return nil
+	return NewKMSPluginBuilder().
+		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+		AsStaticPod().
+		Apply(podSpec, containerName)
 }
 
 // AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
@@ -89,126 +83,28 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataMountPath)
-	if err != nil {
-		return err
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
 	}
-
-	// Don't touch the pod spec further when there are no sidecars.
-	if len(sidecarNames) == 0 {
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return fmt.Errorf("failed to get feature gates: %w", err)
+	}
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
 		return nil
 	}
 
-	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: referenceDataVolumeName, MountPath: referenceDataMountPath, ReadOnly: true}
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
-			return err
-		}
-	}
-
-	// Unlike static pods, aggregated API servers access KMS plugin data by mounting the encryption-config Secret directly as a volume.
-	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
-	if err := ensureReferenceDataVolume(podSpec, encryptionConfigSecretName); err != nil {
+	cfg, err := fetchEncryptionConfig(ctx, encryptionConfigNamespace, encryptionConfigSecretName, secretClient)
+	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-// addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
-// It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
-func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, referenceDataDir string) ([]string, error) {
-	if podSpec == nil {
-		return nil, fmt.Errorf("pod spec cannot be nil")
+	if cfg == nil {
+		return nil
 	}
 
-	if containerName == "" {
-		return nil, fmt.Errorf("container name cannot be empty")
-	}
-
-	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return nil, nil
-	}
-
-	featureGates, err := featureGateAccessor.CurrentFeatureGates()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get feature gates: %w", err)
-	}
-
-	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
-		return nil, nil
-	}
-
-	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
-	}
-
-	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
-	}
-
-	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(encryptionConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get KMS configurations: %w", err)
-	}
-	if len(kmsConfigurations) == 0 {
-		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
-		return nil, nil
-	}
-
-	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
-
-	var sidecarNames []string
-	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
-	for _, kmsConfiguration := range kmsConfigurations {
-		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
-		keyID := kmsConfiguration.Name
-		udsPath := kmsConfiguration.Endpoint
-
-		pluginConfig, ok := encryptionConfig.KMSPlugins[keyID]
-		if !ok {
-			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
-		}
-
-		refData := &referenceDataResolver{
-			pluginsConfigMapData: encryptionConfig.KMSPluginsConfigMapData,
-			pluginsSecretData:    encryptionConfig.KMSPluginsSecretData,
-			referenceDataDir:     referenceDataDir,
-			keyID:                keyID,
-		}
-
-		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, refData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
-		}
-
-		if err := ensureSidecarContainer(podSpec, provider); err != nil {
-			return nil, err
-		}
-
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), socketVolumeMount); err != nil {
-			return nil, err
-		}
-
-		sidecarNames = append(sidecarNames, provider.Name())
-	}
-
-	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
-		return nil, err
-	}
-
-	// The volume mount in the kube-apiserver and KMS plugin containers requires a volume in the podSpec
-	if err := ensureSocketVolume(podSpec); err != nil {
-		return nil, err
-	}
-
-	return sidecarNames, nil
+	return NewKMSPluginBuilder().
+		FromEncryptionConfig(encryptionConfigSecretName, cfg).
+		Apply(podSpec, containerName)
 }
 
 func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {

--- a/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/revisioncontroller/revision_controller.go
@@ -39,7 +39,8 @@ type RevisionController struct {
 	configMapGetter corev1client.ConfigMapsGetter
 	secretGetter    corev1client.SecretsGetter
 
-	revisionPrecondition PreconditionFunc
+	revisionPrecondition  PreconditionFunc
+	revisionPostcondition PostconditionFunc
 }
 
 type RevisionResource struct {
@@ -49,6 +50,9 @@ type RevisionResource struct {
 
 // PreconditionFunc checks if revision precondition is met (is true) and then proceeeds with the creation of new revision
 type PreconditionFunc func(ctx context.Context) (bool, error)
+
+// PostconditionFunc validates the assembled revision data after all resources have been copied but before the revision is marked as ready.
+type PostconditionFunc func(ctx context.Context, revision int32) (bool, error)
 
 // NewRevisionController create a new revision controller.
 func NewRevisionController(
@@ -62,9 +66,15 @@ func NewRevisionController(
 	secretGetter corev1client.SecretsGetter,
 	eventRecorder events.Recorder,
 	revisionPrecondition PreconditionFunc,
+	revisionPostcondition PostconditionFunc,
 ) factory.Controller {
 	if revisionPrecondition == nil {
 		revisionPrecondition = func(ctx context.Context) (bool, error) {
+			return true, nil
+		}
+	}
+	if revisionPostcondition == nil {
+		revisionPostcondition = func(_ context.Context, _ int32) (bool, error) {
 			return true, nil
 		}
 	}
@@ -75,10 +85,11 @@ func NewRevisionController(
 		configMaps:             configMaps,
 		secrets:                secrets,
 
-		operatorClient:       operatorClient,
-		configMapGetter:      configMapGetter,
-		secretGetter:         secretGetter,
-		revisionPrecondition: revisionPrecondition,
+		operatorClient:        operatorClient,
+		configMapGetter:       configMapGetter,
+		secretGetter:          secretGetter,
+		revisionPrecondition:  revisionPrecondition,
+		revisionPostcondition: revisionPostcondition,
 	}
 
 	return factory.New().
@@ -307,6 +318,15 @@ func (c RevisionController) createNewRevision(ctx context.Context, recorder even
 		if obj == nil && !s.Optional {
 			return false, apierrors.NewNotFound(corev1.Resource("secrets"), s.Name)
 		}
+	}
+
+	// We run the post-condition function here because at this point in time, the revision
+	// ConfigMap is already created, but it doesn't yet have the "revision-ready: true" annotation.
+	// This means that the installer pod has not yet started deploying the revision.
+	if postconditionMet, err := c.revisionPostcondition(ctx, revision); err != nil {
+		return false, fmt.Errorf("revision postcondition failed for revision %d: %w", revision, err)
+	} else if !postconditionMet {
+		return false, nil
 	}
 
 	if createdStatus.Annotations == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/controllers.go
@@ -81,7 +81,8 @@ type staticPodOperatorControllerBuilder struct {
 	pdbUnhealthyPodEvictionPolicy *v1.UnhealthyPodEvictionPolicyType
 	guardCreateConditionalFunc    func() (bool, bool, error)
 
-	revisionControllerPrecondition revisioncontroller.PreconditionFunc
+	revisionControllerPrecondition  revisioncontroller.PreconditionFunc
+	revisionControllerPostcondition revisioncontroller.PostconditionFunc
 
 	extraNodeSelector labels.Selector
 }
@@ -131,6 +132,7 @@ type Builder interface {
 	// Use this with caution, as this option can disrupt perspective pods that have not yet had a chance to become healthy.
 	WithPodDisruptionBudgetGuard(operatorNamespace, operatorName, readyzPort, readyzEndpoint string, pdbUnhealthyPodEvictionPolicy *v1.UnhealthyPodEvictionPolicyType, createConditionalFunc func() (bool, bool, error)) Builder
 	WithRevisionControllerPrecondition(revisionControllerPrecondition revisioncontroller.PreconditionFunc) Builder
+	WithRevisionControllerPostcondition(revisionControllerPostcondition revisioncontroller.PostconditionFunc) Builder
 	ToControllers() (manager.ControllerManager, error)
 }
 
@@ -223,6 +225,11 @@ func (b *staticPodOperatorControllerBuilder) WithRevisionControllerPrecondition(
 	return b
 }
 
+func (b *staticPodOperatorControllerBuilder) WithRevisionControllerPostcondition(revisionControllerPostcondition revisioncontroller.PostconditionFunc) Builder {
+	b.revisionControllerPostcondition = revisionControllerPostcondition
+	return b
+}
+
 func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.ControllerManager, error) {
 	manager := manager.NewControllerManager()
 
@@ -261,6 +268,7 @@ func (b *staticPodOperatorControllerBuilder) ToControllers() (manager.Controller
 			secretClient,
 			eventRecorder,
 			b.revisionControllerPrecondition,
+			b.revisionControllerPostcondition,
 		), 1)
 	} else {
 		errs = append(errs, fmt.Errorf("missing revisionController; cannot proceed"))

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -94,17 +94,26 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 
 	apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
-	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
+	previousEncryption := apiServer.Spec.Encryption
+	needsUpdate := !equality.Semantic.DeepEqual(previousEncryption, provider.APIServerEncryption)
 	if needsUpdate {
 		if provider.Setup != nil {
 			provider.Setup(ctx, t)
 		}
-		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
+		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", previousEncryption, provider.APIServerEncryption)
 		apiServer.Spec.Encryption = provider.APIServerEncryption
 		_, err = clientSet.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)
+	}
+
+	// KMS-to-KMS migration: when both old and new are KMS but the config differs,
+	// the key controller creates a new key. We must wait for the next migrated key
+	// rather than asserting no new key is created.
+	if needsUpdate && provider.Type == configv1.EncryptionTypeKMS && previousEncryption.Type == configv1.EncryptionTypeKMS {
+		WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+		return clientSet
 	}
 
 	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -22,6 +23,34 @@ import (
 	library "github.com/openshift/library-go/test/library/encryption"
 )
 
+// resolveVaultKMSPluginImage determines the vault-kube-kms plugin image to use.
+// It checks SHARED_DIR because the openshift-e2e-test step ref is a widely-used
+// shared ref that does not declare VAULT_KMS_PLUGIN_IMAGE in its env list.
+// The vault-install step writes the image reference to a file in SHARED_DIR,
+// allowing subsequent steps to pick it up without modifying the shared ref.
+func resolveVaultKMSPluginImage(t testing.TB) string {
+	t.Helper()
+	if img := os.Getenv("VAULT_KMS_PLUGIN_IMAGE"); img != "" {
+		t.Logf("Using vault KMS plugin image from VAULT_KMS_PLUGIN_IMAGE env: %s", img)
+		return img
+	}
+	sharedDir := os.Getenv("SHARED_DIR")
+	if sharedDir == "" {
+		t.Fatal("SHARED_DIR environment variable is not set; cannot resolve vault KMS plugin image")
+	}
+	imagePath := sharedDir + "/vault-kms-plugin-image"
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		t.Fatalf("failed to read vault KMS plugin image from %s: %v", imagePath, err)
+	}
+	img := strings.TrimSpace(string(data))
+	if img == "" {
+		t.Fatalf("vault KMS plugin image file %s is empty", imagePath)
+	}
+	t.Logf("Resolved vault KMS plugin image from %s: %s", imagePath, img)
+	return img
+}
+
 const (
 	defaultVaultNamespace          = "vault-kms"
 	defaultVaultServiceName        = "vault"
@@ -30,7 +59,6 @@ const (
 	defaultVaultAppRoleSecretName  = "vault-approle-secret"
 	defaultVaultConfigMapName      = "vault-ca-bundle"
 	defaultFAKEVaultKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
-	defaultVaultKMSPluginImage     = "registry.ci.openshift.org/control-plane-custom-builds/vault-kube-kms@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5"
 	defaultVaultAddress            = "https://vault.vault-kms.svc:8200"
 	defaultVaultEnterpriseNS       = "admin"
 	defaultVaultTransitMount       = "transit"
@@ -53,6 +81,7 @@ const (
 // and bundles the AppRole secret setup.
 func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
 	cfg := DefaultVaultKMSPluginConfig
+	cfg.KMS.Vault.KMSPluginImage = resolveVaultKMSPluginImage(t)
 	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
 	// cannot resolve cluster-local Service names (they use host network DNS).
 	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, defaultVaultNamespace, defaultVaultServiceName)
@@ -74,7 +103,6 @@ var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
 	KMS: configv1.KMSPluginConfig{
 		Type: configv1.VaultKMSProvider,
 		Vault: configv1.VaultKMSPluginConfig{
-			KMSPluginImage: defaultVaultKMSPluginImage,
 			VaultAddress:   defaultVaultAddress,
 			VaultNamespace: defaultVaultEnterpriseNS,
 			TransitMount:   defaultVaultTransitMount,
@@ -125,7 +153,6 @@ var SecondaryVaultKMSPluginConfig = configv1.APIServerEncryption{
 	KMS: configv1.KMSPluginConfig{
 		Type: configv1.VaultKMSProvider,
 		Vault: configv1.VaultKMSPluginConfig{
-			KMSPluginImage: defaultVaultKMSPluginImage,
 			VaultAddress:   secondaryVaultAddress,
 			VaultNamespace: defaultVaultEnterpriseNS,
 			TransitMount:   defaultVaultTransitMount,
@@ -150,6 +177,7 @@ var SecondaryVaultKMSPluginConfig = configv1.APIServerEncryption{
 // for the secondary Vault instance, used in KMS-to-KMS migration e2e tests.
 func SecondaryVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
 	cfg := SecondaryVaultKMSPluginConfig
+	cfg.KMS.Vault.KMSPluginImage = resolveVaultKMSPluginImage(t)
 	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, secondaryVaultNamespace, secondaryVaultServiceName)
 	return library.EncryptionProvider{
 		APIServerEncryption: cfg,

--- a/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
@@ -354,6 +354,100 @@ func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenari
 	}
 }
 
+// KMSToKMSMigrationScenario tests migration between two distinct KMS configurations
+// (e.g. different Vault instances or transit keys). Unlike in-place updates, changing a
+// key-triggering field (transit key, vault address, etc.) causes the operator to mint a
+// new encryption key and re-encrypt all resources.
+type KMSToKMSMigrationScenario struct {
+	BasicScenario
+	CreateResourceFunc             func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
+	AssertResourceEncryptedFunc    func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	AssertResourceNotEncryptedFunc func(t testing.TB, clientSet ClientSet, resource runtime.Object)
+	ResourceFunc                   func(t testing.TB, namespace string) runtime.Object
+	ResourceName                   string
+	PrimaryProvider                EncryptionProvider
+	SecondaryProvider              EncryptionProvider
+}
+
+// TestKMSToKMSMigration validates round-trip migration between two KMS providers:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS provider and verify
+//  3. Migrate to secondary KMS provider — a new key is created and resources re-encrypted
+//  4. Migrate back to primary KMS provider — verifies returning to original works
+//  5. Switch to identity — verify resources are decrypted
+func TestKMSToKMSMigration(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	TestEncryptionProvidersMigration(ctx, t, ProvidersMigrationScenario{
+		BasicScenario:                  scenario.BasicScenario,
+		CreateResourceFunc:             scenario.CreateResourceFunc,
+		AssertResourceEncryptedFunc:    scenario.AssertResourceEncryptedFunc,
+		AssertResourceNotEncryptedFunc: scenario.AssertResourceNotEncryptedFunc,
+		ResourceFunc:                   scenario.ResourceFunc,
+		ResourceName:                   scenario.ResourceName,
+		EncryptionProviders: []EncryptionProvider{
+			scenario.PrimaryProvider,
+			scenario.SecondaryProvider,
+			scenario.PrimaryProvider,
+		},
+	})
+}
+
+// TestKMSToKMSOnOff validates KMS on/off cycle using the KMS-to-KMS scenario struct:
+//  1. Create a test resource
+//  2. Encrypt with primary KMS → verify encrypted
+//  3. Switch to identity → verify decrypted
+//  4. Encrypt with secondary KMS → verify encrypted
+//  5. Switch to identity → verify decrypted
+func TestKMSToKMSOnOff(ctx context.Context, t testing.TB, scenario KMSToKMSMigrationScenario) {
+	require.NotNil(t, scenario.PrimaryProvider.Setup, "PrimaryProvider.Setup must not be nil")
+	require.NotNil(t, scenario.SecondaryProvider.Setup, "SecondaryProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.PrimaryProvider.Type, "PrimaryProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.SecondaryProvider.Type, "SecondaryProvider must use KMS encryption type")
+
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+
+	steps := []testStep{
+		{name: "CreateResource", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.CreateResourceFunc(t, clientSet, scenario.Namespace)
+		}},
+		{name: "EncryptWithPrimaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.PrimaryProvider)
+		}},
+		{name: "AssertEncryptedWithPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "OffIdentityAfterPrimary", testFunc: func(t testing.TB) {
+			TestEncryptionTypeIdentity(ctx, t, scenario.BasicScenario)
+		}},
+		{name: "AssertDecryptedAfterPrimary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceNotEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+		{name: "EncryptWithSecondaryKMS", testFunc: func(t testing.TB) {
+			TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.SecondaryProvider)
+		}},
+		{name: "AssertEncryptedWithSecondary", testFunc: func(t testing.TB) {
+			clientSet := GetClients(t)
+			scenario.AssertResourceEncryptedFunc(t, clientSet, scenario.ResourceFunc(t, scenario.Namespace))
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
+}
+
 // KMSInPlaceUpdateScenario tests that updating an in-place KMS config field
 // (e.g. kmsPluginImage) takes effect without creating a new encryption key.
 // The caller supplies Provider (initial valid config) and UpdatedProvider (same config

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b
+# github.com/openshift/library-go v0.0.0-20260615113748-bc9d4056464b => github.com/bertinatto/library-go v0.0.0-20260618191728-9261746c2746
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -1702,3 +1702,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+# github.com/openshift/library-go => github.com/bertinatto/library-go v0.0.0-20260618191728-9261746c2746


### PR DESCRIPTION
The idea is to validate whether the revision is valid or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KMS encryption validation to the cluster-kube-apiserver-operator
  * Verifies KMS plugin sidecar containers are correctly configured and deployed when KMS encryption is enabled
  * Validates consistency between encryption configuration and actual pod specifications
  * Ensures proper initialization of KMS plugin sidecar containers during cluster API server updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->