### PR TITLE
OCPBUGS-85563: [4.21] operator should not override authentication config serviceAccountIssuer with the default one during the operator initialization

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -54,7 +54,7 @@ func observedConfig(existingConfig map[string]interface{},
 
 	errs := []error{}
 	var issuerChanged bool
-	var existingConfigIssuer, observedActiveIssuer string
+	var existingConfigIssuer, originalConfigIssuer, observedActiveIssuer string
 	// when the issuer will change, indicate that by setting `issuerChanged` to true
 	// to emit the informative event
 	defer func() {
@@ -62,7 +62,7 @@ func observedConfig(existingConfig map[string]interface{},
 			recorder.Eventf(
 				"ObserveServiceAccountIssuer",
 				"ServiceAccount issuer changed from %v to %v",
-				existingConfigIssuer, observedActiveIssuer,
+				originalConfigIssuer, observedActiveIssuer,
 			)
 		}
 	}()
@@ -74,7 +74,8 @@ func observedConfig(existingConfig map[string]interface{},
 
 	for i := range existingConfigIssuers {
 		if len(existingConfigIssuers[i]) > 0 {
-			existingConfigIssuer = existingConfigIssuers[i]
+			originalConfigIssuer = existingConfigIssuers[i]
+			existingConfigIssuer = originalConfigIssuer
 			break
 		}
 	}

--- a/pkg/operator/serviceaccountissuercontroller/serviceaccountissuer_controller.go
+++ b/pkg/operator/serviceaccountissuercontroller/serviceaccountissuer_controller.go
@@ -3,9 +3,10 @@ package serviceaccountissuercontroller
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -75,27 +76,16 @@ func (c *ServiceAccountIssuerController) sync(ctx context.Context, controllerCon
 		return nil
 	}
 
-	// there is no service account issuer set and there are no service account issuers in status, no-op.
-	if len(authConfigIssuer) == 0 || len(operator.Status.ServiceAccountIssuers) == 0 {
-		operatorCopy := operator.DeepCopy()
-		operatorCopy.Status.ServiceAccountIssuers = defaultServiceAccountIssuerValue
-		_, statusUpdateErr := c.kubeAPIServerOperatorClient.UpdateStatus(ctx, operatorCopy, metav1.UpdateOptions{})
-		if statusUpdateErr == nil {
-			controllerContext.Recorder().Eventf("ServiceAccountIssuer", "Issuer set to default value %q", defaultServiceAccountIssuerValue[0].Name)
-			statusUpdateErr = factory.SyntheticRequeueError
-		}
-		return statusUpdateErr
+	if len(authConfigIssuer) == 0 {
+		authConfigIssuer = defaultServiceAccountIssuerValue[0].Name
 	}
 
 	activeIssuer := getActiveServiceAccountIssuer(operator.Status.ServiceAccountIssuers)
-	if len(activeIssuer) == 0 {
-		// at this point, we must have the active issuer (the one without expiration time).
-		// if we don't it means somebody changed the status deliberately.
-		// in this case, we correct it by setting the configured value as active.
-		// NOTE: this is an error/edge case
-		return c.makeActiveIssuerTrusted(ctx, authConfigIssuer, authConfigIssuer, operator)
-	}
 
+	// We must have the active issuer (the one without expiration time), even if the following
+	// error/edge case happens. If somebody cleared the status deliberately, we should detect
+	// it with issuerChanged, because activeIssuer will be empty and authConfigIssuer will be
+	// always set/defaulted.
 	issuerChanged := authConfigIssuer != activeIssuer
 
 	// the issuer configured in auth config and the active issuer we have in operator status matches.
@@ -119,10 +109,13 @@ func (c *ServiceAccountIssuerController) sync(ctx context.Context, controllerCon
 	if err := c.makeActiveIssuerTrusted(ctx, activeIssuer, authConfigIssuer, operator); err != nil {
 		// Successful issuer change is event worthy.
 		if err == factory.SyntheticRequeueError {
-			controllerContext.Recorder().Eventf("ServiceAccountIssuer",
-				"Desired ServiceAccountIssuer %q is now active issuer. Previous issuer %q is trusted until %s",
-				authConfigIssuer, activeIssuer, c.nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration),
-			)
+			eventMsg := fmt.Sprintf("Desired ServiceAccountIssuer %q is now active issuer.", authConfigIssuer)
+			if len(activeIssuer) > 0 {
+				eventMsg = fmt.Sprintf("%s Previous issuer %q is trusted until %s.", eventMsg, activeIssuer,
+					c.nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration))
+			}
+			controllerContext.Recorder().Event("ServiceAccountIssuer", eventMsg)
+
 		}
 		return err
 	}
@@ -158,17 +151,17 @@ func (c *ServiceAccountIssuerController) makeActiveIssuerTrusted(ctx context.Con
 		},
 	}
 	for i := range server.Status.ServiceAccountIssuers {
+		// handle the case when new issuer is already in the trusted list
+		// this will remove it from the list
+		if server.Status.ServiceAccountIssuers[i].Name == newIssuer {
+			continue
+		}
 		if server.Status.ServiceAccountIssuers[i].ExpirationTime == nil && server.Status.ServiceAccountIssuers[i].Name == oldIssuer {
 			expiration := metav1.Time{Time: c.nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration)}
 			updated = append(updated, operatorv1.ServiceAccountIssuerStatus{
 				Name:           oldIssuer,
 				ExpirationTime: &expiration,
 			})
-			continue
-		}
-		// handle the case when new issuer is already in the trusted list
-		// this will remove it from the list
-		if server.Status.ServiceAccountIssuers[i].Name == newIssuer {
 			continue
 		}
 		updated = append(updated, server.Status.ServiceAccountIssuers[i])

--- a/pkg/operator/serviceaccountissuercontroller/serviceaccountissuer_controller_test.go
+++ b/pkg/operator/serviceaccountissuercontroller/serviceaccountissuer_controller_test.go
@@ -3,6 +3,10 @@ package serviceaccountissuercontroller
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1lister "github.com/openshift/client-go/config/listers/config/v1"
@@ -12,9 +16,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"reflect"
-	"testing"
-	"time"
 )
 
 type fakeAuthLister struct {
@@ -85,6 +86,23 @@ func TestController(t *testing.T) {
 			},
 			expectedResync: true,
 			expectedStatus: defaultServiceAccountIssuerValue,
+		},
+		{
+			name: "serviceaccountissuer is set and no trusted issuers should result in the serviceaccountissuer to be set",
+			authConfig: configv1.Authentication{Spec: configv1.AuthenticationSpec{
+				ServiceAccountIssuer: "newIssuer",
+			}},
+			operator: operatorv1.KubeAPIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			},
+			expectedResync: true,
+			expectedStatus: []operatorv1.ServiceAccountIssuerStatus{
+				{
+					Name: "newIssuer",
+				},
+			},
 		},
 		{
 			name: "serviceaccountissuer is set in auth config and should be copied to status while making default issuer trusted",
@@ -182,7 +200,7 @@ func TestController(t *testing.T) {
 			},
 		},
 		{
-			name: "serviceaccountissuer value was set to empty and we need to prune status to default issuer",
+			name: "serviceaccountissuer value was set to empty and we need to expire the old and switch to a default issuer",
 			authConfig: configv1.Authentication{Spec: configv1.AuthenticationSpec{
 				ServiceAccountIssuer: "",
 			}},
@@ -202,7 +220,17 @@ func TestController(t *testing.T) {
 					},
 				},
 			},
-			expectedStatus: defaultServiceAccountIssuerValue,
+			expectedStatus: []operatorv1.ServiceAccountIssuerStatus{
+				defaultServiceAccountIssuerValue[0],
+				{
+					Name:           "trustedIssuer1",
+					ExpirationTime: &metav1.Time{Time: nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration)},
+				},
+				{
+					Name:           "trustedIssuer2",
+					ExpirationTime: &metav1.Time{Time: nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration)},
+				},
+			},
 			expectedResync: true,
 		},
 		{
@@ -258,6 +286,39 @@ func TestController(t *testing.T) {
 			expectedStatus: []operatorv1.ServiceAccountIssuerStatus{
 				{
 					Name: "newActiveIssuer",
+				},
+				{
+					Name:           "oldActiveIssuer",
+					ExpirationTime: &metav1.Time{Time: nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration)},
+				},
+			},
+			expectedResync: true,
+		},
+
+		{
+			name: "serviceaccountissuer value was set to empty while default is being expired, default should be made active again",
+			authConfig: configv1.Authentication{Spec: configv1.AuthenticationSpec{
+				ServiceAccountIssuer: "",
+			}},
+			operator: operatorv1.KubeAPIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: operatorv1.KubeAPIServerStatus{
+					ServiceAccountIssuers: []operatorv1.ServiceAccountIssuerStatus{
+						{
+							Name: "oldActiveIssuer",
+						},
+						{
+							Name:           defaultServiceAccountIssuerValue[0].Name,
+							ExpirationTime: &metav1.Time{Time: nowFn().Add(defaultTrustedServiceAccountIssuerExpirationDuration)},
+						},
+					},
+				},
+			},
+			expectedStatus: []operatorv1.ServiceAccountIssuerStatus{
+				{
+					Name: defaultServiceAccountIssuerValue[0].Name,
 				},
 				{
 					Name:           "oldActiveIssuer",

--- a/test/e2e/serviceaccountissuer_test.go
+++ b/test/e2e/serviceaccountissuer_test.go
@@ -44,7 +44,7 @@ func TestServiceAccountIssuer(t *testing.T) {
 
 	t.Run("no serviceaccountissuer set in authentication config results in apiserver config with default issuer set", func(t *testing.T) {
 		setServiceAccountIssuer(t, authConfigClient, "")
-		if err := pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc"}); err != nil {
+		if err := pollForOperandIssuer(t, kubeClient, []string{"https://kubernetes.default.svc", "https://second.foo.bar", "https://first.foo.bar"}); err != nil {
 			t.Errorf("pollForOperandIssuer failed: %v", err)
 		}
 	})


### PR DESCRIPTION
cherrypick of https://github.com/openshift/cluster-kube-apiserver-operator/pull/2062
- the rename commits were left out