### PR TITLE
CNTRLPLANE-3327:Migrate TestEncryptionTypeAESCBC to OTE

### DIFF
--- a/test/e2e/encryption.go
+++ b/test/e2e/encryption.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+)
+
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
+	g.It("[Operator][Serial][Timeout:40m] TestEncryptionTypeAESCBC", func() {
+		testEncryptionTypeAESCBC(g.GinkgoTB())
+	})
+})
+
+func testEncryptionTypeAESCBC(t testing.TB) {
+	library.TestEncryptionTypeAESCBC(t, library.BasicScenario{
+		Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+		EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+		EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		OperatorNamespace:               operatorclient.OperatorNamespace,
+		TargetGRs:                       operatorencryption.DefaultTargetGRs,
+		AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
+	})
+}

--- a/test/e2e/encryption_test.go
+++ b/test/e2e/encryption_test.go
@@ -1,22 +1,14 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
-	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
-	library "github.com/openshift/library-go/test/library/encryption"
 )
 
+// This test calls the shared test function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e-gcp-operator-serial-ote job.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestEncryptionTypeAESCBC(t *testing.T) {
-	library.TestEncryptionTypeAESCBC(t, library.BasicScenario{
-		Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-		EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-		EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		OperatorNamespace:               operatorclient.OperatorNamespace,
-		TargetGRs:                       operatorencryption.DefaultTargetGRs,
-		AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
-	})
+	testEncryptionTypeAESCBC(t)
 }


### PR DESCRIPTION
Migrate TestEncryptionTypeAESCBC to OTE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end AES-CBC encryption test entrypoint for the kube-apiserver operator to validate encryption behavior under realistic conditions.
  * Refactored the existing AES-CBC test to delegate to a shared helper, simplifying execution flow during the test framework migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->