### PR TITLE
[release-4.22] OCPBUGS-85269: fsync static pod cert and manifest writes for crash durability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260317165824-54a3998d81eb
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1
-	github.com/openshift/library-go v0.0.0-20260429151228-ecbc792a4313
+	github.com/openshift/library-go v0.0.0-20260512161954-889c2cd3e381
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1 h1:Hr/R38eg5ZJXfbiaHumjJIN1buDZwhsm4ys4npVCXH0=
 github.com/openshift/client-go v0.0.0-20260317180604-743f664b82d1/go.mod h1:Za51LlH76ALiQ/aKGBYJXmyJNkA//IDJ+I///30CA2M=
-github.com/openshift/library-go v0.0.0-20260429151228-ecbc792a4313 h1:XMY+prVKsPoyCMxQPv9+o4wu7NiMNLvpu29OfizqJOk=
-github.com/openshift/library-go v0.0.0-20260429151228-ecbc792a4313/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
+github.com/openshift/library-go v0.0.0-20260512161954-889c2cd3e381 h1:DuRbvQFYd/2HzMCL+s5Z1kCXh+mdL7Q9UZG99/Sa/ys=
+github.com/openshift/library-go v0.0.0-20260512161954-889c2cd3e381/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal"
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir"
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal/flock"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil"
 )
 
 const stagingDirUID = "installer"
@@ -622,8 +623,8 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 	// Write secrets, config maps and pod to disk
 	// This does not need timeout, instead we should fail hard when we are not able to write.
 	klog.Infof("Writing pod manifest %q ...", path.Join(resourceDir, manifestFileName))
-	if err := os.WriteFile(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
-		return err
+	if err := fsutil.WriteFileFsync(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
+		return fmt.Errorf("failed writing %q: %w", path.Join(resourceDir, manifestFileName), err)
 	}
 
 	// remove the existing file to ensure kubelet gets "create" event from inotify watchers
@@ -633,8 +634,8 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 		return err
 	}
 	klog.Infof("Writing static pod manifest %q ...\n%s", path.Join(o.PodManifestDir, manifestFileName), finalPodBytes)
-	if err := os.WriteFile(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
-		return err
+	if err := fsutil.WriteFileFsync(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
+		return fmt.Errorf("failed writing %q: %w", path.Join(o.PodManifestDir, manifestFileName), err)
 	}
 	return nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/sync.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/sync.go
@@ -8,15 +8,14 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil"
 )
 
-// Sync can be used to atomically synchronize target directory with the given file content map.
-// This is done by populating a staging directory, then atomically swapping it with the target directory.
-// This effectively means that any extra files in the target directory are pruned.
-//
-// The staging directory needs to be explicitly specified. It is initially created using os.MkdirAll with targetDirPerm.
-// It is then populated using files with filePerm. Once the atomic swap is performed, the staging directory
-// (which is now the original target directory) is removed.
+// Sync atomically and durably replaces the contents of targetDir with the given files.
+// It writes files to a staging directory with fsync, then atomically swaps it with
+// the target directory via renameat2(RENAME_EXCHANGE), fsyncing parent directories
+// to ensure the swap is persisted. Extra files in targetDir are pruned.
+// The old target directory (now at stagingDir) is removed after the swap.
 func Sync(targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) error {
 	return sync(&realFS, targetDir, targetDirPerm, stagingDir, files)
 }
@@ -24,27 +23,29 @@ func Sync(targetDir string, targetDirPerm os.FileMode, stagingDir string, files 
 type fileSystem struct {
 	MkdirAll        func(path string, perm os.FileMode) error
 	RemoveAll       func(path string) error
-	WriteFile       func(name string, data []byte, perm os.FileMode) error
+	WriteFileFsync  func(name string, data []byte, perm os.FileMode) error
 	SwapDirectories func(dirA, dirB string) error
+	Fsync           func(name string) error
 }
 
 var realFS = fileSystem{
 	MkdirAll:        os.MkdirAll,
 	RemoveAll:       os.RemoveAll,
-	WriteFile:       os.WriteFile,
+	WriteFileFsync:  fsutil.WriteFileFsync,
 	SwapDirectories: swap,
+	Fsync:           fsutil.Fsync,
 }
 
-// sync prepares a tmp directory and writes all files into that directory.
-// Then it atomically swap the tmp directory for the target one.
-// This is currently implemented as really atomically swapping directories.
+// sync writes files into the staging directory, then durably swaps it with the target.
+// Each file write is individually fsynced (including its parent directory entry) via
+// fs.WriteFileFsync. After the swap, parent directories are fsynced to persist the exchange.
 //
-// The same goal of atomic swap could be implemented using symlinks much like AtomicWriter does in
+// Note: the upstream Kubernetes AtomicWriter uses symlinks for atomic updates but does
+// not fsync, leaving file data in the page cache with no crash durability guarantee:
 // https://github.com/kubernetes/kubernetes/blob/v1.34.0/pkg/volume/util/atomic_writer.go#L58
-// The reason we don't do that is that we already have a directory populated and watched that needs to we swapped.
-// In other words, it's for compatibility reasons. And if we were to migrate to the symlink approach,
-// we would anyway need to atomically turn the current data directory into a symlink.
-// This would all just increase complexity and require atomic swap on the OS level anyway.
+// We use renameat2(RENAME_EXCHANGE) instead of symlinks because we need to swap an
+// existing directory that is already being watched. Migrating to symlinks would still
+// require an atomic swap at the OS level, adding complexity for no benefit.
 func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) (retErr error) {
 	klog.Infof("Ensuring target directory %q exists ...", targetDir)
 	if err := fs.MkdirAll(targetDir, targetDirPerm); err != nil {
@@ -75,7 +76,7 @@ func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDi
 		fullFilename := filepath.Join(stagingDir, filename)
 		klog.Infof("Writing file %q ...", fullFilename)
 
-		if err := fs.WriteFile(fullFilename, file.Content, file.Perm); err != nil {
+		if err := fs.WriteFileFsync(fullFilename, file.Content, file.Perm); err != nil {
 			return fmt.Errorf("failed writing %q: %w", fullFilename, err)
 		}
 	}
@@ -84,5 +85,16 @@ func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDi
 	if err := fs.SwapDirectories(targetDir, stagingDir); err != nil {
 		return fmt.Errorf("failed swapping target directory %q with staging directory %q: %w", targetDir, stagingDir, err)
 	}
+
+	// fsync parent directories to ensure the swap is durable on disk.
+	// renameat2(RENAME_EXCHANGE) modifies parent directory entries, so the
+	// parents must be fsynced to persist which inode each name points to.
+	if err := fs.Fsync(filepath.Dir(targetDir)); err != nil {
+		return fmt.Errorf("failed syncing parent directory of %q: %w", targetDir, err)
+	}
+	if err := fs.Fsync(filepath.Dir(stagingDir)); err != nil {
+		return fmt.Errorf("failed syncing parent directory of %q: %w", stagingDir, err)
+	}
+
 	return
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil/fsutil.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil/fsutil.go
@@ -1,0 +1,33 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Fsync fsyncs a file or directory to ensure it is durable on disk.
+func Fsync(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	// close(2) can surface errors not caught by fsync(2), e.g. on NFS.
+	closeErr := f.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// WriteFileFsync writes data to a file and fsyncs both the file and its
+// parent directory to ensure the write is durable on disk.
+func WriteFileFsync(name string, data []byte, perm os.FileMode) error {
+	if err := os.WriteFile(name, data, perm); err != nil {
+		return err
+	}
+	if err := Fsync(name); err != nil {
+		return err
+	}
+	return Fsync(filepath.Dir(name))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,7 +406,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260429151228-ecbc792a4313
+# github.com/openshift/library-go v0.0.0-20260512161954-889c2cd3e381
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -485,6 +485,7 @@ github.com/openshift/library-go/pkg/operator/staticpod/internal
 github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir
 github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types
 github.com/openshift/library-go/pkg/operator/staticpod/internal/flock
+github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil
 github.com/openshift/library-go/pkg/operator/staticpod/prune
 github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor
 github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cluster-kube-apiserver-operator/pull/2124
Depends on https://github.com/openshift/library-go/pull/2205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate rotation behavior corrected to use standard timing intervals, no longer using accelerated development cycles.
  * OAuth metadata synchronization now properly processes configurations when explicitly specified in authentication settings.

* **Chores**
  * Updated OpenShift API, client libraries, and platform dependencies.
  * Improved internal test code compatibility with modern Go standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->