### PR TITLE
[release-4.20] OCPBUGS-85271: fsync static pod cert and manifest writes for crash durability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
-	github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc
+	github.com/openshift/library-go v0.0.0-20260521134016-2b64044b4a2a
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
-github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc h1:g9BJ/p4ZLgb253FwnWvWEzl2vYSDSvvUZ6s42weVKpM=
-github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
+github.com/openshift/library-go v0.0.0-20260521134016-2b64044b4a2a h1:Bhp51ow4GoxUHVo9gp9mF6SUJ0vaYdwqJhmqHo1ltGc=
+github.com/openshift/library-go v0.0.0-20260521134016-2b64044b4a2a/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/installerpod/cmd.go
@@ -3,38 +3,42 @@ package installerpod
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/clock"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/blang/semver/v4"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	"github.com/openshift/library-go/pkg/config/client"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/resource/retry"
-	"github.com/openshift/library-go/pkg/operator/staticpod"
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir"
 	"github.com/openshift/library-go/pkg/operator/staticpod/internal/flock"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil"
 )
+
+const stagingDirUID = "installer"
 
 type InstallOptions struct {
 	// TODO replace with genericclioptions
@@ -218,8 +222,10 @@ func (o *InstallOptions) kubeletVersion(ctx context.Context) (string, error) {
 
 func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceDir string,
 	secretNames, optionalSecretNames, configNames, optionalConfigNames sets.Set[string], prefixed bool) error {
-	klog.Infof("Creating target resource directory %q ...", resourceDir)
-	if err := os.MkdirAll(resourceDir, 0755); err != nil && !os.IsExist(err) {
+
+	stagingDirBase := getStagingDir(resourceDir)
+	klog.Infof("Pruning staging directory %q ...", stagingDirBase)
+	if err := os.RemoveAll(stagingDirBase); err != nil {
 		return err
 	}
 
@@ -257,15 +263,20 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 		if prefixed {
 			secretBaseName = o.prefixFor(secret.Name)
 		}
-		contentDir := path.Join(resourceDir, "secrets", secretBaseName)
-		klog.Infof("Creating directory %q ...", contentDir)
-		if err := os.MkdirAll(contentDir, 0755); err != nil {
-			return err
-		}
-		for filename, content := range secret.Data {
-			if err := writeSecret(content, path.Join(contentDir, filename)); err != nil {
-				return err
+
+		contentDir := getSecretTargetDir(resourceDir, secretBaseName)
+		stagingDir := getSecretStagingDir(resourceDir, secretBaseName)
+
+		files := make(map[string]types.File, len(secret.Data))
+		for name, content := range secret.Data {
+			files[name] = types.File{
+				Content: content,
+				Perm:    getFilePermissionsSecret(name),
 			}
+		}
+
+		if err := atomicdir.Sync(contentDir, 0755, stagingDir, files); err != nil {
+			return fmt.Errorf("failed to sync secret %s/%s (directory %q): %w", secret.Namespace, secret.Name, contentDir, err)
 		}
 	}
 	for _, configmap := range configs {
@@ -273,18 +284,22 @@ func (o *InstallOptions) copySecretsAndConfigMaps(ctx context.Context, resourceD
 		if prefixed {
 			configMapBaseName = o.prefixFor(configmap.Name)
 		}
-		contentDir := path.Join(resourceDir, "configmaps", configMapBaseName)
-		klog.Infof("Creating directory %q ...", contentDir)
-		if err := os.MkdirAll(contentDir, 0755); err != nil {
-			return err
-		}
-		for filename, content := range configmap.Data {
-			if err := writeConfig([]byte(content), path.Join(contentDir, filename)); err != nil {
-				return err
+
+		contentDir := getConfigMapTargetDir(resourceDir, configMapBaseName)
+		stagingDir := getConfigMapStagingDir(resourceDir, configMapBaseName)
+
+		files := make(map[string]types.File, len(configmap.Data))
+		for name, content := range configmap.Data {
+			files[name] = types.File{
+				Content: []byte(content),
+				Perm:    getFilePermissionsConfigMap(name),
 			}
 		}
-	}
 
+		if err := atomicdir.Sync(contentDir, 0755, stagingDir, files); err != nil {
+			return fmt.Errorf("failed to sync configmap %s/%s (directory %q): %w", configmap.Namespace, configmap.Name, contentDir, err)
+		}
+	}
 	return nil
 }
 
@@ -608,8 +623,8 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 	// Write secrets, config maps and pod to disk
 	// This does not need timeout, instead we should fail hard when we are not able to write.
 	klog.Infof("Writing pod manifest %q ...", path.Join(resourceDir, manifestFileName))
-	if err := os.WriteFile(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
-		return err
+	if err := fsutil.WriteFileFsync(path.Join(resourceDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
+		return fmt.Errorf("failed writing %q: %w", path.Join(resourceDir, manifestFileName), err)
 	}
 
 	// remove the existing file to ensure kubelet gets "create" event from inotify watchers
@@ -619,28 +634,42 @@ func (o *InstallOptions) writePod(rawPodBytes []byte, manifestFileName, resource
 		return err
 	}
 	klog.Infof("Writing static pod manifest %q ...\n%s", path.Join(o.PodManifestDir, manifestFileName), finalPodBytes)
-	if err := os.WriteFile(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
-		return err
+	if err := fsutil.WriteFileFsync(path.Join(o.PodManifestDir, manifestFileName), []byte(finalPodBytes), 0600); err != nil {
+		return fmt.Errorf("failed writing %q: %w", path.Join(o.PodManifestDir, manifestFileName), err)
 	}
 	return nil
 }
 
-func writeConfig(content []byte, fullFilename string) error {
-	klog.Infof("Writing config file %q ...", fullFilename)
-
-	filePerms := os.FileMode(0600)
-	if strings.HasSuffix(fullFilename, ".sh") {
-		filePerms = 0755
-	}
-	return staticpod.WriteFileAtomic(content, filePerms, fullFilename)
+func getStagingDir(targetDir string) string {
+	return filepath.Join(targetDir, "staging", stagingDirUID)
 }
 
-func writeSecret(content []byte, fullFilename string) error {
-	klog.Infof("Writing secret manifest %q ...", fullFilename)
+func getConfigMapTargetDir(targetDir, configMapName string) string {
+	return filepath.Join(targetDir, "configmaps", configMapName)
+}
 
-	filePerms := os.FileMode(0600)
-	if strings.HasSuffix(fullFilename, ".sh") {
-		filePerms = 0700
+func getConfigMapStagingDir(targetDir, configMapName string) string {
+	return filepath.Join(getStagingDir(targetDir), "configmaps", configMapName)
+}
+
+func getSecretTargetDir(targetDir, secretName string) string {
+	return filepath.Join(targetDir, "secrets", secretName)
+}
+
+func getSecretStagingDir(targetDir, secretName string) string {
+	return filepath.Join(getStagingDir(targetDir), "secrets", secretName)
+}
+
+func getFilePermissionsConfigMap(filename string) os.FileMode {
+	if strings.HasSuffix(filename, ".sh") {
+		return 0755
 	}
-	return staticpod.WriteFileAtomic(content, filePerms, fullFilename)
+	return 0600
+}
+
+func getFilePermissionsSecret(filename string) os.FileMode {
+	if strings.HasSuffix(filename, ".sh") {
+		return 0700
+	}
+	return 0600
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/swap_linux.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/swap_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package atomicdir
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// swap can be used to exchange two directories atomically.
+func swap(firstDir, secondDir string) error {
+	// Renameat2 can be used to exchange two directories atomically when RENAME_EXCHANGE flag is specified.
+	// The paths to be exchanged can be specified in multiple ways:
+	//
+	//   * You can specify a file descriptor and a relative path to that descriptor.
+	//   * You can specify an absolute path, in which case the file descriptor is ignored.
+	//
+	// We use AT_FDCWD special file descriptor so that when any of the paths is relative,
+	// it's relative to the current working directory.
+	//
+	// For more details, see `man renameat2` as that is the associated C library function.
+	return unix.Renameat2(unix.AT_FDCWD, firstDir, unix.AT_FDCWD, secondDir, unix.RENAME_EXCHANGE)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/swap_other.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/swap_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package atomicdir
+
+import "errors"
+
+// swap can be used to exchange two directories atomically.
+//
+// This function is only implemented for Linux and returns an error on other platforms.
+func swap(firstDir, secondDir string) error {
+	return errors.New("swap is not supported on this platform")
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/sync.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/sync.go
@@ -1,0 +1,100 @@
+package atomicdir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types"
+	"github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil"
+)
+
+// Sync atomically and durably replaces the contents of targetDir with the given files.
+// It writes files to a staging directory with fsync, then atomically swaps it with
+// the target directory via renameat2(RENAME_EXCHANGE), fsyncing parent directories
+// to ensure the swap is persisted. Extra files in targetDir are pruned.
+// The old target directory (now at stagingDir) is removed after the swap.
+func Sync(targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) error {
+	return sync(&realFS, targetDir, targetDirPerm, stagingDir, files)
+}
+
+type fileSystem struct {
+	MkdirAll        func(path string, perm os.FileMode) error
+	RemoveAll       func(path string) error
+	WriteFileFsync  func(name string, data []byte, perm os.FileMode) error
+	SwapDirectories func(dirA, dirB string) error
+	Fsync           func(name string) error
+}
+
+var realFS = fileSystem{
+	MkdirAll:        os.MkdirAll,
+	RemoveAll:       os.RemoveAll,
+	WriteFileFsync:  fsutil.WriteFileFsync,
+	SwapDirectories: swap,
+	Fsync:           fsutil.Fsync,
+}
+
+// sync writes files into the staging directory, then durably swaps it with the target.
+// Each file write is individually fsynced (including its parent directory entry) via
+// fs.WriteFileFsync. After the swap, parent directories are fsynced to persist the exchange.
+//
+// Note: the upstream Kubernetes AtomicWriter uses symlinks for atomic updates but does
+// not fsync, leaving file data in the page cache with no crash durability guarantee:
+// https://github.com/kubernetes/kubernetes/blob/v1.34.0/pkg/volume/util/atomic_writer.go#L58
+// We use renameat2(RENAME_EXCHANGE) instead of symlinks because we need to swap an
+// existing directory that is already being watched. Migrating to symlinks would still
+// require an atomic swap at the OS level, adding complexity for no benefit.
+func sync(fs *fileSystem, targetDir string, targetDirPerm os.FileMode, stagingDir string, files map[string]types.File) (retErr error) {
+	klog.Infof("Ensuring target directory %q exists ...", targetDir)
+	if err := fs.MkdirAll(targetDir, targetDirPerm); err != nil {
+		return fmt.Errorf("failed creating target directory: %w", err)
+	}
+
+	klog.Infof("Creating staging directory %q ...", stagingDir)
+	if err := fs.MkdirAll(stagingDir, targetDirPerm); err != nil {
+		return fmt.Errorf("failed creating staging directory: %w", err)
+	}
+	defer func() {
+		if err := fs.RemoveAll(stagingDir); err != nil {
+			if retErr != nil {
+				retErr = fmt.Errorf("failed removing staging directory %q: %w; previous error: %w", stagingDir, err, retErr)
+				return
+			}
+			retErr = fmt.Errorf("failed removing staging directory %q: %w", stagingDir, err)
+		}
+	}()
+
+	for filename, file := range files {
+		// Make sure filename is a plain filename, not a path.
+		// This also ensures the staging directory cannot be escaped.
+		if filename != filepath.Base(filename) {
+			return fmt.Errorf("filename cannot be a path: %q", filename)
+		}
+
+		fullFilename := filepath.Join(stagingDir, filename)
+		klog.Infof("Writing file %q ...", fullFilename)
+
+		if err := fs.WriteFileFsync(fullFilename, file.Content, file.Perm); err != nil {
+			return fmt.Errorf("failed writing %q: %w", fullFilename, err)
+		}
+	}
+
+	klog.Infof("Atomically swapping staging directory %q with target directory %q ...", stagingDir, targetDir)
+	if err := fs.SwapDirectories(targetDir, stagingDir); err != nil {
+		return fmt.Errorf("failed swapping target directory %q with staging directory %q: %w", targetDir, stagingDir, err)
+	}
+
+	// fsync parent directories to ensure the swap is durable on disk.
+	// renameat2(RENAME_EXCHANGE) modifies parent directory entries, so the
+	// parents must be fsynced to persist which inode each name points to.
+	if err := fs.Fsync(filepath.Dir(targetDir)); err != nil {
+		return fmt.Errorf("failed syncing parent directory of %q: %w", targetDir, err)
+	}
+	if err := fs.Fsync(filepath.Dir(stagingDir)); err != nil {
+		return fmt.Errorf("failed syncing parent directory of %q: %w", stagingDir, err)
+	}
+
+	return
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types/file.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types/file.go
@@ -1,0 +1,10 @@
+// Package types exists to avoid import cycles as it's imported by both atomicdir and atomicdir/testing.
+package types
+
+import "os"
+
+// File represents file content together with the associated permissions.
+type File struct {
+	Content []byte
+	Perm    os.FileMode
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil/fsutil.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil/fsutil.go
@@ -1,0 +1,33 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Fsync fsyncs a file or directory to ensure it is durable on disk.
+func Fsync(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	// close(2) can surface errors not caught by fsync(2), e.g. on NFS.
+	closeErr := f.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// WriteFileFsync writes data to a file and fsyncs both the file and its
+// parent directory to ensure the write is durable on disk.
+func WriteFileFsync(name string, data []byte, perm os.FileMode) error {
+	if err := os.WriteFile(name, data, perm); err != nil {
+		return err
+	}
+	if err := Fsync(name); err != nil {
+		return err
+	}
+	return Fsync(filepath.Dir(name))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -400,7 +400,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20251110200504-2685cf1242fc
+# github.com/openshift/library-go v0.0.0-20260521134016-2b64044b4a2a
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -475,7 +475,10 @@ github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodfallb
 github.com/openshift/library-go/pkg/operator/staticpod/controller/staticpodstate
 github.com/openshift/library-go/pkg/operator/staticpod/installerpod
 github.com/openshift/library-go/pkg/operator/staticpod/internal
+github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir
+github.com/openshift/library-go/pkg/operator/staticpod/internal/atomicdir/types
 github.com/openshift/library-go/pkg/operator/staticpod/internal/flock
+github.com/openshift/library-go/pkg/operator/staticpod/internal/fsutil
 github.com/openshift/library-go/pkg/operator/staticpod/prune
 github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor
 github.com/openshift/library-go/pkg/operator/staticpod/startupmonitor/annotations


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/cluster-kube-apiserver-operator/pull/2124.

Depends on https://github.com/openshift/library-go/pull/2207. 