### PR TITLE
[release-4.12] NO-JIRA: refactor: Updating go builder in the CI, Dockerfile and go.mod to be consistent with ART 4.12

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-kube-apiserver-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-kube-apiserver-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/bootstrap-manifests /usr/share/bootkube/manifests/bootstrap-manifests/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/config /usr/share/bootkube/manifests/config/
 COPY --from=builder /go/src/github.com/openshift/cluster-kube-apiserver-operator/bindata/bootkube/manifests /usr/share/bootkube/manifests/manifests/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-kube-apiserver-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/apparentlymart/go-cidr v1.0.1

--- a/pkg/operator/startupmonitorreadiness/readiness_checks.go
+++ b/pkg/operator/startupmonitorreadiness/readiness_checks.go
@@ -244,9 +244,10 @@ func checkRevision(kasPod *corev1.Pod, monitorRevision int) (bool, string, strin
 }
 
 // goodReadyzEndpoint performs HTTP checks against readyz?verbose=true endpoint
-//  returns true, "", "", when we got HTTP 200 "successThreshold" times
-//  returns false, "NotReady", EntireResponseBody (if any) on HTTP != 200
-//  returns false, "NotReadyError", EntireResponseBody (if any) in case of any error or timeout
+//
+//	returns true, "", "", when we got HTTP 200 "successThreshold" times
+//	returns false, "NotReady", EntireResponseBody (if any) on HTTP != 200
+//	returns false, "NotReadyError", EntireResponseBody (if any) in case of any error or timeout
 func goodReadyzEndpoint(client *http.Client, rawURL string, successThreshold int, interval time.Duration) func(ctx context.Context) (bool, string, string) {
 	return func(ctx context.Context) (bool, string, string) {
 		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/readyz?verbose=true", rawURL), "NotReady", doHTTPCheckMultipleTimes(successThreshold, interval))
@@ -254,9 +255,10 @@ func goodReadyzEndpoint(client *http.Client, rawURL string, successThreshold int
 }
 
 // goodHealthzEndpoint performs an HTTP check against healthz?verbose=true endpoint
-//  returns true, "", "", on HTTP 200
-//  returns false, "Unhealthy", EntireResponseBody (if any) on HTTP != 200
-//  returns false, "UnhealthyError", EntireResponseBody (if any) in case of any error or timeout
+//
+//	returns true, "", "", on HTTP 200
+//	returns false, "Unhealthy", EntireResponseBody (if any) on HTTP != 200
+//	returns false, "UnhealthyError", EntireResponseBody (if any) in case of any error or timeout
 func goodHealthzEndpoint(client *http.Client, rawURL string) func(context.Context) (bool, string, string) {
 	return func(ctx context.Context) (bool, string, string) {
 		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/healthz?verbose=true", rawURL), "Unhealthy", doHTTPCheck)
@@ -264,9 +266,10 @@ func goodHealthzEndpoint(client *http.Client, rawURL string) func(context.Contex
 }
 
 // goodHealthzEtcdEndpoint performs an HTTP check against healthz/etcd endpoint
-//  returns true, "", "", on HTTP 200
-//  returns false, "EtcdUnhealthy", EntireResponseBody (if any) on HTTP != 200
-//  returns false, "EtcdUnhealthyError", EntireResponseBody (if any) in case of any error or timeout
+//
+//	returns true, "", "", on HTTP 200
+//	returns false, "EtcdUnhealthy", EntireResponseBody (if any) on HTTP != 200
+//	returns false, "EtcdUnhealthyError", EntireResponseBody (if any) in case of any error or timeout
 func goodHealthzEtcdEndpoint(client *http.Client, rawURL string) func(context.Context) (bool, string, string) {
 	return func(ctx context.Context) (bool, string, string) {
 		return doHTTPCheckAndTransform(ctx, client, fmt.Sprintf("%s/healthz/etcd", rawURL), "EtcdUnhealthy", doHTTPCheck)


### PR DESCRIPTION
Updates the Go language version to 1.19 to align with the ART stream configuration for the release-4.12 branch across both the CI pipeline and the Dockerfile.

As a best practice, the go.mod file has also been updated to 1.19. This was validated using `mingo`, which flagged a strict requirement for 1.19 due to our upstream dependencies.

Running mingo -check -tests -deps all -strict caught the following version mismatch prior to the update:
`Error: scanning directory: go.mod declares version 1.18 but computed minimum is 1.19 [k8s.io/api@v0.25.0 declares Go version 1.19]`
