### PR TITLE
[WIP]Use Vault KMS provider for encryption e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260511191110-9b69e5fa27e9
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260515094948-509d00758cf2
+	github.com/openshift/library-go v0.0.0-20260519084655-6d8a09d73bef
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0
@@ -136,3 +136,5 @@ require (
 )
 
 replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+
+replace github.com/openshift/library-go => github.com/gangwgr/library-go v0.0.0-20260520104344-b64a640cb793

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQ
 github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gangwgr/library-go v0.0.0-20260520104344-b64a640cb793 h1:htLkfUm/k5GtxeRZBzhc3DexcAR0HRsS7gSTq6Nd9lY=
+github.com/gangwgr/library-go v0.0.0-20260520104344-b64a640cb793/go.mod h1:gKG9lctU0yEftSoT3DUyeIWz1oAgF0EHUpwI4pnCo4o=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -165,8 +167,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260515094948-509d00758cf2 h1:JoiqT7XZ4Wle3s2vBOYwe8m8p4h9ko2gEN+IAzrXEOI=
-github.com/openshift/library-go v0.0.0-20260515094948-509d00758cf2/go.mod h1:gKG9lctU0yEftSoT3DUyeIWz1oAgF0EHUpwI4pnCo4o=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/certrotation"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	encryptionkms "github.com/openshift/library-go/pkg/operator/encryption/kms"
+	kmspluginlifecycle "github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
@@ -224,7 +224,7 @@ func createTargetConfig(ctx context.Context, c TargetConfigController, recorder 
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/config", err))
 	}
-	_, _, err = managePods(ctx, c.kubeClient.CoreV1(), c.featureGateAccessor, c.isStartupMonitorEnabledFn, recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.operatorImageVersion)
+	_, _, err = managePods(ctx, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), c.featureGateAccessor, c.isStartupMonitorEnabledFn, recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.operatorImageVersion)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-pod", err))
 	}
@@ -308,7 +308,7 @@ func manageKubeAPIServerConfig(ctx context.Context, client coreclientv1.ConfigMa
 	return resourceapply.ApplyConfigMap(ctx, client, recorder, requiredConfigMap)
 }
 
-func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, featureGateAccessor featuregates.FeatureGateAccess, isStartupMonitorEnabledFn func() (bool, error), recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec, operatorImageVersion string) (*corev1.ConfigMap, bool, error) {
+func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, secretClient coreclientv1.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, isStartupMonitorEnabledFn func() (bool, error), recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec, imagePullSpec, operatorImagePullSpec, operatorImageVersion string) (*corev1.ConfigMap, bool, error) {
 	appliedPodTemplate, err := manageTemplate(string(bindata.MustAsset("assets/kube-apiserver/pod.yaml")), imagePullSpec, operatorImagePullSpec, operatorImageVersion, operatorSpec)
 	if err != nil {
 		return nil, false, err
@@ -329,8 +329,8 @@ func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, featu
 		required.Spec.Containers[i].Env = append(container.Env, proxyEnvVars...)
 	}
 
-	if err := encryptionkms.AddKMSPluginVolumeAndMountToPodSpec(&required.Spec, "kube-apiserver", featureGateAccessor); err != nil {
-		return nil, false, fmt.Errorf("failed to add KMS encryption volumes: %w", err)
+	if err := kmspluginlifecycle.AddKMSPluginSidecarToPodSpec(ctx, &required.Spec, "kube-apiserver", operatorclient.TargetNamespace, "encryption-config", secretClient, featureGateAccessor); err != nil {
+		return nil, false, fmt.Errorf("failed to add KMS plugin sidecar: %w", err)
 	}
 
 	configMap := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/kube-apiserver/pod-cm.yaml"))

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -1,14 +1,12 @@
 package e2e_encryption_kms
 
 import (
-	"context"
 	"fmt"
 	"math/rand/v2"
 	"testing"
 
 	g "github.com/onsi/ginkgo/v2"
 
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
 	library "github.com/openshift/library-go/test/library/encryption"
@@ -38,10 +36,6 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 // 9. Disables encryption (Identity) again
 // 10. Verifies secret is NOT encrypted again
 func testKMSEncryptionOnOff(t testing.TB) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
 	library.TestEncryptionTurnOnAndOff(t, library.OnOffScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -57,10 +51,7 @@ func testKMSEncryptionOnOff(t testing.TB) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
-		EncryptionProvider: configv1.APIServerEncryption{
-			Type: configv1.EncryptionTypeKMS,
-			KMS:  librarykms.DefaultFakeKMSPluginConfig,
-		},
+		EncryptionProvider:             librarykms.DefaultVaultEncryptionProvider,
 	})
 }
 
@@ -73,7 +64,6 @@ func testKMSEncryptionOnOff(t testing.TB) {
 // 5. Migrates between the providers in the shuffled order
 // 6. Verifies secret is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(t testing.TB) {
-	librarykms.DeployUpstreamMockKMSPlugin(context.Background(), t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
 	library.TestEncryptionProvidersMigration(t, library.ProvidersMigrationScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -89,8 +79,8 @@ func testKMSEncryptionProvidersMigration(t testing.TB) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
-		EncryptionProviders: library.ShuffleEncryptionProviders([]configv1.APIServerEncryption{
-			{Type: configv1.EncryptionTypeKMS, KMS: librarykms.DefaultFakeKMSPluginConfig},
+		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
+			librarykms.DefaultVaultEncryptionProvider,
 			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
 		}),
 	})

--- a/test/e2e-encryption-perf/encryption_perf_test.go
+++ b/test/e2e-encryption-perf/encryption_perf_test.go
@@ -85,7 +85,7 @@ func TestPerfEncryption(tt *testing.T) {
 			waitUntilNamespaceActive,
 			library.DBLoaderRepeatParallel(5010, 50, false, createConfigMap, reportConfigMap),
 			library.DBLoaderRepeatParallel(9010, 50, false, createSecret, reportSecret)),
-		EncryptionProvider: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)},
+		EncryptionProvider: library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
 	})
 }
 

--- a/test/e2e-encryption-rotation/encryption_rotation_test.go
+++ b/test/e2e-encryption-rotation/encryption_rotation_test.go
@@ -41,6 +41,6 @@ func TestEncryptionRotation(t *testing.T) {
 			_, err = operatorClient.Update(context.TODO(), apiServerOperator, metav1.UpdateOptions{})
 			return err
 		},
-		EncryptionProvider: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)},
+		EncryptionProvider: library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
 	})
 }

--- a/test/e2e-encryption/encryption_test.go
+++ b/test/e2e-encryption/encryption_test.go
@@ -53,6 +53,6 @@ func TestEncryptionTurnOnAndOff(t *testing.T) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
-		EncryptionProvider:             configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)},
+		EncryptionProvider:             library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
 	})
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -1,0 +1,184 @@
+package pluginlifecycle
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// sidecarProvider abstracts the construction of a KMS plugin sidecar container for a specific provider (e.g. Vault).
+type sidecarProvider interface {
+	// Name returns the identifier used to name the sidecar container and locate its volume mounts.
+	Name() string
+	// BuildSidecarContainer returns a fully configured sidecar container ready to be injected into the API server pod
+	BuildSidecarContainer() (corev1.Container, error)
+}
+
+// newSidecarProvider creates a provider-specific SidecarProvider for the given keyID, UDS endpoint, and plugin configuration.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig) (sidecarProvider, error) {
+	switch pluginConfig.Type {
+	case configv1.VaultKMSProvider:
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig)
+	default:
+		return nil, fmt.Errorf("unsupported KMS plugin configuration")
+	}
+}
+
+// AddKMSPluginSidecarToPodSpec discovers KMS plugins from the encryption-config secret and injects a sidecar container for each one into the pod spec.
+// It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
+// It uses an uncached client to avoid injecting sidecars based on a stale encryption configuration.
+func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+	if podSpec == nil {
+		return fmt.Errorf("pod spec cannot be nil")
+	}
+
+	if containerName == "" {
+		return fmt.Errorf("container name cannot be empty")
+	}
+
+	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
+		return nil
+	}
+
+	featureGates, err := featureGateAccessor.CurrentFeatureGates()
+	if err != nil {
+		return fmt.Errorf("failed to get feature gates: %w", err)
+	}
+
+	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
+		return nil
+	}
+
+	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
+	if err != nil {
+		return fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+	}
+
+	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(encryptionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get KMS configurations: %w", err)
+	}
+	if len(kmsConfigurations) == 0 {
+		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
+		return nil
+	}
+
+	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
+
+	for _, kmsConfiguration := range kmsConfigurations {
+		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
+		keyID := kmsConfiguration.Name
+		udsPath := kmsConfiguration.Endpoint
+
+		pluginConfig, ok := encryptionConfig.KMSPlugins[keyID]
+		if !ok {
+			return fmt.Errorf("missing plugin config for keyID %s", keyID)
+		}
+
+		sidecarProvider, err := newSidecarProvider(keyID, udsPath, pluginConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
+		}
+
+		if err := ensureSidecarContainer(podSpec, sidecarProvider); err != nil {
+			return err
+		}
+
+		if err := ensureSocketVolumeMount(podSpec, sidecarProvider.Name()); err != nil {
+			return err
+		}
+	}
+
+	if err := ensureSocketVolumeMount(podSpec, containerName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {
+	sidecar, err := provider.BuildSidecarContainer()
+	if err != nil {
+		return fmt.Errorf("failed to build sidecar container: %w", err)
+	}
+
+	for i, container := range podSpec.Containers {
+		if container.Name == sidecar.Name {
+			podSpec.Containers[i] = sidecar
+			return nil
+		}
+	}
+
+	podSpec.Containers = append(podSpec.Containers, sidecar)
+	return nil
+}
+
+func ensureSocketVolumeMount(podSpec *corev1.PodSpec, containerName string) error {
+	containerIndex := -1
+	for i, container := range podSpec.Containers {
+		if container.Name == containerName {
+			containerIndex = i
+			break
+		}
+	}
+
+	if containerIndex < 0 {
+		return fmt.Errorf("container %s not found", containerName)
+	}
+
+	container := &podSpec.Containers[containerIndex]
+	foundMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == "kms-plugin-socket" {
+			foundMount = true
+			break
+		}
+	}
+	if !foundMount {
+		container.VolumeMounts = append(container.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "kms-plugin-socket",
+				MountPath: "/var/run/kmsplugin",
+			},
+		)
+	}
+
+	// The volume mount in the container requires a volume in the podSpec
+	ensureSocketVolume(podSpec)
+	return nil
+}
+
+func ensureSocketVolume(podSpec *corev1.PodSpec) {
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == "kms-plugin-socket" {
+			return
+		}
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes,
+		corev1.Volume{
+			Name: "kms-plugin-socket",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -1,0 +1,73 @@
+package pluginlifecycle
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
+func newVaultSidecarProvider(name, keyID, udsPath string, pluginConfig configv1.KMSPluginConfig) (*vault, error) {
+	return &vault{
+		name:    name,
+		keyID:   keyID,
+		udsPath: udsPath,
+		config:  &pluginConfig.Vault,
+	}, nil
+}
+
+// vault implements SidecarProvider for HashiCorp Vault KMS.
+type vault struct {
+	name    string
+	keyID   string
+	udsPath string
+	config  *configv1.VaultKMSPluginConfig
+}
+
+// Name returns the sidecar name appended by the key id.
+func (v *vault) Name() string {
+	return fmt.Sprintf("%s-%s", v.name, v.keyID)
+}
+
+// BuildSidecarContainer returns a container spec for the Vault KMS plugin sidecar
+// configured with the Vault address, namespace, transit mount, and transit key.
+func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
+	// Required API fields: always set.
+	args := []string{
+		fmt.Sprintf("-listen-address=%s", v.udsPath),
+		fmt.Sprintf("-vault-address=%s", v.config.VaultAddress),
+		fmt.Sprintf("-transit-key=%s", v.config.TransitKey),
+		// TODO(bertinatto): dummy value for the Vault mock plugin; will come from the encryption-config secret.
+		fmt.Sprintf("-approle-role-id=dummy-role-id-%s", v.keyID),
+		// TODO(bertinatto): placeholder path for the Vault mock plugin; will differ per operator (KASO vs. aggregated apiserver operators).
+		fmt.Sprintf("-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-%s", v.keyID),
+	}
+
+	// Optional fields: only pass non-empty values.
+	if v.config.VaultNamespace != "" {
+		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
+	}
+
+	if v.config.TransitMount != "" {
+		args = append(args, fmt.Sprintf("-transit-mount=%s", v.config.TransitMount))
+	}
+
+	return corev1.Container{
+		Name:                     v.Name(),
+		Image:                    v.config.KMSPluginImage,
+		Args:                     args,
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		// TODO(bertinatto): the plugin sidecar needs to be measure under heavy load to figure out good defaults.
+		// For now follow what most sidecars in the kube-apiserver pod do. xref:
+		// https://github.com/openshift/cluster-kube-apiserver-operator/commit/e15a19cd2474c8b60ce17ac16dd8f422c729847a
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+			},
+		},
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -36,9 +36,9 @@ var (
 	waitPollTimeout       = 69*time.Minute + 10*time.Minute
 	defaultEncryptionMode = string(configv1.EncryptionTypeIdentity)
 
-	SupportedStaticEncryptionProviders = []configv1.APIServerEncryption{
-		{Type: configv1.EncryptionTypeAESGCM},
-		{Type: configv1.EncryptionTypeAESCBC},
+	SupportedStaticEncryptionProviders = []EncryptionProvider{
+		{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESGCM}},
+		{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC}},
 	}
 )
 
@@ -56,21 +56,26 @@ type EncryptionKeyMeta struct {
 
 type UpdateUnsupportedConfigFunc func(raw []byte) error
 
-func SetAndWaitForEncryptionType(t testing.TB, provider configv1.APIServerEncryption, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
+func SetAndWaitForEncryptionType(t testing.TB, provider EncryptionProvider, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
 	t.Helper()
+	ctx := context.TODO()
+
 	t.Logf("Starting encryption e2e test for %q mode", provider.Type)
 
 	clientSet := GetClients(t)
 	lastMigratedKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube, namespace, labelSelector)
 	require.NoError(t, err)
 
-	apiServer, err := clientSet.ApiServerConfig.Get(context.TODO(), "cluster", metav1.GetOptions{})
+	apiServer, err := clientSet.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
 	require.NoError(t, err)
-	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider)
+	needsUpdate := !equality.Semantic.DeepEqual(apiServer.Spec.Encryption, provider.APIServerEncryption)
 	if needsUpdate {
-		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider)
-		apiServer.Spec.Encryption = provider
-		_, err = clientSet.ApiServerConfig.Update(context.TODO(), apiServer, metav1.UpdateOptions{})
+		if provider.Setup != nil {
+			provider.Setup(ctx, t)
+		}
+		t.Logf("Updating encryption configuration for APIServer from %#v to %#v", apiServer.Spec.Encryption, provider.APIServerEncryption)
+		apiServer.Spec.Encryption = provider.APIServerEncryption
+		_, err = clientSet.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
 		require.NoError(t, err)
 	} else {
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -1,11 +1,70 @@
 package kms
 
 import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	library "github.com/openshift/library-go/test/library/encryption"
 )
 
-// DefaultFakeKMSPluginConfig is a fake Vault KMS configuration used by tests.
-// The values are not real and are likely to change as the KMS integration evolves.
+const (
+	defaultVaultNamespace         = "vault-kms"
+	defaultVaultPodName           = "vault-0"
+	defaultVaultCredentialsSecret = "vault-credentials"
+	defaultVaultAppRoleSecretName = "vault-approle-secret"
+	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:03bb07a2c08b509653c4c70217a06a4b389c10b4d87922f50ee5eac82db5e140"
+	defaultVaultAddress           = "https://vault.vault-kms.svc:8200"
+	defaultVaultEnterpriseNS      = "admin"
+	defaultVaultTransitMount      = "transit"
+	defaultVaultTransitKey        = "kms-key"
+	defaultAppRoleTargetNamespace = "openshift-config"
+	vaultCommandTimeout           = 30 * time.Second
+)
+
+// DefaultVaultEncryptionProvider is a ready-to-use Vault KMS EncryptionProvider for e2e tests.
+// It bundles the default config with the AppRole secret setup.
+var DefaultVaultEncryptionProvider = library.EncryptionProvider{
+	APIServerEncryption: DefaultVaultKMSPluginConfig,
+	Setup:               ensureDefaultVaultAppRoleSecret,
+}
+
+// DefaultVaultKMSPluginConfig is the standard Vault KMS encryption config
+// used by CI e2e tests.
+var DefaultVaultKMSPluginConfig = configv1.APIServerEncryption{
+	Type: configv1.EncryptionTypeKMS,
+	KMS: configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: defaultVaultKMSPluginImage,
+			VaultAddress:   defaultVaultAddress,
+			VaultNamespace: defaultVaultEnterpriseNS,
+			TransitMount:   defaultVaultTransitMount,
+			TransitKey:     defaultVaultTransitKey,
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
+				},
+			},
+		},
+	},
+}
+
+// DefaultFakeKMSPluginConfig is a fake Vault KMS configuration used by unit tests.
 var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 	Type: configv1.VaultKMSProvider,
 	Vault: configv1.VaultKMSPluginConfig{
@@ -19,4 +78,90 @@ var DefaultFakeKMSPluginConfig = configv1.KMSPluginConfig{
 		},
 		TransitKey: "test-transit-key",
 	},
+}
+
+// ensureDefaultVaultAppRoleSecret reads credentials from the vault-credentials secret
+// (created by a CI step) and applies the AppRole secret in openshift-config
+// using the default configuration constants.
+func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
+	t.Helper()
+	cs := library.GetClients(t)
+
+	creds, err := cs.Kube.CoreV1().Secrets(defaultVaultNamespace).Get(ctx, defaultVaultCredentialsSecret, metav1.GetOptions{})
+	require.NoError(t, err, "failed to read %s/%s secret (was the vault-install CI step run?)", defaultVaultNamespace, defaultVaultCredentialsSecret)
+
+	required := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVaultAppRoleSecretName,
+			Namespace: defaultAppRoleTargetNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"roleID":   creds.Data["role-id"],
+			"secretID": creds.Data["secret-id"],
+		},
+	}
+	recorder := events.NewInMemoryRecorder("vault-approle-secret-setup", clock.RealClock{})
+	_, changed, err := resourceapply.ApplySecret(ctx, cs.Kube.CoreV1(), recorder, required)
+	require.NoError(t, err, "failed to apply AppRole secret")
+	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
+}
+
+// RotateVaultTransitKey rotates the Vault transit encryption key. All old key versions are retained.
+// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
+// Steps:
+// 1. Get initial key version
+// 2. Execute 'vault write -f transit/keys/<key-name>/rotate' via oc exec
+// 3. Get new key version and validate it increased
+func RotateVaultTransitKey(ctx context.Context, t testing.TB) {
+	t.Helper()
+
+	initialVersion := getCurrentKeyVersion(ctx, t)
+	rotateKey(ctx, t)
+	newVersion := getCurrentKeyVersion(ctx, t)
+
+	require.Greater(t, newVersion, initialVersion, "rotation failed: version did not increase (before=%d, after=%d)", initialVersion, newVersion)
+}
+
+// rotateKey executes the vault key rotation command
+func rotateKey(ctx context.Context, t testing.TB) {
+	t.Helper()
+	commandCtx, cancel := context.WithTimeout(ctx, vaultCommandTimeout)
+	defer cancel()
+
+	// Command: vault write -f transit/keys/<key-name>/rotate
+	// Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
+	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
+		"vault", "write", "-f", fmt.Sprintf("transit/keys/%s/rotate", defaultVaultTransitKey))
+
+	t.Logf("Executing: %s", cmd.String())
+	output, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); ok {
+		require.NoError(t, err, "vault key rotation failed, stderr: %s", string(ee.Stderr))
+	}
+	require.NoError(t, err, "vault key rotation failed")
+	t.Logf("Command output: %s", string(output))
+}
+
+// getCurrentKeyVersion retrieves the current (latest) key version
+func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
+	t.Helper()
+	commandCtx, cancel := context.WithTimeout(ctx, vaultCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "oc", "exec", defaultVaultPodName, "-n", defaultVaultNamespace, "--",
+		"vault", "read", "-field=latest_version", fmt.Sprintf("transit/keys/%s", defaultVaultTransitKey))
+
+	t.Logf("Executing: %s", cmd.String())
+	output, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); ok {
+		require.NoError(t, err, "failed to read key version, stderr: %s", string(ee.Stderr))
+	}
+	require.NoError(t, err, "failed to read key version")
+	t.Logf("Command output: %s", string(output))
+
+	version, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	require.NoError(t, err, "failed to parse key version from output: %q", string(output))
+
+	return version
 }

--- a/vendor/github.com/openshift/library-go/test/library/encryption/perf_scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/perf_scenarios.go
@@ -19,7 +19,7 @@ type PerfScenario struct {
 	AssertMigrationTime   func(t testing.TB, migrationTime time.Duration)
 	// DBLoaderWorker is the number of workers that will execute DBLoaderFunc
 	DBLoaderWorkers    int
-	EncryptionProvider configv1.APIServerEncryption
+	EncryptionProvider EncryptionProvider
 }
 
 func TestPerfEncryption(t *testing.T, scenario PerfScenario) {

--- a/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"context"
 	"fmt"
 	mathrand "math/rand/v2"
 	"strings"
@@ -25,19 +26,29 @@ type BasicScenario struct {
 	AssertFunc                      func(t testing.TB, clientSet ClientSet, expectedMode configv1.EncryptionType, namespace, labelSelector string)
 }
 
+// EncryptionProvider pairs an encryption config with an optional setup function
+// that ensures prerequisites (secrets, credentials, infrastructure) are in place.
+type EncryptionProvider struct {
+	configv1.APIServerEncryption
+	// Setup is called once before the provider is first used. May be nil.
+	// Context is accepted as an explicit argument because testing.TB.Context()
+	// is not supported by all implementations (e.g. Ginkgo's GinkgoTBWrapper).
+	Setup func(ctx context.Context, t testing.TB)
+}
+
 func TestEncryptionTypeIdentity(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
-	clientSet := SetAndWaitForEncryptionType(e, configv1.APIServerEncryption{Type: configv1.EncryptionTypeIdentity}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	clientSet := SetAndWaitForEncryptionType(e, EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionTypeIdentity}}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
 func TestEncryptionTypeUnset(t testing.TB, scenario BasicScenario) {
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
-	clientSet := SetAndWaitForEncryptionType(e, configv1.APIServerEncryption{}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	clientSet := SetAndWaitForEncryptionType(e, EncryptionProvider{}, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
 	scenario.AssertFunc(e, clientSet, configv1.EncryptionTypeIdentity, scenario.Namespace, scenario.LabelSelector)
 }
 
-func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, providers []configv1.APIServerEncryption) configv1.APIServerEncryption {
+func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, providers []EncryptionProvider) EncryptionProvider {
 	t.Helper()
 	if len(providers) > 1 {
 		t.Fatalf("expected at most one provider, got %d", len(providers))
@@ -45,10 +56,10 @@ func resolveProvider(t testing.TB, defaultType configv1.EncryptionType, provider
 	if len(providers) == 1 {
 		return providers[0]
 	}
-	return configv1.APIServerEncryption{Type: defaultType}
+	return EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: defaultType}}
 }
 
-func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeAESCBC, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -56,7 +67,7 @@ func TestEncryptionTypeAESCBC(t testing.TB, scenario BasicScenario, providers ..
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeAESGCM, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -64,7 +75,7 @@ func TestEncryptionTypeAESGCM(t testing.TB, scenario BasicScenario, providers ..
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...configv1.APIServerEncryption) {
+func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...EncryptionProvider) {
 	provider := resolveProvider(t, configv1.EncryptionTypeKMS, providers)
 	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
 	clientSet := SetAndWaitForEncryptionType(e, provider, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
@@ -72,7 +83,7 @@ func TestEncryptionTypeKMS(t testing.TB, scenario BasicScenario, providers ...co
 	AssertEncryptionConfig(e, clientSet, scenario.EncryptionConfigSecretName, scenario.EncryptionConfigSecretNamespace, scenario.TargetGRs)
 }
 
-func TestEncryptionType(t testing.TB, scenario BasicScenario, provider configv1.APIServerEncryption) {
+func TestEncryptionType(t testing.TB, scenario BasicScenario, provider EncryptionProvider) {
 	switch provider.Type {
 	case configv1.EncryptionTypeAESCBC:
 		TestEncryptionTypeAESCBC(t, scenario, provider)
@@ -94,7 +105,7 @@ type OnOffScenario struct {
 	AssertResourceNotEncryptedFunc func(t testing.TB, clientSet ClientSet, resource runtime.Object)
 	ResourceFunc                   func(t testing.TB, namespace string) runtime.Object
 	ResourceName                   string
-	EncryptionProvider             configv1.APIServerEncryption
+	EncryptionProvider             EncryptionProvider
 }
 
 type testStep struct {
@@ -155,13 +166,13 @@ type ProvidersMigrationScenario struct {
 	// EncryptionProviders is the list of encryption providers to migrate through.
 	// The test will migrate through each provider in order, then always end by
 	// switching to identity (off) to verify the resource is re-written unencrypted.
-	EncryptionProviders []configv1.APIServerEncryption
+	EncryptionProviders []EncryptionProvider
 }
 
 // ShuffleEncryptionProviders returns a new slice with the providers in random order,
 // leaving the original slice unchanged. Use this to test different migration orderings.
-func ShuffleEncryptionProviders(providers []configv1.APIServerEncryption) []configv1.APIServerEncryption {
-	shuffled := make([]configv1.APIServerEncryption, len(providers))
+func ShuffleEncryptionProviders(providers []EncryptionProvider) []EncryptionProvider {
+	shuffled := make([]EncryptionProvider, len(providers))
 	copy(shuffled, providers)
 	mathrand.Shuffle(len(shuffled), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
@@ -232,7 +243,7 @@ type RotationScenario struct {
 	CreateResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
 	GetRawResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) string
 	UnsupportedConfigFunc UpdateUnsupportedConfigFunc
-	EncryptionProvider    configv1.APIServerEncryption
+	EncryptionProvider    EncryptionProvider
 }
 
 // TestEncryptionRotation first encrypts data with aescbc key

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260515094948-509d00758cf2
+# github.com/openshift/library-go v0.0.0-20260519084655-6d8a09d73bef => github.com/gangwgr/library-go v0.0.0-20260520104344-b64a640cb793
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -446,6 +446,7 @@ github.com/openshift/library-go/pkg/operator/encryption/deployer
 github.com/openshift/library-go/pkg/operator/encryption/encoding
 github.com/openshift/library-go/pkg/operator/encryption/encryptiondata
 github.com/openshift/library-go/pkg/operator/encryption/kms
+github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle
 github.com/openshift/library-go/pkg/operator/encryption/observer
 github.com/openshift/library-go/pkg/operator/encryption/secrets
 github.com/openshift/library-go/pkg/operator/encryption/state
@@ -1699,3 +1700,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+# github.com/openshift/library-go => github.com/gangwgr/library-go v0.0.0-20260520104344-b64a640cb793


### PR DESCRIPTION
Replaces PR #2147 (auto-closed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end KMS encryption tests now use a Vault-backed KMS configuration, set up required AppRole credentials in-cluster, and no longer rely on a mock KMS plugin.
  * Migration scenarios now exercise Vault plus a static AES provider to better mirror real-world transitions.

* **Chores**
  * Updated build dependency mapping and prepared operator codepaths for future KMS plugin sidecar integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->