### PR TITLE
NO-JIRA: Automatic agentic rebase: Update library-go to d8750ed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96
+	github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96 h1:lzM66uIxm7/yY4azyzeZpPSb3LZDyACUd3dQAoVQb7I=
-github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e h1:YZwznqixO2lJa3eNSghZiKCgYbdk5IRvqDf7k6NKFZ4=
+github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/test/e2e-encryption-rotation/encryption_rotation_test.go
+++ b/test/e2e-encryption-rotation/encryption_rotation_test.go
@@ -19,6 +19,17 @@ var provider = flag.String("provider", "aescbc", "encryption provider used by th
 // rotation by setting the "encyrption.Reason" in the operator's configuration
 // file
 func TestEncryptionRotation(t *testing.T) {
+	updateUnsupportedConfig := func(raw []byte) error {
+		operatorClient := operatorencryption.GetOperator(t)
+		apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		apiServerOperator.Spec.UnsupportedConfigOverrides.Raw = raw
+		_, err = operatorClient.Update(context.TODO(), apiServerOperator, metav1.UpdateOptions{})
+		return err
+	}
+
 	library.TestEncryptionRotation(t.Context(), t, library.RotationScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -29,18 +40,10 @@ func TestEncryptionRotation(t *testing.T) {
 			TargetGRs:                       operatorencryption.DefaultTargetGRs,
 			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
 		},
-		CreateResourceFunc: operatorencryption.CreateAndStoreSecretOfLife,
-		GetRawResourceFunc: operatorencryption.GetRawSecretOfLife,
-		UnsupportedConfigFunc: func(raw []byte) error {
-			operatorClient := operatorencryption.GetOperator(t)
-			apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			apiServerOperator.Spec.UnsupportedConfigOverrides.Raw = raw
-			_, err = operatorClient.Update(context.TODO(), apiServerOperator, metav1.UpdateOptions{})
-			return err
-		},
-		EncryptionProvider: library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
+		CreateResourceFunc:          operatorencryption.CreateAndStoreSecretOfLife,
+		GetRawResourceFunc:          operatorencryption.GetRawSecretOfLife,
+		ForceRotationFunc:           library.StaticEncryptionForceRotation(updateUnsupportedConfig),
+		WaitForRotationCompleteFunc: library.WaitForNextEncryptionKeyRotation(),
+		EncryptionProvider:          library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
 	})
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
@@ -39,7 +39,17 @@ type Config struct {
 // KMSPluginsSecretData maps keyID to secret data carried from Key Secrets into
 // the encryption-config Secret. Structure: keyID → secretName → dataKey → value.
 type KMSPluginsSecretData struct {
-	ByKeyID map[string]state.KMSSecretData
+	byKeyID map[string]state.KMSSecretData
+}
+
+// Get returns the KMSSecretData for the given keyID and true if it exists,
+// or a zero value and false otherwise. It is safe to call on a nil map.
+func (d *KMSPluginsSecretData) Get(keyID string) (state.KMSSecretData, bool) {
+	if d.byKeyID == nil {
+		return state.KMSSecretData{}, false
+	}
+	sd, ok := d.byKeyID[keyID]
+	return sd, ok
 }
 
 // SetFromRawKey stores a value for the given keyID, splitting rawKey
@@ -48,25 +58,25 @@ func (d *KMSPluginsSecretData) SetFromRawKey(keyID, rawKey string, value []byte)
 	if len(keyID) == 0 {
 		return fmt.Errorf("keyID must not be empty")
 	}
-	if d.ByKeyID == nil {
-		d.ByKeyID = map[string]state.KMSSecretData{}
+	if d.byKeyID == nil {
+		d.byKeyID = map[string]state.KMSSecretData{}
 	}
-	sd := d.ByKeyID[keyID]
+	sd := d.byKeyID[keyID]
 	if err := sd.SetFromRawKey(rawKey, value); err != nil {
 		return err
 	}
-	d.ByKeyID[keyID] = sd
+	d.byKeyID[keyID] = sd
 	return nil
 }
 
 // FlatEntriesByKeyID returns the stored data as a map of keyID to flat entries,
 // where each flat entry is keyed by "secretName_dataKey".
 func (d *KMSPluginsSecretData) FlatEntriesByKeyID() map[string]map[string][]byte {
-	if d.ByKeyID == nil {
+	if d.byKeyID == nil {
 		return nil
 	}
 	result := map[string]map[string][]byte{}
-	for keyID, sd := range d.ByKeyID {
+	for keyID, sd := range d.byKeyID {
 		if flat := sd.FlatEntries(); flat != nil {
 			result[keyID] = flat
 		}
@@ -111,8 +121,8 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 				}
 			}
 			if key.HasKMSSecretData() {
-				if existing, exists := kmsPluginsSecretData.ByKeyID[key.Key.Name]; exists {
-					if !equality.Semantic.DeepEqual(existing, key.KMS.PluginSecretData) {
+				if existing, exists := kmsPluginsSecretData.Get(key.Key.Name); exists {
+					if !equality.Semantic.DeepEqual(existing.FlatEntries(), key.KMS.PluginSecretData.FlatEntries()) {
 						return nil, fmt.Errorf("KMS secret data mismatch for keyID %s: secret data from different resources must be identical", key.Key.Name)
 					}
 				} else {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
@@ -91,7 +91,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// which is then split on "_" to recover secretName and dataKey.
 	var kmsPluginsSecretData KMSPluginsSecretData
 	for key, value := range encryptionConfigSecret.Data {
-		keyID, rawKey, found, err := parseSecretDataKey(key)
+		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse secret data key %s: %w", key, err)
 		}
@@ -151,8 +151,8 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	// Each entry from FlatEntries() (e.g. "app-role_role-id") is combined with the keyID
 	// (e.g. "1") to produce "kms-plugin-secret-app-role_role-id-1".
 	for keyID, flatEntries := range secretData.KMSPluginsSecretData.FlatEntriesByKeyID() {
-		for flatKey, value := range flatEntries {
-			s.Data[encryptionConfigSecretDataPrefix+flatKey+"-"+keyID] = value
+		for rawKey, value := range flatEntries {
+			s.Data[FormatKMSSecretDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -202,7 +202,19 @@ func ExtractUniqueAndSortedKMSConfigurations(secretData *Config) ([]*apiserverco
 	return result, nil
 }
 
-func parseSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
+// FormatKMSSecretDataKey returns the data key used in the encryption-config Secret
+// for a KMS plugin secret entry: "kms-plugin-secret-{rawKey}-{keyID}",
+// where rawKey is the combined "secretName_dataKey" from KMSSecretData.FlatEntry.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use KMSSecretData.Set,
+// which rejects empty values and underscores in secretName.
+func FormatKMSSecretDataKey(rawKey, keyID string) string {
+	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
+}
+
+func parseKMSSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
 	rest, found := strings.CutPrefix(dataKey, encryptionConfigSecretDataPrefix)
 	if !found {
 		return "", "", false, nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -9,10 +9,16 @@ import (
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
+)
+
+const (
+	kmsPluginSocketVolumeName = "kms-plugin-socket"
+	kmsPluginSocketMountPath  = "/var/run/kmsplugin"
 )
 
 // sidecarProvider abstracts the construction of a KMS plugin sidecar container for a specific provider (e.g. Vault).
@@ -27,7 +33,7 @@ type sidecarProvider interface {
 func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
@@ -83,6 +89,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 	klog.V(4).Infof("injecting %d KMS sidecar(s)", len(kmsConfigurations))
 
+	socketVolumeMount := corev1.VolumeMount{Name: kmsPluginSocketVolumeName, MountPath: kmsPluginSocketMountPath, ReadOnly: false}
 	for _, kmsConfiguration := range kmsConfigurations {
 		// ExtractUniqueAndSortedKMSConfigurations function rewrites the .Name field to include only the key ID
 		keyID := kmsConfiguration.Name
@@ -102,12 +109,12 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 			return err
 		}
 
-		if err := ensureSocketVolumeMountInContainer(podSpec.InitContainers, sidecarProvider.Name()); err != nil {
+		if err := ensureVolumeMountInContainer(podSpec.InitContainers, sidecarProvider.Name(), socketVolumeMount); err != nil {
 			return err
 		}
 	}
 
-	if err := ensureSocketVolumeMountInContainer(podSpec.Containers, containerName); err != nil {
+	if err := ensureVolumeMountInContainer(podSpec.Containers, containerName, socketVolumeMount); err != nil {
 		return err
 	}
 
@@ -134,7 +141,7 @@ func ensureSidecarContainer(podSpec *corev1.PodSpec, provider sidecarProvider) e
 	return nil
 }
 
-func ensureSocketVolumeMountInContainer(containers []corev1.Container, containerName string) error {
+func ensureVolumeMountInContainer(containers []corev1.Container, containerName string, volumeMount corev1.VolumeMount) error {
 	containerIndex := -1
 	for i, container := range containers {
 		if container.Name == containerName {
@@ -147,35 +154,29 @@ func ensureSocketVolumeMountInContainer(containers []corev1.Container, container
 		return fmt.Errorf("container %s not found", containerName)
 	}
 
-	foundMount := false
 	container := &containers[containerIndex]
 	for _, m := range container.VolumeMounts {
-		if m.Name == "kms-plugin-socket" {
-			foundMount = true
-			break
+		if m.Name == volumeMount.Name {
+			if !equality.Semantic.DeepEqual(m, volumeMount) {
+				return fmt.Errorf("container %s already has volume mount %s with different settings", containerName, volumeMount.Name)
+			}
+			return nil
 		}
 	}
-	if !foundMount {
-		container.VolumeMounts = append(container.VolumeMounts,
-			corev1.VolumeMount{
-				Name:      "kms-plugin-socket",
-				MountPath: "/var/run/kmsplugin",
-			},
-		)
-	}
+	container.VolumeMounts = append(container.VolumeMounts, volumeMount)
 	return nil
 }
 
 func ensureSocketVolume(podSpec *corev1.PodSpec) {
 	for _, volume := range podSpec.Volumes {
-		if volume.Name == "kms-plugin-socket" {
+		if volume.Name == kmsPluginSocketVolumeName {
 			return
 		}
 	}
 
 	podSpec.Volumes = append(podSpec.Volumes,
 		corev1.Volume{
-			Name: "kms-plugin-socket",
+			Name: kmsPluginSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -10,12 +10,12 @@ import (
 )
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin configuration.
-func newVaultSidecarProvider(name, keyID, udsPath string, pluginConfig configv1.KMSPluginConfig) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig) (*vault, error) {
 	return &vault{
 		name:    name,
 		keyID:   keyID,
 		udsPath: udsPath,
-		config:  &pluginConfig.Vault,
+		config:  vaultConfig,
 	}, nil
 }
 
@@ -24,7 +24,7 @@ type vault struct {
 	name    string
 	keyID   string
 	udsPath string
-	config  *configv1.VaultKMSPluginConfig
+	config  configv1.VaultKMSPluginConfig
 }
 
 // Name returns the sidecar name appended by the key id.
@@ -51,6 +51,10 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	if v.config.VaultNamespace != "" {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
+
+	// TODO(bertinatto): this is a temporary workaround until the ca bundle is wired into the
+	// encryption config secret. This should be removed before shipping the KMS feature.
+	args = append(args, "-tls-skip-verify")
 
 	return corev1.Container{
 		Name:            v.Name(),

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
@@ -61,7 +61,7 @@ func (k *KeyState) HasKMSPlugin() bool {
 }
 
 func (k *KeyState) HasKMSSecretData() bool {
-	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.Entries) > 0
+	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.entries) > 0
 }
 
 // KMSState stores all KMS encryption mode related configurations
@@ -77,9 +77,26 @@ type KMSState struct {
 }
 
 // KMSSecretData stores data key-value pairs fetched from referenced secrets.
-// Entries maps secret names to their data key-value pairs.
+// entries maps secret names to their data key-value pairs.
 type KMSSecretData struct {
-	Entries map[string]map[string][]byte
+	entries map[string]map[string][]byte
+}
+
+// Get returns the value for the given secretName and dataKey. It returns false if
+// secretName or dataKey is empty, if Entries is nil, or if the key does not exist.
+func (d *KMSSecretData) Get(secretName, dataKey string) ([]byte, bool) {
+	if len(secretName) == 0 || len(dataKey) == 0 {
+		return nil, false
+	}
+	if d.entries == nil {
+		return nil, false
+	}
+	secretEntries, ok := d.entries[secretName]
+	if !ok {
+		return nil, false
+	}
+	value, ok := secretEntries[dataKey]
+	return value, ok
 }
 
 func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
@@ -89,13 +106,13 @@ func (d *KMSSecretData) Set(secretName, dataKey string, value []byte) error {
 	if strings.Contains(secretName, "_") {
 		return fmt.Errorf("secret name %q must not contain underscores", secretName)
 	}
-	if d.Entries == nil {
-		d.Entries = map[string]map[string][]byte{}
+	if d.entries == nil {
+		d.entries = map[string]map[string][]byte{}
 	}
-	if d.Entries[secretName] == nil {
-		d.Entries[secretName] = map[string][]byte{}
+	if d.entries[secretName] == nil {
+		d.entries[secretName] = map[string][]byte{}
 	}
-	d.Entries[secretName][dataKey] = value
+	d.entries[secretName][dataKey] = value
 	return nil
 }
 
@@ -109,17 +126,27 @@ func (d *KMSSecretData) SetFromRawKey(rawKey string, value []byte) error {
 	return d.Set(parts[0], parts[1], value)
 }
 
+// FlatEntry returns the combined key "secretName_dataKey" used in flat representations.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use Set,
+// which rejects empty values and underscores in secretName.
+func (d *KMSSecretData) FlatEntry(secretName, dataKey string) string {
+	return secretName + secretDataKeySeparator + dataKey
+}
+
 // FlatEntries returns the stored data as a flat map keyed by "secretName_dataKey".
 // "_" separates secretName from dataKey because "_" is forbidden in
 // Kubernetes secret names, making the split unambiguous.
 func (d *KMSSecretData) FlatEntries() map[string][]byte {
-	if d.Entries == nil {
+	if d.entries == nil {
 		return nil
 	}
 	result := map[string][]byte{}
-	for secretName, keys := range d.Entries {
+	for secretName, keys := range d.entries {
 		for dataKey, value := range keys {
-			result[secretName+secretDataKeySeparator+dataKey] = value
+			result[d.FlatEntry(secretName, dataKey)] = value
 		}
 	}
 	return result

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
@@ -42,6 +42,8 @@ func NewInMemoryRecorder(sourceComponent string, clock clock.PassiveClock) InMem
 }
 
 func (r *inMemoryEventRecorder) ComponentName() string {
+	r.Lock()
+	defer r.Unlock()
 	return r.source
 }
 
@@ -55,6 +57,8 @@ func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
 }
 
 func (r *inMemoryEventRecorder) WithContext(ctx context.Context) Recorder {
+	r.Lock()
+	defer r.Unlock()
 	r.ctx = ctx
 	return r
 }
@@ -65,7 +69,9 @@ func (r *inMemoryEventRecorder) WithComponentSuffix(suffix string) Recorder {
 
 // Events returns list of recorded events
 func (r *inMemoryEventRecorder) Events() []*corev1.Event {
-	return r.events
+	r.Lock()
+	defer r.Unlock()
+	return append([]*corev1.Event(nil), r.events...)
 }
 
 func (r *inMemoryEventRecorder) Event(reason, message string) {

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -55,6 +56,32 @@ type EncryptionKeyMeta struct {
 }
 
 type UpdateUnsupportedConfigFunc func(raw []byte) error
+
+// ForceRotationFunc triggers a key rotation in a provider-specific way.
+// Static encryption (AES-CBC/AES-GCM) sets encryption.reason in unsupported config;
+// KMS rotates the external KMS key (for example Vault transit).
+type ForceRotationFunc func(t testing.TB, ctx context.Context)
+
+// WaitForRotationCompleteFunc waits until re-migration after rotation has finished.
+// Static encryption waits for the next encryption key secret to be migrated;
+// KMS waits for a new finished entry in KeyRotationStatus, created by the rotation controller.
+type WaitForRotationCompleteFunc func(t testing.TB, clientSet ClientSet, prevKeyMeta EncryptionKeyMeta, scenario BasicScenario)
+
+// StaticEncryptionForceRotation returns a ForceRotationFunc that mints a new key via encryption.reason.
+func StaticEncryptionForceRotation(updateUnsupportedConfig UpdateUnsupportedConfigFunc) ForceRotationFunc {
+	return func(t testing.TB, _ context.Context) {
+		t.Helper()
+		require.NoError(t, ForceKeyRotation(t, updateUnsupportedConfig, fmt.Sprintf("test-key-rotation-%s", rand.String(4))))
+	}
+}
+
+// WaitForNextEncryptionKeyRotation waits until a new encryption key secret is fully migrated.
+func WaitForNextEncryptionKeyRotation() WaitForRotationCompleteFunc {
+	return func(t testing.TB, clientSet ClientSet, prevKeyMeta EncryptionKeyMeta, scenario BasicScenario) {
+		t.Helper()
+		WaitForNextMigratedKey(t, clientSet.Kube, prevKeyMeta, scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+	}
+}
 
 func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider EncryptionProvider, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) ClientSet {
 	t.Helper()

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -124,13 +124,17 @@ func ensureDefaultVaultAppRoleSecret(ctx context.Context, t testing.TB) {
 	t.Logf("Applied AppRole secret %s in %s (changed=%v)", defaultVaultAppRoleSecretName, defaultAppRoleTargetNamespace, changed)
 }
 
+func ForceVaultKeyRotation() library.ForceRotationFunc {
+	return RotateVaultTransitKey
+}
+
 // RotateVaultTransitKey rotates the Vault transit encryption key. All old key versions are retained.
 // Reference: https://developer.hashicorp.com/vault/api-docs/secret/transit#rotate-key
 // Steps:
 // 1. Get initial key version
 // 2. Execute 'vault write -f transit/keys/<key-name>/rotate' via oc exec
 // 3. Get new key version and validate it increased
-func RotateVaultTransitKey(ctx context.Context, t testing.TB) {
+func RotateVaultTransitKey(t testing.TB, ctx context.Context) {
 	t.Helper()
 
 	initialVersion := getCurrentKeyVersion(ctx, t)

--- a/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -238,14 +237,15 @@ func TestEncryptionProvidersMigration(ctx context.Context, t testing.TB, scenari
 
 type RotationScenario struct {
 	BasicScenario
-	CreateResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
-	GetRawResourceFunc    func(t testing.TB, clientSet ClientSet, namespace string) string
-	UnsupportedConfigFunc UpdateUnsupportedConfigFunc
-	EncryptionProvider    EncryptionProvider
+	CreateResourceFunc          func(t testing.TB, clientSet ClientSet, namespace string) runtime.Object
+	GetRawResourceFunc          func(t testing.TB, clientSet ClientSet, namespace string) string
+	EncryptionProvider          EncryptionProvider
+	ForceRotationFunc           ForceRotationFunc
+	WaitForRotationCompleteFunc WaitForRotationCompleteFunc
 }
 
-// TestEncryptionRotation first encrypts data with aescbc key
-// then it forces a key rotation by setting the "encyrption.Reason" in the operator's configuration file
+// TestEncryptionRotation encrypts data, forces a provider-specific key rotation, waits for
+// re-migration to complete, and verifies the resource was re-encrypted with different content.
 func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario RotationScenario) {
 	// test data
 	ns := scenario.Namespace
@@ -254,7 +254,7 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	// step 1: create the desired resource
 	e := NewE(t)
 	clientSet := GetClients(e)
-	scenario.CreateResourceFunc(e, GetClients(e), ns)
+	scenario.CreateResourceFunc(e, clientSet, ns)
 
 	// step 2: run provided encryption scenario
 	TestEncryptionType(ctx, t, scenario.BasicScenario, scenario.EncryptionProvider)
@@ -265,14 +265,18 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	// step 4: force key rotation and wait for migration to complete
 	lastMigratedKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube, ns, labelSelector)
 	require.NoError(e, err)
-	require.NoError(e, ForceKeyRotation(e, scenario.UnsupportedConfigFunc, fmt.Sprintf("test-key-rotation-%s", rand.String(4))))
-	WaitForNextMigratedKey(e, clientSet.Kube, lastMigratedKeyMeta, scenario.TargetGRs, ns, labelSelector)
+	t.Logf("Forcing key rotation for %q encryption", scenario.EncryptionProvider.Type)
+	scenario.ForceRotationFunc(e, ctx)
+
+	t.Logf("Waiting for rotation migration to complete")
+	scenario.WaitForRotationCompleteFunc(e, clientSet, lastMigratedKeyMeta, scenario.BasicScenario)
+
 	scenario.AssertFunc(e, clientSet, scenario.EncryptionProvider.Type, ns, labelSelector)
 
 	// step 5: verify if the provided resource was encrypted with a different key (step 2 vs step 4)
 	rawEncryptedResourceWithKey2 := scenario.GetRawResourceFunc(e, clientSet, ns)
 	if rawEncryptedResourceWithKey1 == rawEncryptedResourceWithKey2 {
-		t.Errorf("expected the resource to has a different content after a key rotation,\ncontentBeforeRotation %s\ncontentAfterRotation %s", rawEncryptedResourceWithKey1, rawEncryptedResourceWithKey2)
+		t.Errorf("expected the resource to have different content after a key rotation,\ncontentBeforeRotation %s\ncontentAfterRotation %s", rawEncryptedResourceWithKey1, rawEncryptedResourceWithKey2)
 	}
 
 	// TODO: assert conditions - operator and encryption migration controller must report status as active not progressing, and not failing for all scenarios

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260602120152-0cf249e20e96
+# github.com/openshift/library-go v0.0.0-20260603103329-d8750ed2813e
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
## Summary

Automated dependency update for `github.com/openshift/library-go`.

## Details

- **library-go commit**: [`d8750ed`](https://github.com/openshift/library-go/commit/d8750ed2813e167e9aed7b16365aea51b3c3700b)
- **Update date**: 2026-06-03
- **Generated by**: Claude Code agentic workflow

## Changes

- Updated `go.mod` and `go.sum`
- Refreshed vendor directory

## Testing

- [ ] CI tests pass
- [ ] Manual verification recommended

---

🤖 This PR was created automatically by an AI agent using Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer compatible version.

* **Tests**
  * Refactored the end-to-end encryption rotation test to use a shared helper for unsupported-config updates and streamlined the test scenario wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->