### PR TITLE
NO-JIRA: Removal of unuse suites

### DIFF
--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -73,18 +73,7 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		Name:        "openshift/cluster-kube-apiserver-operator/operator/serial",
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("[Operator]") && name.contains("[Serial]") || name.contains("[Disruptive]")`,
-		},
-		ClusterStability: oteextension.ClusterStabilityDisruptive,
-	})
-
-	// Tests tagged with [Serial], and [Conformance] are included.
-	extension.AddSuite(oteextension.Suite{
-		Name:        "openshift/cluster-kube-apiserver-operator/conformance/serial",
-		Parents:     []string{"openshift/conformance/serial"},
-		Parallelism: 1,
-		Qualifiers: []string{
-			`name.contains("[Serial]") && name.contains("[Conformance]")`,
+			`name.contains("[Operator]") && name.contains("[Serial]")`,
 		},
 	})
 


### PR DESCRIPTION
Removal of unuse suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened operator test suite qualification to run a narrower, more specific set of operator+serial tests.
  * Removed the separate conformance serial test suite from the extension test registry to avoid overlapping selections.
  * Overall test registry simplified to reduce redundant test execution and focus on intended operator-serial scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->