### PR TITLE
OCPBUGS-86699: Fix kube-apiserver-to-kubelet-signer refresh interval

### DIFF
--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -229,7 +229,7 @@ func newCertRotationController(
 			Validity: devRotationExceptionYear, // this comes from the installer
 			// Refresh set to 80% of the validity.
 			// This range is consistent with most other signers defined in this pkg.
-			Refresh:                devRotationExceptionMonth,
+			Refresh:                devRotationExceptionTenMonth,
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			CertificateName:        "kube-apiserver.kubelet-client-signer",
 			PKIProfileProvider:     pkiProvider,


### PR DESCRIPTION
The refresh interval should be set to 80% of the validity period (292 days for a 365-day validity), consistent with the other signers in this package. Commit 498dc3f24 correctly raised the validity back to devRotationExceptionYear but did not raise the refresh accordingly, leaving it at devRotationExceptionMonth (30 days) instead of devRotationExceptionTenMonth (292 days).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted certificate refresh interval configuration to improve certificate lifecycle management and rotation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->