### PR TITLE
NO-JIRA: remove old mock plugin deployment

### DIFF
--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -37,10 +37,6 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 // 9. Disables encryption (Identity) again
 // 10. Verifies secret is NOT encrypted again
 func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
-	// Deploy the mock KMS plugin for testing.
-	// NOTE: This manual deployment is only required for KMS v1. In the future,
-	// the platform will manage the KMS plugins, and this code will no longer be needed.
-	librarykms.DeployUpstreamMockKMSPlugin(ctx, t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
 	library.TestEncryptionTurnOnAndOff(ctx, t, library.OnOffScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -69,7 +65,6 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 // 5. Migrates between the providers in the shuffled order
 // 6. Verifies secret is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
-	librarykms.DeployUpstreamMockKMSPlugin(ctx, t, library.GetClients(t).Kube, librarykms.WellKnownUpstreamMockKMSPluginNamespace, librarykms.WellKnownUpstreamMockKMSPluginImage, librarykms.DefaultKMSPluginCount)
 	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,


### PR DESCRIPTION
 remove old mock plugin deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Streamlined KMS encryption tests by removing redundant explicit mock plugin deployments so flows run through the intended on/off and migration scenarios.
  * Confirmed encryption provider configurations remain unchanged.
  * Note: a top-of-test step comment may still be outdated and not reflect the current setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->