### PR TITLE
Bug 86057: auth: fall back to Authentication CR for serviceAccountIssuer during early startup

### DIFF
--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer.go
@@ -41,7 +41,7 @@ func ObserveServiceAccountIssuer(
 ) (map[string]interface{}, []error) {
 
 	listers := genericListers.(configobservation.Listers)
-	ret, errs := observedConfig(existingConfig, listers.KubeAPIServerOperatorLister().Get, listers.InfrastructureLister().Get, recorder)
+	ret, errs := observedConfig(existingConfig, listers.KubeAPIServerOperatorLister().Get, listers.InfrastructureLister().Get, listers.AuthConfigLister.Get, recorder)
 	return configobserver.Pruned(ret, serviceAccountIssuerPath, audiencesPath, jwksURIPath), errs
 }
 
@@ -50,7 +50,9 @@ func ObserveServiceAccountIssuer(
 // Authentication resource.
 func observedConfig(existingConfig map[string]interface{},
 	getOperator func(name string) (*operatorv1.KubeAPIServer, error),
-	getInfrastructureConfig func(string) (*configv1.Infrastructure, error), recorder events.Recorder) (map[string]interface{}, []error) {
+	getInfrastructureConfig func(string) (*configv1.Infrastructure, error),
+	getAuthConfig func(string) (*configv1.Authentication, error),
+	recorder events.Recorder) (map[string]interface{}, []error) {
 
 	errs := []error{}
 	var issuerChanged bool
@@ -98,6 +100,18 @@ func observedConfig(existingConfig map[string]interface{},
 	// observedActiveIssuer is the desired service account issuer set in KAS operator status
 	// This apiServerArgumentValue is being synced using serviceaccountissuer controller.
 	observedActiveIssuer = getActiveServiceAccountIssuer(operator.Status.ServiceAccountIssuers)
+	// If the operator status does not yet have a custom issuer (e.g. during early startup
+	// before ServiceAccountIssuerController has run), fall back to reading the Authentication
+	// CR directly. This prevents the first KAS revision from using the default issuer when
+	// a custom one is configured, avoiding token issuer mismatch during STS/IRSA installs.
+	if len(observedActiveIssuer) == 0 && getAuthConfig != nil {
+		if authConfig, authErr := getAuthConfig("cluster"); authErr == nil && authConfig != nil {
+			if len(authConfig.Spec.ServiceAccountIssuer) > 0 {
+				klog.V(2).Infof("Using serviceAccountIssuer from Authentication CR (operator status not yet populated): %s", authConfig.Spec.ServiceAccountIssuer)
+				observedActiveIssuer = authConfig.Spec.ServiceAccountIssuer
+			}
+		}
+	}
 	// if desired active issuer is not set (the serviceaccountissuer for some reason has not defaulted it)
 	// then make sure, we default it here, because we have to set the jwks-uri correctly.
 	if defaultedExistingConfigIssuer == defaultServiceAccountIssuerValue && len(observedActiveIssuer) == 0 {

--- a/pkg/operator/configobservation/auth/auth_serviceaccountissuer_test.go
+++ b/pkg/operator/configobservation/auth/auth_serviceaccountissuer_test.go
@@ -163,6 +163,9 @@ func TestObservedConfig(t *testing.T) {
 						},
 					}, tc.infraError
 				},
+				func(_ string) (*configv1.Authentication, error) {
+					return &configv1.Authentication{}, nil
+				},
 				testRecorder,
 			)
 


### PR DESCRIPTION
## Summary

When provisioning STS/IRSA clusters via Hive/ACM with AssumeRole credentials,
the first production kube-apiserver revision starts with the default
`serviceAccountIssuer` (`https://kubernetes.default.svc`) instead of the custom
S3 OIDC issuer from the Authentication CR. This causes `machine-api-controllers`
to receive tokens with the wrong issuer, and AWS STS rejects them with
`InvalidIdentityToken`. Workers never provision; the install times out.

## Root Cause

`ObserveServiceAccountIssuer` reads only from `KubeAPIServer.status.serviceAccountIssuers`
(populated asynchronously by `ServiceAccountIssuerController`). When AssumeRole
credentials add per-call STS latency to bootstrap, `targetConfigReconciler` creates
revision 1 *before* the status is populated — so the observer returns an empty value
and KAS defaults to `https://kubernetes.default.svc`.

Controllers start concurrently in `pkg/operator/starter.go`:
```
go targetConfigReconciler.Run(ctx, 1)         // creates KAS revisions
go configObserver.Run(ctx, 1)                 // reads status (may be empty)
go serviceAccountIssuerController.Run(ctx, 1) // Auth CR → writes status
```

## Customer Test Matrix

| # | OCP | Installer Credentials | Result |
|---|-----|-----------------------|--------|
| 1 | 4.19.9 | Static IAM keys | PASS — correct issuer from rev 1 |
| 2 | 4.20.22 | Static IAM keys | PASS — correct issuer from rev 1 |
| 3 | 4.19.20 | credentialsAssumeRole (Hive) | FAIL — wrong issuer, timeout |
| 4 | 4.21.15 | credentialsAssumeRole (Hive) | FAIL — wrong issuer, timeout |
| 5 | 4.19.20 | AssumeRole via AWS profile | FAIL — wrong issuer, timeout |

## Fix

In `ObserveServiceAccountIssuer`, after reading from operator status and finding
no active issuer, fall back to reading `Authentication.spec.serviceAccountIssuer`
directly from the Authentication CR. The `AuthConfigLister` is already available
in the `configobservation.Listers` struct.

When the status IS populated (steady-state), the fallback is never reached — so
this is a no-op for existing clusters and non-STS installs.

## Testing

- Existing unit tests updated and passing
- Verified non-STS clusters (no custom issuer) are unaffected
- Verified steady-state behavior (status populated) is unchanged
- Customer validation pending after backport

## Related

- OCPBUGS-86057: https://redhat.atlassian.net/browse/OCPBUGS-86057
- openshift/cluster-kube-apiserver-operator#1006 (original STS support)
- openshift/cluster-kube-apiserver-operator#1012 (re-add after revert)
- openshift/installer#4373 (installer-side STS)


Made with [Cursor](https://cursor.com)