### PR TITLE
NO-JIRA: Automatic agentic rebase: Update library-go to 0cf249e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260601085205-dd8108fa7369
+	github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260601085205-dd8108fa7369 h1:msrYS7vyy/6YH4AzfUQxg0LNZlsIgMT+tIVNm6xVWWE=
-github.com/openshift/library-go v0.0.0-20260601085205-dd8108fa7369/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96 h1:lzM66uIxm7/yY4azyzeZpPSb3LZDyACUd3dQAoVQb7I=
+github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/OWNERS
@@ -1,10 +1,9 @@
 reviewers:
+  - ardaguclu
   - dgrisonnet
   - p0lyn0mial
-  - sttts
-  - tkashem
 approvers:
+  - ardaguclu
   - dgrisonnet
   - p0lyn0mial
-  - sttts
-  - tkashem
+

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -61,13 +61,12 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 		// regular containers and keeps it running for the pod's lifetime.
 		RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		// TODO(bertinatto): the plugin sidecar needs to be measure under heavy load to figure out good defaults.
-		// For now follow what most sidecars in the kube-apiserver pod do. xref:
-		// https://github.com/openshift/cluster-kube-apiserver-operator/commit/e15a19cd2474c8b60ce17ac16dd8f422c729847a
+		// Vault team recommendation based on single-node OCP cluster measurements:
+		// ~10 mCPU / 32-64 MiB steady state, memory peaked at ~60 MiB under 400 KEK rotations.
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
-				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		},
 	}, nil

--- a/vendor/github.com/openshift/library-go/test/library/encryption/OWNERS
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/OWNERS
@@ -1,10 +1,9 @@
 reviewers:
+  - ardaguclu
   - dgrisonnet
   - p0lyn0mial
-  - sttts
-  - tkashem
 approvers:
+  - ardaguclu
   - dgrisonnet
   - p0lyn0mial
-  - sttts
-  - tkashem
+

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -3,6 +3,7 @@ package kms
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -26,7 +27,7 @@ const (
 	defaultVaultPodName           = "vault-0"
 	defaultVaultCredentialsSecret = "vault-credentials"
 	defaultVaultAppRoleSecretName = "vault-approle-secret"
-	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:03bb07a2c08b509653c4c70217a06a4b389c10b4d87922f50ee5eac82db5e140"
+	defaultVaultKMSPluginImage    = "quay.io/openshifttest/mock-kms-plugin@sha256:958a2f8276037468aa47dc2137d3c30dfcd96489455eddb2fe655f8168a57622"
 	defaultVaultAddress           = "https://vault.vault-kms.svc:8200"
 	defaultVaultEnterpriseNS      = "admin"
 	defaultVaultTransitMount      = "transit"
@@ -35,11 +36,18 @@ const (
 	vaultCommandTimeout           = 30 * time.Second
 )
 
-// DefaultVaultEncryptionProvider is a ready-to-use Vault KMS EncryptionProvider for e2e tests.
-// It bundles the default config with the AppRole secret setup.
-var DefaultVaultEncryptionProvider = library.EncryptionProvider{
-	APIServerEncryption: DefaultVaultKMSPluginConfig,
-	Setup:               ensureDefaultVaultAppRoleSecret,
+// DefaultVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider for e2e tests.
+// It resolves the Vault Service ClusterIP at call time to avoid DNS resolution issues,
+// and bundles the AppRole secret setup.
+func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
+	cfg := DefaultVaultKMSPluginConfig
+	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
+	// cannot resolve cluster-local Service names (they use host network DNS).
+	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t)
+	return library.EncryptionProvider{
+		APIServerEncryption: cfg,
+		Setup:               ensureDefaultVaultAppRoleSecret,
+	}
 }
 
 var DefaultFakeVaultEncryptionProvider = library.EncryptionProvider{
@@ -173,4 +181,30 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 	require.NoError(t, err, "failed to parse key version from output: %q", string(output))
 
 	return version
+}
+
+// getVaultServiceAddress returns the Vault address using the Service's ClusterIP
+// instead of the DNS name, reading the port and scheme from the Service spec.
+func getVaultServiceAddress(ctx context.Context, t testing.TB) string {
+	t.Helper()
+	cs := library.GetClients(t)
+
+	svc, err := cs.Kube.CoreV1().Services(defaultVaultNamespace).Get(ctx, "vault", metav1.GetOptions{})
+	require.NoError(t, err, "failed to get vault Service in namespace %s", defaultVaultNamespace)
+	require.NotEmpty(t, svc.Spec.ClusterIP, "vault Service has no ClusterIP")
+	require.NotEmpty(t, svc.Spec.Ports, "vault Service has no ports")
+
+	// The Vault Helm chart names the client port "https" (8200).
+	var port *corev1.ServicePort
+	for i := range svc.Spec.Ports {
+		if svc.Spec.Ports[i].Name == "https" {
+			port = &svc.Spec.Ports[i]
+			break
+		}
+	}
+	require.NotNil(t, port, "vault Service has no port named \"https\"")
+
+	addr := fmt.Sprintf("https://%s", net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(port.Port))))
+	t.Logf("Resolved Vault Service address: %s", addr)
+	return addr
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260601085205-dd8108fa7369
+# github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
## Summary

Automated dependency update for `github.com/openshift/library-go`.

## Details

- **library-go commit**: [`0cf249e`](https://github.com/openshift/library-go/commit/0cf249e20e96c9e41c4d387cf480d4cb89125886)
- **Update date**: 2026-06-02
- **Generated by**: Claude Code agentic workflow

## Changes

- Updated `go.mod` and `go.sum`
- Refreshed vendor directory

## Testing

- [ ] CI tests pass
- [ ] Manual verification recommended

---

🤖 This PR was created automatically by an AI agent using Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency to a newer release to keep the codebase current, improving stability and performance. This is a low-risk dependency bump with no user-facing feature or API changes, and requires minimal follow-up from end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->