### PR TITLE
CNTRLPLANE-3226: bump library-go to get KMS plugin credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e
+	github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e h1:YZwznqixO2lJa3eNSghZiKCgYbdk5IRvqDf7k6NKFZ4=
-github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499 h1:Ff5OLOVD1Kj5RYEUHaBCOWGzqdEjygIGvReaj7uIxpc=
+github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -330,7 +330,7 @@ func managePods(ctx context.Context, client coreclientv1.ConfigMapsGetter, secre
 		required.Spec.Containers[i].Env = append(container.Env, proxyEnvVars...)
 	}
 
-	if err := kmspluginlifecycle.AddKMSPluginSidecarToPodSpec(ctx, &required.Spec, "kube-apiserver", operatorclient.TargetNamespace, "encryption-config", secretClient, featureGateAccessor); err != nil {
+	if err := kmspluginlifecycle.AddKMSPluginSidecarToStaticPodSpec(ctx, &required.Spec, "kube-apiserver", operatorclient.TargetNamespace, "encryption-config", secretClient, featureGateAccessor); err != nil {
 		return nil, false, fmt.Errorf("failed to add KMS plugin to pod spec: %w", err)
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
@@ -32,34 +32,34 @@ type Config struct {
 	KMSPlugins map[string]configv1.KMSPluginConfig
 	// KMSPluginsSecretData maps keyID to secret data carried from
 	// Key Secrets into the encryption-config Secret.
-	// Structure: keyID → secretName → dataKey → value.
-	KMSPluginsSecretData KMSPluginsSecretData
+	// Structure: keyID → referenceName → dataKey → value.
+	KMSPluginsSecretData KMSPluginsReferenceData
 }
 
-// KMSPluginsSecretData maps keyID to secret data carried from Key Secrets into
-// the encryption-config Secret. Structure: keyID → secretName → dataKey → value.
-type KMSPluginsSecretData struct {
-	byKeyID map[string]state.KMSSecretData
+// KMSPluginsReferenceData maps keyID to reference data carried from Key Secrets into
+// the encryption-config Secret. Structure: keyID → referenceName → dataKey → value.
+type KMSPluginsReferenceData struct {
+	byKeyID map[string]state.KMSReferenceData
 }
 
-// Get returns the KMSSecretData for the given keyID and true if it exists,
+// Get returns the KMSReferenceData for the given keyID and true if it exists,
 // or a zero value and false otherwise. It is safe to call on a nil map.
-func (d *KMSPluginsSecretData) Get(keyID string) (state.KMSSecretData, bool) {
+func (d *KMSPluginsReferenceData) Get(keyID string) (state.KMSReferenceData, bool) {
 	if d.byKeyID == nil {
-		return state.KMSSecretData{}, false
+		return state.KMSReferenceData{}, false
 	}
 	sd, ok := d.byKeyID[keyID]
 	return sd, ok
 }
 
 // SetFromRawKey stores a value for the given keyID, splitting rawKey
-// on "_" into secretName and dataKey.
-func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte) error {
+// on "_" into referenceName and dataKey.
+func (d *KMSPluginsReferenceData) SetFromRawKey(keyID, rawKey string, value []byte) error {
 	if len(keyID) == 0 {
 		return fmt.Errorf("keyID must not be empty")
 	}
 	if d.byKeyID == nil {
-		d.byKeyID = map[string]state.KMSSecretData{}
+		d.byKeyID = map[string]state.KMSReferenceData{}
 	}
 	sd := d.byKeyID[keyID]
 	if err := sd.SetFromRawKey(rawKey, value); err != nil {
@@ -70,8 +70,8 @@ func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte)
 }
 
 // FlatEntriesByKeyID returns the stored data as a map of keyID to flat entries,
-// where each flat entry is keyed by "secretName_dataKey".
-func (d *KMSPluginsSecretData) FlatEntriesByKeyID() map[string]map[string][]byte {
+// where each flat entry is keyed by "referenceName_dataKey".
+func (d *KMSPluginsReferenceData) FlatEntriesByKeyID() map[string]map[string][]byte {
 	if d.byKeyID == nil {
 		return nil
 	}
@@ -92,7 +92,7 @@ func (c *Config) HasEncryptionConfiguration() bool {
 func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupResourceState) (*Config, error) {
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
 	var kmsPlugins map[string]configv1.KMSPluginConfig
-	var kmsPluginsSecretData KMSPluginsSecretData
+	var kmsPluginsSecretData KMSPluginsReferenceData
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
@@ -89,7 +89,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// (e.g. "kms-plugin-secret-app-role_role-id-1"). keyIDFromSecretDataKey
 	// returns the keyID (e.g. "1") and the combined key (e.g. "app-role_role-id"),
 	// which is then split on "_" to recover secretName and dataKey.
-	var kmsPluginsSecretData KMSPluginsSecretData
+	var kmsPluginsSecretData KMSPluginsReferenceData
 	for key, value := range encryptionConfigSecret.Data {
 		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
 		if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
@@ -1,0 +1,43 @@
+package pluginlifecycle
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+)
+
+// credentialResolver resolves KMS plugin credentials for a specific keyID
+// by looking up secret data and mapping it to values or file paths on disk.
+type credentialResolver struct {
+	keyID             string
+	credentialsDir    string
+	pluginsSecretData encryptiondata.KMSPluginsReferenceData
+}
+
+// Value returns the credential value for the given secret name and data key.
+func (r *credentialResolver) Value(secretName, dataKey string) (string, error) {
+	sd, ok := r.pluginsSecretData.Get(r.keyID)
+	if !ok {
+		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
+	}
+	v, ok := sd.Get(secretName, dataKey)
+	if !ok {
+		return "", fmt.Errorf("missing %s in secret %s for keyID %s", dataKey, secretName, r.keyID)
+	}
+	return string(v), nil
+}
+
+// FilePath returns the on-disk path where the credential for the given secret name and data key is mounted.
+func (r *credentialResolver) FilePath(secretName, dataKey string) (string, error) {
+	sd, ok := r.pluginsSecretData.Get(r.keyID)
+	if !ok {
+		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
+	}
+	rawKey, ok := sd.FlatEntry(secretName, dataKey)
+	if !ok {
+		return "", fmt.Errorf("missing %s in secret %s for keyID %s", dataKey, secretName, r.keyID)
+	}
+	secretDataKey := encryptiondata.FormatKMSSecretDataKey(rawKey, r.keyID)
+	return filepath.Join(r.credentialsDir, secretDataKey), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -3,6 +3,7 @@ package pluginlifecycle
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
@@ -14,6 +15,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	resourceDirVolumeName = "resource-dir"
+	credentialsVolumeName = "kms-plugin-credentials"
+	credentialsMountPath  = "/var/run/secrets/kms-plugin"
+	resourcesDir          = "/etc/kubernetes/static-pod-resources"
 )
 
 const (
@@ -29,66 +38,134 @@ type sidecarProvider interface {
 	BuildSidecarContainer() (corev1.Container, error)
 }
 
-// newSidecarProvider creates a provider-specific SidecarProvider for the given keyID, UDS endpoint, and plugin configuration.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig) (sidecarProvider, error) {
+// newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
+// wiring in credentials via the credentialResolver.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *credentialResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
 }
 
-// AddKMSPluginSidecarToPodSpec discovers KMS plugins from the encryption-config secret and injects a sidecar container for each one into the pod spec.
+// AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
+//
+// Static pods access credentials through the resource-dir volume, which the static pod revision controller
+// populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
+// is configured to run as UID 0.
+//
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
-// It uses an uncached client to avoid injecting sidecars based on a stale encryption configuration.
+// The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
+func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
+	credentialsDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
+
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsDir)
+	if err != nil {
+		return err
+	}
+
+	// Don't touch the pod spec further when there are no sidecars.
+	if len(sidecarNames) == 0 {
+		return nil
+	}
+
+	for _, name := range sidecarNames {
+		volumeMount := corev1.VolumeMount{Name: resourceDirVolumeName, MountPath: resourcesDir, ReadOnly: true}
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
+			return err
+		}
+		// The resource-dir files are owned by root, so the sidecar needs root to read credential files.
+		if err := setRunAsUser(podSpec.InitContainers, name, 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddKMSPluginSidecarToPodSpec injects KMS plugin sidecar containers into an aggregated API server pod spec (e.g., openshift-apiserver, oauth-apiserver).
+//
+// It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
+// The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsMountPath)
+	if err != nil {
+		return err
+	}
+
+	// Don't touch the pod spec further when there are no sidecars.
+	if len(sidecarNames) == 0 {
+		return nil
+	}
+
+	for _, name := range sidecarNames {
+		volumeMount := corev1.VolumeMount{Name: credentialsVolumeName, MountPath: credentialsMountPath, ReadOnly: true}
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
+			return err
+		}
+	}
+
+	// Unlike static pods, aggregated API servers access credentials by mounting the encryption-config Secret directly as a volume.
+	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
+	if err := ensureCredentialsVolume(podSpec, encryptionConfigSecretName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
+// It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
+func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, credentialsDir string) ([]string, error) {
 	if podSpec == nil {
-		return fmt.Errorf("pod spec cannot be nil")
+		return nil, fmt.Errorf("pod spec cannot be nil")
 	}
 
 	if containerName == "" {
-		return fmt.Errorf("container name cannot be empty")
+		return nil, fmt.Errorf("container name cannot be empty")
 	}
 
 	if !featureGateAccessor.AreInitialFeatureGatesObserved() {
-		return nil
+		return nil, nil
 	}
 
 	featureGates, err := featureGateAccessor.CurrentFeatureGates()
 	if err != nil {
-		return fmt.Errorf("failed to get feature gates: %w", err)
+		return nil, fmt.Errorf("failed to get feature gates: %w", err)
 	}
 
 	if !featureGates.Enabled(features.FeatureGateKMSEncryption) {
-		return nil
+		return nil, nil
 	}
 
 	encryptionConfigurationSecret, err := secretClient.Secrets(encryptionConfigNamespace).Get(ctx, encryptionConfigSecretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		klog.V(4).Infof("skipping KMS sidecar injection: %s/%s secret not found", encryptionConfigNamespace, encryptionConfigSecretName)
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		return fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+		return nil, fmt.Errorf("failed to get %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
 	}
 
 	encryptionConfig, err := encryptiondata.FromSecret(encryptionConfigurationSecret)
 	if err != nil {
-		return fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
+		return nil, fmt.Errorf("failed to extract encryption config from %s/%s secret: %w", encryptionConfigNamespace, encryptionConfigSecretName, err)
 	}
 
 	kmsConfigurations, err := encryptiondata.ExtractUniqueAndSortedKMSConfigurations(encryptionConfig)
 	if err != nil {
-		return fmt.Errorf("failed to get KMS configurations: %w", err)
+		return nil, fmt.Errorf("failed to get KMS configurations: %w", err)
 	}
 	if len(kmsConfigurations) == 0 {
 		klog.V(4).Infof("skipping KMS sidecar injection: no KMS plugins found in EncryptionConfiguration")
-		return nil
+		return nil, nil
 	}
 
 	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
 
+	var sidecarNames []string
 	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
 	for _, kmsConfiguration := range kmsConfigurations {
 		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
@@ -97,31 +174,41 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 		pluginConfig, ok := encryptionConfig.KMSPlugins[keyID]
 		if !ok {
-			return fmt.Errorf("missing plugin config for keyID %s", keyID)
+			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
 		}
 
-		sidecarProvider, err := newSidecarProvider(keyID, udsPath, pluginConfig)
+		creds := &credentialResolver{
+			pluginsSecretData: encryptionConfig.KMSPluginsSecretData,
+			credentialsDir:    credentialsDir,
+			keyID:             keyID,
+		}
+
+		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, creds)
 		if err != nil {
-			return fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
+			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
 		}
 
-		if err := ensureSidecarContainer(podSpec, sidecarProvider); err != nil {
-			return err
+		if err := ensureSidecarContainer(podSpec, provider); err != nil {
+			return nil, err
 		}
 
-		if err := ensureVolumeMountInContainer(podSpec.InitContainers, sidecarProvider.Name(), socketVolumeMount); err != nil {
-			return err
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, provider.Name(), socketVolumeMount); err != nil {
+			return nil, err
 		}
+
+		sidecarNames = append(sidecarNames, provider.Name())
 	}
 
 	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
-		return err
+		return nil, err
 	}
 
 	// The volume mount in the kube-apiserver and KMS plugin containers requires a volume in the podSpec
-	ensureSocketVolume(podSpec)
+	if err := ensureSocketVolume(podSpec); err != nil {
+		return nil, err
+	}
 
-	return nil
+	return sidecarNames, nil
 }
 
 func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) error {
@@ -167,19 +254,50 @@ func ensureVolumeMountInContainer(containers []corev1.Container, containerName s
 	return nil
 }
 
-func ensureSocketVolume(podSpec *corev1.PodSpec) {
-	for _, volume := range podSpec.Volumes {
-		if volume.Name == kmsPluginSocketVolumeName {
-			return
+func ensureVolume(podSpec *corev1.PodSpec, volume corev1.Volume) error {
+	for _, v := range podSpec.Volumes {
+		if v.Name == volume.Name {
+			if !equality.Semantic.DeepEqual(v, volume) {
+				return fmt.Errorf("pod already has volume %s with different settings", v.Name)
+			}
+			return nil
 		}
 	}
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+	return nil
+}
 
-	podSpec.Volumes = append(podSpec.Volumes,
-		corev1.Volume{
-			Name: kmsPluginSocketVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
+func ensureSocketVolume(podSpec *corev1.PodSpec) error {
+	volume := corev1.Volume{
+		Name: kmsPluginSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	return ensureVolume(podSpec, volume)
+}
+
+func ensureCredentialsVolume(podSpec *corev1.PodSpec, secretName string) error {
+	volume := corev1.Volume{
+		Name: credentialsVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
 			},
 		},
-	)
+	}
+	return ensureVolume(podSpec, volume)
+}
+
+func setRunAsUser(containers []corev1.Container, containerName string, uid int64) error {
+	for i, c := range containers {
+		if c.Name == containerName {
+			if c.SecurityContext == nil {
+				containers[i].SecurityContext = &corev1.SecurityContext{}
+			}
+			containers[i].SecurityContext.RunAsUser = ptr.To(uid)
+			return nil
+		}
+	}
+	return fmt.Errorf("container %s not found", containerName)
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -9,22 +9,39 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig) (*vault, error) {
+// newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
+// It assumes the input data has been already been validated.
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
+	secretName := vaultConfig.Authentication.AppRole.Secret.Name
+
+	roleID, err := creds.Value(secretName, "role-id")
+	if err != nil {
+		return nil, err
+	}
+
+	secretIDPath, err := creds.FilePath(secretName, "secret-id")
+	if err != nil {
+		return nil, err
+	}
+
 	return &vault{
-		name:    name,
-		keyID:   keyID,
-		udsPath: udsPath,
-		config:  vaultConfig,
+		name:         name,
+		keyID:        keyID,
+		udsPath:      udsPath,
+		config:       vaultConfig,
+		roleID:       roleID,
+		secretIDPath: secretIDPath,
 	}, nil
 }
 
 // vault implements SidecarProvider for HashiCorp Vault KMS.
 type vault struct {
-	name    string
-	keyID   string
-	udsPath string
-	config  configv1.VaultKMSPluginConfig
+	name         string
+	keyID        string
+	udsPath      string
+	config       configv1.VaultKMSPluginConfig
+	roleID       string
+	secretIDPath string
 }
 
 // Name returns the sidecar name appended by the key id.
@@ -41,10 +58,8 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		fmt.Sprintf("-vault-address=%s", v.config.VaultAddress),
 		fmt.Sprintf("-transit-mount=%s", v.config.TransitMount),
 		fmt.Sprintf("-transit-key=%s", v.config.TransitKey),
-		// TODO(bertinatto): dummy value for the Vault mock plugin; will come from the encryption-config secret.
-		fmt.Sprintf("-approle-role-id=dummy-role-id-%s", v.keyID),
-		// TODO(bertinatto): placeholder path for the Vault mock plugin; will differ per operator (KASO vs. aggregated apiserver operators).
-		fmt.Sprintf("-approle-secret-id-path=/var/run/secrets/vault-kms/secret-id-%s", v.keyID),
+		fmt.Sprintf("-approle-role-id=%s", v.roleID),
+		fmt.Sprintf("-approle-secret-id-path=%s", v.secretIDPath),
 	}
 
 	// Optional fields: only pass non-empty values.
@@ -67,6 +82,7 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		// Vault team recommendation based on single-node OCP cluster measurements:
 		// ~10 mCPU / 32-64 MiB steady state, memory peaked at ~60 MiB under 400 KEK rotations.
+		// Slack discussion: https://redhat-external.slack.com/archives/C09KZ5QCBUH/p1779134070543079
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("64Mi"),

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
@@ -18,10 +18,10 @@ const (
 Altering of the encryption secrets will render you cluster inaccessible.
 Catastrophic data loss can occur from the most minor changes.`
 
-	// secretDataKeySeparator separates the secret name from the data key.
+	// referenceDataKeySeparator separates the reference name from the data key.
 	// Underscore is used because it is forbidden in Kubernetes secret/configmap
 	// names, preventing collisions.
-	secretDataKeySeparator = "_"
+	referenceDataKeySeparator = "_"
 )
 
 // GroupResourceState represents, for a single group resource, the write and read keys in a
@@ -73,25 +73,25 @@ type KMSState struct {
 	Plugin configv1.KMSPluginConfig
 
 	// PluginSecretData stores data key-value pairs fetched from referenced secrets.
-	PluginSecretData KMSSecretData
+	PluginSecretData KMSReferenceData
 }
 
-// KMSSecretData stores data key-value pairs fetched from referenced secrets.
-// entries maps secret names to their data key-value pairs.
-type KMSSecretData struct {
+// KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.
+// entries maps reference names (secret or configmap) to their data key-value pairs.
+type KMSReferenceData struct {
 	entries map[string]map[string][]byte
 }
 
-// Get returns the value for the given secretName and dataKey. It returns false if
-// secretName or dataKey is empty, if Entries is nil, or if the key does not exist.
-func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
-	if len(secretName) == 0 || len(dataKey) == 0 {
+// Get returns the value for the given referenceName and dataKey. It returns false if
+// referenceName or dataKey is empty, if Entries is nil, or if the key does not exist.
+func (d *KMSReferenceData) Get(referenceName, dataKey string) ([]byte, bool) {
+	if len(referenceName) == 0 || len(dataKey) == 0 {
 		return nil, false
 	}
 	if d.entries == nil {
 		return nil, false
 	}
-	secretEntries, ok := d.entries[secretName]
+	secretEntries, ok := d.entries[referenceName]
 	if !ok {
 		return nil, false
 	}
@@ -99,54 +99,61 @@ func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
 	return value, ok
 }
 
-func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
-	if len(secretName) == 0 || len(dataKey) == 0 || len(value) == 0 {
-		return fmt.Errorf("secretName, dataKey, and value must not be empty")
+func (d *KMSReferenceData) Set(referenceName, dataKey string, value []byte) error {
+	if len(referenceName) == 0 || len(dataKey) == 0 || len(value) == 0 {
+		return fmt.Errorf("referenceName, dataKey, and value must not be empty")
 	}
-	if strings.Contains(secretName, "_") {
-		return fmt.Errorf("secret name %q must not contain underscores", secretName)
+	if strings.Contains(referenceName, "_") {
+		return fmt.Errorf("referenceName name %q must not contain underscores", referenceName)
 	}
 	if d.entries == nil {
 		d.entries = map[string]map[string][]byte{}
 	}
-	if d.entries[secretName] == nil {
-		d.entries[secretName] = map[string][]byte{}
+	if d.entries[referenceName] == nil {
+		d.entries[referenceName] = map[string][]byte{}
 	}
-	d.entries[secretName][dataKey] = value
+	d.entries[referenceName][dataKey] = value
 	return nil
 }
 
-// SetFromRawKey splits a combined key of the form "secretName_dataKey"
+// SetFromRawKey splits a combined key of the form "referenceName_dataKey"
 // and stores the value.
-func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
-	parts := strings.SplitN(rawKey, secretDataKeySeparator, 2)
+func (d *KMSReferenceData) SetFromRawKey(rawKey string, value []byte) error {
+	parts := strings.SplitN(rawKey, referenceDataKeySeparator, 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("invalid combined key %q: expected format {secretName}%s{dataKey}", rawKey, secretDataKeySeparator)
+		return fmt.Errorf("invalid combined key %q: expected format {referenceName}%s{dataKey}", rawKey, referenceDataKeySeparator)
 	}
 	return d.Set(parts[0], parts[1], value)
 }
 
-// FlatEntry returns the combined key "secretName_dataKey" used in flat representations.
+// FlatEntry returns the combined key "referenceName_dataKey" used in flat representations.
 //
 // Note:
 //
 // It does not validate inputs. The callers are expected to use Set,
-// which rejects empty values and underscores in secretName.
-func (d *KMSSecretData) FlatEntry(secretName, dataKey string) string {
-	return secretName + secretDataKeySeparator + dataKey
+// which rejects empty values and underscores in referenceName.
+func (d *KMSReferenceData) FlatEntry(referenceName, dataKey string) (string, bool) {
+	if _, ok := d.Get(referenceName, dataKey); !ok {
+		return "", false
+	}
+	return d.flatEntry(referenceName, dataKey), true
 }
 
-// FlatEntries returns the stored data as a flat map keyed by "secretName_dataKey".
-// "_" separates secretName from dataKey because "_" is forbidden in
-// Kubernetes secret names, making the split unambiguous.
-func (d *KMSSecretData) FlatEntries() map[string][]byte {
+func (d *KMSReferenceData) flatEntry(referenceName, dataKey string) string {
+	return referenceName + referenceDataKeySeparator + dataKey
+}
+
+// FlatEntries returns the stored data as a flat map keyed by "referenceName_dataKey".
+// "_" separates referenceName from dataKey because "_" is forbidden in
+// Kubernetes secret/configmap names, making the split unambiguous.
+func (d *KMSReferenceData) FlatEntries() map[string][]byte {
 	if d.entries == nil {
 		return nil
 	}
 	result := map[string][]byte{}
 	for secretName, keys := range d.entries {
 		for dataKey, value := range keys {
-			result[d.FlatEntry(secretName, dataKey)] = value
+			result[d.flatEntry(secretName, dataKey)] = value
 		}
 	}
 	return result

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -23,17 +23,18 @@ import (
 )
 
 const (
-	defaultVaultNamespace         = "vault-kms"
-	defaultVaultPodName           = "vault-0"
-	defaultVaultCredentialsSecret = "vault-credentials"
-	defaultVaultAppRoleSecretName = "vault-approle-secret"
-	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
-	defaultVaultAddress           = "https://vault.vault-kms.svc:8200"
-	defaultVaultEnterpriseNS      = "admin"
-	defaultVaultTransitMount      = "transit"
-	defaultVaultTransitKey        = "kms-key"
-	defaultAppRoleTargetNamespace = "openshift-config"
-	vaultCommandTimeout           = 30 * time.Second
+	defaultVaultNamespace          = "vault-kms"
+	defaultVaultPodName            = "vault-0"
+	defaultVaultCredentialsSecret  = "vault-credentials"
+	defaultVaultAppRoleSecretName  = "vault-approle-secret"
+	defaultFAKEVaultKMSPluginImage = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
+	defaultVaultKMSPluginImage     = "registry.ci.openshift.org/control-plane-custom-builds/vault-kube-kms@sha256:33599dd6eee61dcf9a60138759fafda3d88593a3c2072585156882c6b5bd3fa5"
+	defaultVaultAddress            = "https://vault.vault-kms.svc:8200"
+	defaultVaultEnterpriseNS       = "admin"
+	defaultVaultTransitMount       = "transit"
+	defaultVaultTransitKey         = "kms-key"
+	defaultAppRoleTargetNamespace  = "openshift-config"
+	vaultCommandTimeout            = 30 * time.Second
 )
 
 // DefaultVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider for e2e tests.
@@ -83,7 +84,7 @@ var DefaultFakeKMSPluginConfig = configv1.APIServerEncryption{
 	KMS: configv1.KMSPluginConfig{
 		Type: configv1.VaultKMSProvider,
 		Vault: configv1.VaultKMSPluginConfig{
-			KMSPluginImage: defaultVaultKMSPluginImage,
+			KMSPluginImage: defaultFAKEVaultKMSPluginImage,
 			VaultAddress:   "https://vault.example.com",
 			Authentication: configv1.VaultAuthentication{
 				Type: configv1.VaultAuthenticationTypeAppRole,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e
+# github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency mapping to use pinned alternative sources for two third-party modules.

* **Bug Fixes**
  * Improved KMS plugin sidecar injection for managed pods to enhance deployment reliability.

* **Tests**
  * e2e KMS encryption tests now run against a real Vault-backed provider instead of the previous fake provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->