### PR TITLE
OCPBUGS-86057: render: fall back to Authentication CR

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -29,6 +29,7 @@ import (
 	genericrenderoptions "github.com/openshift/library-go/pkg/operator/render/options"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -237,15 +238,23 @@ func (r *renderOpts) Run() error {
 			return fmt.Errorf("unable to parse restricted CIDRs from config %q: %v", r.clusterConfigFile, err)
 		}
 	}
+
+	clusterAuthFileRead := false
 	if len(r.clusterAuthFile) > 0 {
 		clusterAuthFileData, err := ioutil.ReadFile(r.clusterAuthFile)
 		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to load authentication config: %v", err)
 		}
 		if len(clusterAuthFileData) > 0 {
+			clusterAuthFileRead = true
 			if err := discoverServiceAccountIssuer(clusterAuthFileData, &renderConfig); err != nil {
 				return fmt.Errorf("unable to parse service-account issuers from config %q: %v", r.clusterAuthFile, err)
 			}
+		}
+	}
+	if !clusterAuthFileRead {
+		if err := r.discoverServiceAccountIssuerFromManifests(&renderConfig); err != nil {
+			return fmt.Errorf("unable to discover service-account issuer from rendered manifests: %v", err)
 		}
 	}
 
@@ -422,6 +431,24 @@ func mustReadTemplateFile(fname string) genericrenderoptions.Template {
 		panic(fmt.Sprintf("Failed to load %q: %v", fname, err))
 	}
 	return genericrenderoptions.Template{FileName: fname, Content: bs}
+}
+
+func (r *renderOpts) discoverServiceAccountIssuerFromManifests(renderConfig *TemplateData) error {
+	manifests, err := r.generic.ReadInputManifests()
+	if err != nil {
+		return err
+	}
+
+	authManifest, err := manifests.GetManifest(configv1.GroupVersion.WithKind("Authentication"), "", "cluster")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	klog.V(4).Infof("--cluster-auth-file not present; using Authentication CR from rendered manifests: %q", authManifest.OriginalFilename)
+	return discoverServiceAccountIssuer(authManifest.Content, renderConfig)
 }
 
 func discoverServiceAccountIssuer(clusterAuthFileData []byte, renderConfig *TemplateData) error {

--- a/pkg/cmd/render/render_test.go
+++ b/pkg/cmd/render/render_test.go
@@ -223,10 +223,9 @@ func TestDiscoverCIDRs(t *testing.T) {
 }
 
 func TestRenderCommand(t *testing.T) {
-	assetsInputDir, err := ioutil.TempDir("", "testdata")
-	if err != nil {
-		t.Errorf("unable to create assets input directory, error: %v", err)
-	}
+	assetsInputDir := t.TempDir()
+	authManifestsDir := t.TempDir()
+
 	templateDir := filepath.Join("..", "..", "..", "bindata", "bootkube")
 
 	defaultFGDir := filepath.Join("testdata", "rendered", "default-fg")
@@ -460,6 +459,73 @@ spec:
 				}
 				if !reflect.DeepEqual(cfg.APIServerArguments["service-account-issuer"], kubecontrolplanev1.Arguments([]string{"https://test.dummy.url"})) {
 					return fmt.Errorf("expected the service-account-issuer to be [ https://test.dummy.url ], but it was %s", cfg.APIServerArguments["service-account-issuer"])
+				}
+				return nil
+			},
+		},
+		{
+			name: "discovers service account issuer from rendered manifests when cluster-auth-file not set",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--asset-output-dir=",
+				"--config-output-file=",
+				"--payload-version=test",
+				"--rendered-manifest-files=" + defaultFGDir + "," + filepath.Join(authManifestsDir, "no-auth-file"),
+				"--manifest-operator-image=kube-apiserver-operator:latest",
+				"--operand-kubernetes-version=1.31.0",
+			},
+			setupFunction: func() error {
+				dir := filepath.Join(authManifestsDir, "no-auth-file")
+				if err := os.MkdirAll(dir, 0700); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dir, "authentication.yaml"), []byte(`apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec:
+  serviceAccountIssuer: https://test.dummy.url`), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				issuer := cfg.APIServerArguments["service-account-issuer"]
+				expected := kubecontrolplanev1.Arguments{"https://test.dummy.url"}
+				if !reflect.DeepEqual(issuer, expected) {
+					return fmt.Errorf("expected service-account-issuer %q, got %q", expected, issuer)
+				}
+				return nil
+			},
+		},
+		{
+			name: "discovers service account issuer from rendered manifests when cluster-auth-file missing",
+			args: []string{
+				"--asset-input-dir=" + assetsInputDir,
+				"--templates-input-dir=" + templateDir,
+				"--cluster-auth-file=" + filepath.Join(assetsInputDir, "nonexistent-authentication.yaml"),
+				"--asset-output-dir=",
+				"--config-output-file=",
+				"--payload-version=test",
+				"--rendered-manifest-files=" + defaultFGDir + "," + filepath.Join(authManifestsDir, "missing-auth-file"),
+				"--manifest-operator-image=kube-apiserver-operator:latest",
+				"--operand-kubernetes-version=1.31.0",
+			},
+			setupFunction: func() error {
+				dir := filepath.Join(authManifestsDir, "missing-auth-file")
+				if err := os.MkdirAll(dir, 0700); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dir, "authentication.yaml"), []byte(`apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec:
+  serviceAccountIssuer: https://test.dummy.url`), 0644)
+			},
+			testFunction: func(cfg *kubecontrolplanev1.KubeAPIServerConfig) error {
+				issuer := cfg.APIServerArguments["service-account-issuer"]
+				expected := kubecontrolplanev1.Arguments{"https://test.dummy.url"}
+				if !reflect.DeepEqual(issuer, expected) {
+					return fmt.Errorf("expected service-account-issuer %q, got %q", expected, issuer)
 				}
 				return nil
 			},


### PR DESCRIPTION
When deploying STS clusters via Hive/ACM with credentialsMode: Manual, users supply the Authentication CR through manifestsConfigMapRef/ manifestsSecretRef but no cluster-authentication-02-config.yaml is generated by ccoctl or the installer. As a result the render command silently boots with the default service-account issuer, triggering a kube-apiserver rollout after bootstrap that races against token expiry and causes install timeouts.

After the existing --cluster-auth-file lookup, if ServiceAccountIssuer is still empty, scan the already-loaded --rendered-manifest-files for any config.openshift.io/v1 Authentication CR using the library-go ListManifestOfType helper (the same mechanism used for FeatureGate discovery) and extract the issuer from the first match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback to discover the service account issuer from rendered input manifests when the cluster authentication file is missing or empty, ensuring the issuer is populated reliably.

* **Tests**
  * Added tests to validate service account issuer discovery from authentication manifests included in rendered inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->