### PR TITLE
OCPBUGS-85183: Add kind-aware staleness detection for runtime-config entries

### DIFF
--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -29,7 +29,7 @@ var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVers
 		// admission plugin uses v1beta1 informers. The openshift-apiserver can't be rebased until the
 		// o/k 1.36 rebase lands and a 1.36 branch is created on openshift/kubernetes-apiserver.
 		{
-			KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.37.0"),
+			KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.34.0"),
 			GroupVersion:     schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
 			Kinds:            []string{"MutatingAdmissionPolicy", "MutatingAdmissionPolicyBinding"},
 		},

--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 	"MutatingAdmissionPolicy": {
 		// Both v1alpha1 and v1beta1 versions must be served pre-GA because e2e tests exercise both APIs.
 		// A GA OpenShift release could inadvertently serve these versions if MutatingAdmissionPolicy
@@ -28,17 +28,30 @@ var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVers
 		// k8s.io/apiserver at 1.34 (via openshift/kubernetes-apiserver) and its MutatingAdmissionPolicy
 		// admission plugin uses v1beta1 informers. The openshift-apiserver can't be rebased until the
 		// o/k 1.36 rebase lands and a 1.36 branch is created on openshift/kubernetes-apiserver.
-		{KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}},
-		{KubeVersionRange: semver.MustParseRange(">=1.34.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}},
+		{
+			KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.37.0"),
+			GroupVersion:     schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+			Kinds:            []string{"MutatingAdmissionPolicy", "MutatingAdmissionPolicyBinding"},
+		},
+		{
+			KubeVersionRange: semver.MustParseRange(">=1.34.0 <1.37.0"),
+			GroupVersion:     schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
+			Kinds:            []string{"MutatingAdmissionPolicy", "MutatingAdmissionPolicyBinding"},
+		},
 	},
 }
 
-type groupVersionByOpenshiftVersion struct {
+type groupVersionKindsByOpenshiftVersion struct {
 	schema.GroupVersion
 	KubeVersionRange semver.Range
+	// Kinds lists the specific resource kinds this entry is about. When set,
+	// staleness checks can verify per-kind whether the API has graduated to v1
+	// or a higher pre-release version exists. When unset, only a coarse
+	// group-level version priority check is performed.
+	Kinds []string
 }
 
-func getGroupVersionByFeatureGate(groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion, kubeVersion semver.Version) (map[configv1.FeatureGateName][]schema.GroupVersion, error) {
+func getGroupVersionByFeatureGate(groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion, kubeVersion semver.Version) (map[configv1.FeatureGateName][]schema.GroupVersion, error) {
 	result := make(map[configv1.FeatureGateName][]schema.GroupVersion, len(groupVersionsByFeatureGate))
 	groupByVersions := map[string][]string{}
 	for featureGate, APIGroups := range groupVersionsByFeatureGate {

--- a/pkg/operator/configobservation/apienablement/observe_runtime_config.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config.go
@@ -15,14 +15,19 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
-var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{}
+var defaultGroupVersionsByFeatureGate = map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{}
 
-type groupVersionByOpenshiftVersion struct {
+type groupVersionKindsByOpenshiftVersion struct {
 	schema.GroupVersion
 	KubeVersionRange semver.Range
+	// Kinds lists the specific resource kinds this entry is about. When set,
+	// staleness checks can verify per-kind whether the API has graduated to v1
+	// or a higher pre-release version exists. When unset, only a coarse
+	// group-level version priority check is performed.
+	Kinds []string
 }
 
-func getGroupVersionByFeatureGate(groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion, kubeVersion semver.Version) (map[configv1.FeatureGateName][]schema.GroupVersion, error) {
+func getGroupVersionByFeatureGate(groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion, kubeVersion semver.Version) (map[configv1.FeatureGateName][]schema.GroupVersion, error) {
 	result := make(map[configv1.FeatureGateName][]schema.GroupVersion, len(groupVersionsByFeatureGate))
 	groupByVersions := map[string][]string{}
 	for featureGate, APIGroups := range groupVersionsByFeatureGate {

--- a/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	componentbaseversion "k8s.io/component-base/version"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func staticObserver(cfg map[string]interface{}, errs []error) configobserver.ObserveConfigFunc {
@@ -175,14 +179,14 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 	for _, tc := range []struct {
 		name                       string
 		kubeVersion                semver.Version
-		groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion
+		groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion
 		expectedGroupVersions      map[configv1.FeatureGateName][]schema.GroupVersion
 		expectErrors               bool
 	}{
 		{
 			name:        "partial from/to",
 			kubeVersion: semver.MustParse("1.30.0"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"ValidatingAdmissionPolicy": {{GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}}},
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
@@ -197,7 +201,7 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "resolves newer API",
 			kubeVersion: semver.MustParse("1.31.0"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
@@ -210,7 +214,7 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "resolves minor versions API",
 			kubeVersion: semver.MustParse("1.31.15"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.15"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.15"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
@@ -223,7 +227,7 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "no intersection resolves to empty",
 			kubeVersion: semver.MustParse("1.31.15"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.14"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.16"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
@@ -244,5 +248,30 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 				t.Errorf("unexpecteded errors: %v", err)
 			}
 		})
+	}
+}
+
+// TestDefaultGroupVersionsByFeatureGateNotStale verifies that the API versions
+// listed in defaultGroupVersionsByFeatureGate are still current for the vendored
+// Kubernetes version. This test fails after a kube rebase when an API graduates
+// or a new pre-release version appears.
+//
+// If this test fails:
+//   - "kind X exists in stable v1" — the API has graduated to GA. Remove the
+//     entry from defaultGroupVersionsByFeatureGate; v1 is served by default.
+//   - "kind X exists in <higher version> but only [<lower>] are listed" — a
+//     higher pre-release version is available. Add the new version to the map,
+//     or update the existing entry.
+//   - "serves <GV> but higher-priority <GV> exists; set Kinds..." — the entry
+//     has no Kinds field. Add the relevant kinds so the test can do precise
+//     per-resource checking instead of flagging at the group level.
+func TestDefaultGroupVersionsByFeatureGateNotStale(t *testing.T) {
+	kubeVersion, err := semver.Parse(componentbaseversion.DefaultKubeBinaryVersion + ".0")
+	if err != nil {
+		t.Fatalf("failed to parse DefaultKubeBinaryVersion %q: %v", componentbaseversion.DefaultKubeBinaryVersion, err)
+	}
+
+	for _, v := range findStaleGroupVersionEntries(defaultGroupVersionsByFeatureGate, clientgoscheme.Scheme, kubeVersion) {
+		t.Errorf("feature gate %q: %s", v.FeatureGate, v.Message)
 	}
 }

--- a/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
@@ -257,13 +257,18 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 // or a new pre-release version appears.
 //
 // If this test fails:
-//   - "kind X exists in stable v1" — the API has graduated to GA. Remove the
+//   - "API version ... is not registered" — the GV was removed from the scheme.
+//     Remove the entry from defaultGroupVersionsByFeatureGate.
+//   - "kind ... is not registered in ..." — the kind was removed or renamed.
+//     Update or remove the kind from the entry's Kinds list.
+//   - "kind ... exists in stable v1" — the API has graduated to GA. Remove the
 //     entry from defaultGroupVersionsByFeatureGate; v1 is served by default.
-//   - "kind X exists in <higher version> but only [<lower>] are listed" — a
-//     higher pre-release version is available. Add the new version to the map,
-//     or update the existing entry.
-//   - "serves <GV> but higher-priority <GV> exists; set Kinds..." — the entry
-//     has no Kinds field. Add the relevant kinds so the test can do precise
+//   - "kind ... highest pre-release version is ... but entry lists ..." — the
+//     entry's version is no longer the highest pre-release. Update the entry's
+//     GV or narrow its KubeVersionRange to exclude versions where a higher
+//     pre-release exists.
+//   - "serves ... but higher version ... exists; set Kinds..." — the entry has
+//     no Kinds field. Add the relevant kinds so the test can do precise
 //     per-resource checking instead of flagging at the group level.
 func TestDefaultGroupVersionsByFeatureGateNotStale(t *testing.T) {
 	kubeVersion, err := semver.Parse(componentbaseversion.DefaultKubeBinaryVersion + ".0")

--- a/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
+++ b/pkg/operator/configobservation/apienablement/observe_runtime_config_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	componentbaseversion "k8s.io/component-base/version"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func staticObserver(cfg map[string]interface{}, errs []error) configobserver.ObserveConfigFunc {
@@ -175,14 +179,14 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 	for _, tc := range []struct {
 		name                       string
 		kubeVersion                semver.Version
-		groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion
+		groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion
 		expectedGroupVersions      map[configv1.FeatureGateName][]schema.GroupVersion
 		expectErrors               bool
 	}{
 		{
 			name:        "partial from/to",
 			kubeVersion: semver.MustParse("1.30.0"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"ValidatingAdmissionPolicy": {{GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}}},
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
@@ -197,7 +201,7 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "resolves newer API",
 			kubeVersion: semver.MustParse("1.31.0"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.0"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
@@ -210,7 +214,7 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "resolves minor versions API",
 			kubeVersion: semver.MustParse("1.31.15"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.15"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.15"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
@@ -223,13 +227,32 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 		{
 			name:        "no intersection resolves to empty",
 			kubeVersion: semver.MustParse("1.31.15"),
-			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionByOpenshiftVersion{
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"DynamicResourceAllocation": {
 					{KubeVersionRange: semver.MustParseRange("< 1.31.14"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha2"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.31.16"), GroupVersion: schema.GroupVersion{Group: "resource.k8s.io", Version: "v1alpha3"}},
 				},
 			},
 			expectedGroupVersions: map[configv1.FeatureGateName][]schema.GroupVersion{},
+		},
+		{
+			// Both versions are served simultaneously when their ranges overlap, as was the case for
+			// MutatingAdmissionPolicy (v1alpha1 >=1.33 <1.37, v1beta1 >=1.34 <1.37) where e2e tests
+			// exercised both APIs before the feature graduated to GA.
+			name:        "overlapping ranges resolve to both versions simultaneously",
+			kubeVersion: semver.MustParse("1.35.0"),
+			groupVersionsByFeatureGate: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"MutatingAdmissionPolicy": {
+					{KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}},
+					{KubeVersionRange: semver.MustParseRange(">=1.34.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}},
+				},
+			},
+			expectedGroupVersions: map[configv1.FeatureGateName][]schema.GroupVersion{
+				"MutatingAdmissionPolicy": {
+					{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+					{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
+				},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -244,5 +267,35 @@ func TestGroupVersionsByFeatureGate(t *testing.T) {
 				t.Errorf("unexpecteded errors: %v", err)
 			}
 		})
+	}
+}
+
+// TestDefaultGroupVersionsByFeatureGateNotStale verifies that the API versions
+// listed in defaultGroupVersionsByFeatureGate are still current for the vendored
+// Kubernetes version. This test fails after a kube rebase when an API graduates
+// or a new pre-release version appears.
+//
+// If this test fails:
+//   - "API version ... is not registered" — the GV was removed from the scheme.
+//     Remove the entry from defaultGroupVersionsByFeatureGate.
+//   - "kind ... is not registered in ..." — the kind was removed or renamed.
+//     Update or remove the kind from the entry's Kinds list.
+//   - "kind ... exists in stable v1" — the API has graduated to GA. Remove the
+//     entry from defaultGroupVersionsByFeatureGate; v1 is served by default.
+//   - "kind ... highest pre-release version is ... but entry lists ..." — the
+//     entry's version is no longer the highest pre-release. Update the entry's
+//     GV or narrow its KubeVersionRange to exclude versions where a higher
+//     pre-release exists.
+//   - "serves ... but higher version ... exists; set Kinds..." — the entry has
+//     no Kinds field. Add the relevant kinds so the test can do precise
+//     per-resource checking instead of flagging at the group level.
+func TestDefaultGroupVersionsByFeatureGateNotStale(t *testing.T) {
+	kubeVersion, err := semver.Parse(componentbaseversion.DefaultKubeBinaryVersion + ".0")
+	if err != nil {
+		t.Fatalf("failed to parse DefaultKubeBinaryVersion %q: %v", componentbaseversion.DefaultKubeBinaryVersion, err)
+	}
+
+	for _, v := range findStaleGroupVersionEntries(defaultGroupVersionsByFeatureGate, clientgoscheme.Scheme, kubeVersion) {
+		t.Errorf("feature gate %q: %s", v.FeatureGate, v.Message)
 	}
 }

--- a/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
+++ b/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
@@ -1,0 +1,393 @@
+package apienablement
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type violation struct {
+	FeatureGate configv1.FeatureGateName
+	Kind        string
+	Message     string
+}
+
+// findStaleGroupVersionEntries checks whether the API versions listed in the map
+// are stale relative to what the scheme actually has registered. It supports two
+// modes depending on whether Kinds is set on each entry.
+func findStaleGroupVersionEntries(
+	groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion,
+	scheme *runtime.Scheme,
+	kubeVersion semver.Version,
+) []violation {
+	var violations []violation
+
+	for featureGate, entries := range groupVersionsByFeatureGate {
+		// Filter to entries whose KubeVersionRange matches the current kube version.
+		var resolved []groupVersionKindsByOpenshiftVersion
+		for _, entry := range entries {
+			if entry.KubeVersionRange == nil || entry.KubeVersionRange(kubeVersion) {
+				resolved = append(resolved, entry)
+			}
+		}
+
+		for _, entry := range resolved {
+			// Check that the GV itself is registered in the scheme.
+			if !scheme.IsVersionRegistered(entry.GroupVersion) {
+				violations = append(violations, violation{
+					FeatureGate: featureGate,
+					Message: fmt.Sprintf(
+						"API version %s is not registered in the scheme (kube %s) — "+
+							"the version may have been removed",
+						entry.GroupVersion, kubeVersion,
+					),
+				})
+				continue
+			}
+
+			if len(entry.Kinds) == 0 {
+				// Kinds not specified — fall back to a simple version priority check.
+				// Flag if any higher-priority version is registered for the same group.
+				// This is imprecise (the higher version may be for unrelated resources)
+				// but safe — it nudges maintainers to specify Kinds for precise checking.
+				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
+					if gv == entry.GroupVersion {
+						break
+					}
+					violations = append(violations, violation{
+						FeatureGate: featureGate,
+						Message: fmt.Sprintf(
+							"serves %s but higher-priority %s exists (kube %s); "+
+								"set Kinds on the entry for precise checking, or update the version",
+							entry.GroupVersion, gv, kubeVersion,
+						),
+					})
+					break
+				}
+				continue
+			}
+
+			// Kinds specified — run precise per-kind checks.
+			entryTypes := scheme.KnownTypes(entry.GroupVersion)
+			for _, kind := range entry.Kinds {
+				// Check that the kind actually exists in the listed GV.
+				if _, exists := entryTypes[kind]; !exists {
+					violations = append(violations, violation{
+						FeatureGate: featureGate,
+						Kind:        kind,
+						Message: fmt.Sprintf(
+							"kind %q is not registered in %s (kube %s) — "+
+								"the kind may have been removed or renamed",
+							kind, entry.GroupVersion, kubeVersion,
+						),
+					})
+					continue
+				}
+
+				// Check 1: GA graduation. If the kind exists in v1, the API has
+				// graduated and is served by default — the pre-release runtime-config
+				// entry is stale and should be removed.
+				gaGV := schema.GroupVersion{Group: entry.Group, Version: "v1"}
+				if knownTypes := scheme.KnownTypes(gaGV); knownTypes != nil {
+					if _, exists := knownTypes[kind]; exists {
+						violations = append(violations, violation{
+							FeatureGate: featureGate,
+							Kind:        kind,
+							Message: fmt.Sprintf(
+								"kind %q exists in stable %s (kube %s) — "+
+									"remove pre-release entries",
+								kind, gaGV, kubeVersion,
+							),
+						})
+						continue
+					}
+				}
+
+				// Check 2: highest pre-release version is listed. Collect all versions
+				// listed for this kind across resolved entries, then verify that the
+				// highest-priority pre-release version containing this kind is among them.
+				listedVersions := sets.New[string]()
+				for _, other := range resolved {
+					if other.Group != entry.Group {
+						continue
+					}
+					for _, k := range other.Kinds {
+						if k == kind {
+							listedVersions.Insert(other.Version)
+						}
+					}
+				}
+
+				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
+					// Skip v1 — already handled by check 1 above.
+					if gv.Version == "v1" {
+						continue
+					}
+					if knownTypes := scheme.KnownTypes(gv); knownTypes != nil {
+						if _, exists := knownTypes[kind]; exists {
+							if !listedVersions.Has(gv.Version) {
+								violations = append(violations, violation{
+									FeatureGate: featureGate,
+									Kind:        kind,
+									Message: fmt.Sprintf(
+										"kind %q exists in %s but only %v are listed (kube %s) — "+
+											"update entries",
+										kind, gv, sets.List(listedVersions), kubeVersion,
+									),
+								})
+							}
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return violations
+}
+
+func TestFindStaleGroupVersionEntries(t *testing.T) {
+	scheme := newTestScheme()
+	kubeVersion := semver.MustParse("1.35.0")
+
+	for _, tc := range []struct {
+		name           string
+		entries        map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion
+		wantViolations []violation
+	}{
+		// Kinds unset — simple mode
+		{
+			name: "no kinds, no higher version — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}}},
+			},
+		},
+		{
+			name: "no kinds, higher version exists — violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Message:     "serves testgroup/v1alpha1 but higher-priority testgroup/v1 exists (kube 1.35.0); set Kinds on the entry for precise checking, or update the version",
+			}},
+		},
+		{
+			name: "no kinds, entry is highest version — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1"}}},
+			},
+		},
+
+		// Kinds set — GA graduation (check 1)
+		{
+			name: "kind exists in v1 — violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindA",
+				Message:     `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`,
+			}},
+		},
+		{
+			name: "kind does not exist in v1 — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta2"}, Kinds: []string{"KindC"}}},
+			},
+		},
+		{
+			name: "multiple kinds all in v1 — violations for all",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindA", "KindB"}}},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+				{FeatureGate: "TestGate", Kind: "KindB", Message: `kind "KindB" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+			},
+		},
+		{
+			name: "multiple kinds, only some in v1 — violation only for graduated",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindA", "KindD"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindA",
+				Message:     `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`,
+			}},
+		},
+		{
+			name: "v1 does not exist for group — no GA violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}, Kinds: []string{"KindX"}}},
+			},
+		},
+
+		// Kinds set — highest pre-release version (check 2)
+		{
+			name: "highest pre-release is listed — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}}},
+			},
+		},
+		{
+			name: "highest pre-release not listed — violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" exists in testgroup/v1beta1 but only [v1alpha1] are listed (kube 1.35.0) — update entries`,
+			}},
+		},
+		{
+			name: "each kind flags its own highest version independently",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindC", "KindD"}}},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindC", Message: `kind "KindC" exists in testgroup/v1beta2 but only [v1alpha1] are listed (kube 1.35.0) — update entries`},
+				{FeatureGate: "TestGate", Kind: "KindD", Message: `kind "KindD" exists in testgroup/v1beta1 but only [v1alpha1] are listed (kube 1.35.0) — update entries`},
+			},
+		},
+		{
+			name: "multiple entries cover highest for kind — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+		},
+
+		// Kube version range filtering
+		{
+			name: "entry filtered by kube version range — skipped",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{
+					KubeVersionRange: semver.MustParseRange("< 1.30.0"),
+					GroupVersion:     schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"},
+					Kinds:            []string{"KindD"},
+				}},
+			},
+		},
+		{
+			name: "all entries filtered out — no violations",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{KubeVersionRange: semver.MustParseRange("< 1.30.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{KubeVersionRange: semver.MustParseRange(">= 1.40.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+		},
+		{
+			name: "overlapping ranges both resolve, highest listed — no violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{KubeVersionRange: semver.MustParseRange(">= 1.33.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{KubeVersionRange: semver.MustParseRange(">= 1.34.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+		},
+
+		// Unregistered GV or kind
+		{
+			name: "GV not registered in scheme — violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "nonexistent", Version: "v1alpha1"}, Kinds: []string{"Foo"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Message:     "API version nonexistent/v1alpha1 is not registered in the scheme (kube 1.35.0) — the version may have been removed",
+			}},
+		},
+		{
+			name: "kind not in listed GV — violation",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"NoSuchKind"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "NoSuchKind",
+				Message:     `kind "NoSuchKind" is not registered in testgroup/v1beta1 (kube 1.35.0) — the kind may have been removed or renamed`,
+			}},
+		},
+		{
+			name: "same kind in different groups — checked independently",
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}},
+					{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}},
+				},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" is not registered in othergroup/v1alpha1 (kube 1.35.0) — the kind may have been removed or renamed`},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			violations := findStaleGroupVersionEntries(tc.entries, scheme, kubeVersion)
+			if diff := cmp.Diff(tc.wantViolations, violations); diff != "" {
+				t.Errorf("unexpected violations (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Test types for synthetic scheme.
+
+type KindA struct{ metav1.TypeMeta }
+type KindB struct{ metav1.TypeMeta }
+type KindC struct{ metav1.TypeMeta }
+type KindD struct{ metav1.TypeMeta }
+type KindX struct{ metav1.TypeMeta }
+
+func (o *KindA) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindB) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindC) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindD) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindX) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	testGroup := "testgroup"
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1"}, &KindA{}, &KindB{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1beta2"}, &KindA{}, &KindB{}, &KindC{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1beta1"}, &KindA{}, &KindB{}, &KindC{}, &KindD{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1alpha1"}, &KindA{}, &KindB{}, &KindC{}, &KindD{})
+
+	if err := scheme.SetVersionPriority(
+		schema.GroupVersion{Group: testGroup, Version: "v1"},
+		schema.GroupVersion{Group: testGroup, Version: "v1beta2"},
+		schema.GroupVersion{Group: testGroup, Version: "v1beta1"},
+		schema.GroupVersion{Group: testGroup, Version: "v1alpha1"},
+	); err != nil {
+		panic(err)
+	}
+
+	otherGroup := "othergroup"
+	scheme.AddKnownTypes(schema.GroupVersion{Group: otherGroup, Version: "v1alpha1"}, &KindX{})
+
+	if err := scheme.SetVersionPriority(
+		schema.GroupVersion{Group: otherGroup, Version: "v1alpha1"},
+	); err != nil {
+		panic(err)
+	}
+
+	return scheme
+}

--- a/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
+++ b/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
+	versionutil "k8s.io/apimachinery/pkg/version"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -55,23 +55,23 @@ func findStaleGroupVersionEntries(
 			}
 
 			if len(entry.Kinds) == 0 {
-				// Kinds not specified — fall back to a simple version priority check.
-				// Flag if any higher-priority version is registered for the same group.
-				// This is imprecise (the higher version may be for unrelated resources)
-				// but safe — it nudges maintainers to specify Kinds for precise checking.
+				// Kinds not specified — fall back to a simple version check.
+				// Flag if any semantically higher version is registered for the
+				// same group. This is imprecise (the higher version may be for
+				// unrelated resources) but safe — it nudges maintainers to specify
+				// Kinds for precise checking.
 				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
-					if gv == entry.GroupVersion {
+					if versionutil.CompareKubeAwareVersionStrings(gv.Version, entry.Version) > 0 {
+						violations = append(violations, violation{
+							FeatureGate: featureGate,
+							Message: fmt.Sprintf(
+								"serves %s but higher version %s exists (kube %s); "+
+									"set Kinds on the entry for precise checking, or update the version",
+								entry.GroupVersion, gv, kubeVersion,
+							),
+						})
 						break
 					}
-					violations = append(violations, violation{
-						FeatureGate: featureGate,
-						Message: fmt.Sprintf(
-							"serves %s but higher-priority %s exists (kube %s); "+
-								"set Kinds on the entry for precise checking, or update the version",
-							entry.GroupVersion, gv, kubeVersion,
-						),
-					})
-					break
 				}
 				continue
 			}
@@ -112,42 +112,34 @@ func findStaleGroupVersionEntries(
 					}
 				}
 
-				// Check 2: highest pre-release version is listed. Collect all versions
-				// listed for this kind across resolved entries, then verify that the
-				// highest-priority pre-release version containing this kind is among them.
-				listedVersions := sets.New[string]()
-				for _, other := range resolved {
-					if other.Group != entry.Group {
-						continue
-					}
-					for _, k := range other.Kinds {
-						if k == kind {
-							listedVersions.Insert(other.Version)
-						}
-					}
-				}
-
+				// Check 2: this entry's version must be the highest pre-release
+				// version for the kind. If a higher pre-release version exists,
+				// this entry is stale for this kind. We compare version strings
+				// semantically rather than relying on scheme priority order,
+				// which may not reflect the correct version hierarchy.
+				var highestPreRelease schema.GroupVersion
 				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
-					// Skip v1 — already handled by check 1 above.
 					if gv.Version == "v1" {
 						continue
 					}
 					if knownTypes := scheme.KnownTypes(gv); knownTypes != nil {
 						if _, exists := knownTypes[kind]; exists {
-							if !listedVersions.Has(gv.Version) {
-								violations = append(violations, violation{
-									FeatureGate: featureGate,
-									Kind:        kind,
-									Message: fmt.Sprintf(
-										"kind %q exists in %s but only %v are listed (kube %s) — "+
-											"update entries",
-										kind, gv, sets.List(listedVersions), kubeVersion,
-									),
-								})
+							if highestPreRelease.Version == "" || versionutil.CompareKubeAwareVersionStrings(gv.Version, highestPreRelease.Version) > 0 {
+								highestPreRelease = gv
 							}
-							break
 						}
 					}
+				}
+				if highestPreRelease.Version != "" && entry.Version != highestPreRelease.Version {
+					violations = append(violations, violation{
+						FeatureGate: featureGate,
+						Kind:        kind,
+						Message: fmt.Sprintf(
+							"kind %q highest pre-release version is %s but entry lists %s (kube %s) — "+
+								"update or remove the entry",
+							kind, highestPreRelease, entry.GroupVersion, kubeVersion,
+						),
+					})
 				}
 			}
 		}
@@ -179,7 +171,7 @@ func TestFindStaleGroupVersionEntries(t *testing.T) {
 			},
 			wantViolations: []violation{{
 				FeatureGate: "TestGate",
-				Message:     "serves testgroup/v1alpha1 but higher-priority testgroup/v1 exists (kube 1.35.0); set Kinds on the entry for precise checking, or update the version",
+				Message:     "serves testgroup/v1alpha1 but higher version testgroup/v1 exists (kube 1.35.0); set Kinds on the entry for precise checking, or update the version",
 			}},
 		},
 		{
@@ -243,14 +235,14 @@ func TestFindStaleGroupVersionEntries(t *testing.T) {
 			},
 		},
 		{
-			name: "highest pre-release not listed — violation",
+			name: "entry version is not the highest pre-release — violation",
 			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}}},
 			},
 			wantViolations: []violation{{
 				FeatureGate: "TestGate",
 				Kind:        "KindD",
-				Message:     `kind "KindD" exists in testgroup/v1beta1 but only [v1alpha1] are listed (kube 1.35.0) — update entries`,
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
 			}},
 		},
 		{
@@ -259,18 +251,23 @@ func TestFindStaleGroupVersionEntries(t *testing.T) {
 				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindC", "KindD"}}},
 			},
 			wantViolations: []violation{
-				{FeatureGate: "TestGate", Kind: "KindC", Message: `kind "KindC" exists in testgroup/v1beta2 but only [v1alpha1] are listed (kube 1.35.0) — update entries`},
-				{FeatureGate: "TestGate", Kind: "KindD", Message: `kind "KindD" exists in testgroup/v1beta1 but only [v1alpha1] are listed (kube 1.35.0) — update entries`},
+				{FeatureGate: "TestGate", Kind: "KindC", Message: `kind "KindC" highest pre-release version is testgroup/v1beta2 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`},
+				{FeatureGate: "TestGate", Kind: "KindD", Message: `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`},
 			},
 		},
 		{
-			name: "multiple entries cover highest for kind — no violation",
+			name: "lower version entry is stale even if highest is also listed",
 			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"TestGate": {
 					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
 					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
 				},
 			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
+			}},
 		},
 
 		// Kube version range filtering
@@ -294,13 +291,18 @@ func TestFindStaleGroupVersionEntries(t *testing.T) {
 			},
 		},
 		{
-			name: "overlapping ranges both resolve, highest listed — no violation",
+			name: "overlapping ranges, lower version entry is stale",
 			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
 				"TestGate": {
 					{KubeVersionRange: semver.MustParseRange(">= 1.33.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
 					{KubeVersionRange: semver.MustParseRange(">= 1.34.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
 				},
 			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
+			}},
 		},
 
 		// Unregistered GV or kind

--- a/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
+++ b/pkg/operator/configobservation/apienablement/stale_gv_helpers_test.go
@@ -1,0 +1,457 @@
+package apienablement
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	versionutil "k8s.io/apimachinery/pkg/version"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type violation struct {
+	FeatureGate configv1.FeatureGateName
+	Kind        string
+	Message     string
+}
+
+// findStaleGroupVersionEntries checks whether the API versions listed in the map
+// are stale relative to what the scheme actually has registered. It supports two
+// modes depending on whether Kinds is set on each entry.
+func findStaleGroupVersionEntries(
+	groupVersionsByFeatureGate map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion,
+	scheme *runtime.Scheme,
+	kubeVersion semver.Version,
+) []violation {
+	var violations []violation
+
+	for featureGate, entries := range groupVersionsByFeatureGate {
+		// Filter to entries whose KubeVersionRange matches the current kube version.
+		var resolved []groupVersionKindsByOpenshiftVersion
+		for _, entry := range entries {
+			if entry.KubeVersionRange == nil || entry.KubeVersionRange(kubeVersion) {
+				resolved = append(resolved, entry)
+			}
+		}
+
+		for _, entry := range resolved {
+			// Check that the GV itself is registered in the scheme.
+			if !scheme.IsVersionRegistered(entry.GroupVersion) {
+				violations = append(violations, violation{
+					FeatureGate: featureGate,
+					Message: fmt.Sprintf(
+						"API version %s is not registered in the scheme (kube %s) — "+
+							"the version may have been removed",
+						entry.GroupVersion, kubeVersion,
+					),
+				})
+				continue
+			}
+
+			if len(entry.Kinds) == 0 {
+				// Kinds not specified — fall back to a simple version check.
+				// Flag if any semantically higher version is registered for the
+				// same group. This is imprecise (the higher version may be for
+				// unrelated resources) but safe — it nudges maintainers to specify
+				// Kinds for precise checking.
+				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
+					if versionutil.CompareKubeAwareVersionStrings(gv.Version, entry.Version) > 0 {
+						violations = append(violations, violation{
+							FeatureGate: featureGate,
+							Message: fmt.Sprintf(
+								"serves %s but higher version %s exists (kube %s); "+
+									"set Kinds on the entry for precise checking, or update the version",
+								entry.GroupVersion, gv, kubeVersion,
+							),
+						})
+						break
+					}
+				}
+				continue
+			}
+
+			// Kinds specified — run precise per-kind checks.
+			entryTypes := scheme.KnownTypes(entry.GroupVersion)
+			for _, kind := range entry.Kinds {
+				// Check that the kind actually exists in the listed GV.
+				if _, exists := entryTypes[kind]; !exists {
+					violations = append(violations, violation{
+						FeatureGate: featureGate,
+						Kind:        kind,
+						Message: fmt.Sprintf(
+							"kind %q is not registered in %s (kube %s) — "+
+								"the kind may have been removed or renamed",
+							kind, entry.GroupVersion, kubeVersion,
+						),
+					})
+					continue
+				}
+
+				// Check 1: GA graduation. If the kind exists in v1, the API has
+				// graduated and is served by default — the pre-release runtime-config
+				// entry is stale and should be removed.
+				gaGV := schema.GroupVersion{Group: entry.Group, Version: "v1"}
+				if knownTypes := scheme.KnownTypes(gaGV); knownTypes != nil {
+					if _, exists := knownTypes[kind]; exists {
+						violations = append(violations, violation{
+							FeatureGate: featureGate,
+							Kind:        kind,
+							Message: fmt.Sprintf(
+								"kind %q exists in stable %s (kube %s) — "+
+									"remove pre-release entries",
+								kind, gaGV, kubeVersion,
+							),
+						})
+						continue
+					}
+				}
+
+				// Check 2: this entry's version must be the highest pre-release
+				// version for the kind. If a higher pre-release version exists,
+				// this entry is stale for this kind. We compare version strings
+				// semantically rather than relying on scheme priority order,
+				// which may not reflect the correct version hierarchy.
+				var highestPreRelease schema.GroupVersion
+				for _, gv := range scheme.PrioritizedVersionsForGroup(entry.Group) {
+					if gv.Version == "v1" {
+						continue
+					}
+					if knownTypes := scheme.KnownTypes(gv); knownTypes != nil {
+						if _, exists := knownTypes[kind]; exists {
+							if highestPreRelease.Version == "" || versionutil.CompareKubeAwareVersionStrings(gv.Version, highestPreRelease.Version) > 0 {
+								highestPreRelease = gv
+							}
+						}
+					}
+				}
+				if highestPreRelease.Version != "" && entry.Version != highestPreRelease.Version {
+					violations = append(violations, violation{
+						FeatureGate: featureGate,
+						Kind:        kind,
+						Message: fmt.Sprintf(
+							"kind %q highest pre-release version is %s but entry lists %s (kube %s) — "+
+								"update or remove the entry",
+							kind, highestPreRelease, entry.GroupVersion, kubeVersion,
+						),
+					})
+				}
+			}
+		}
+	}
+
+	return violations
+}
+
+func TestFindStaleGroupVersionEntries(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		scheme         *runtime.Scheme
+		kubeVersion    semver.Version
+		entries        map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion
+		wantViolations []violation
+	}{
+		// Kinds unset — simple mode
+		{
+			name:        "no kinds, no higher version — no violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}}},
+			},
+		},
+		{
+			name:        "no kinds, higher version exists — violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Message:     "serves testgroup/v1alpha1 but higher version testgroup/v1 exists (kube 1.35.0); set Kinds on the entry for precise checking, or update the version",
+			}},
+		},
+		{
+			name:        "no kinds, entry is highest version — no violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1"}}},
+			},
+		},
+
+		// Kinds set — GA graduation (check 1)
+		{
+			name:        "kind exists in v1 — violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindA",
+				Message:     `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`,
+			}},
+		},
+		{
+			name:        "kind does not exist in v1 — no violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta2"}, Kinds: []string{"KindC"}}},
+			},
+		},
+		{
+			name:        "multiple kinds all in v1 — violations for all",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindA", "KindB"}}},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+				{FeatureGate: "TestGate", Kind: "KindB", Message: `kind "KindB" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+			},
+		},
+		{
+			name:        "multiple kinds, only some in v1 — violation only for graduated",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindA", "KindD"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindA",
+				Message:     `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`,
+			}},
+		},
+		{
+			name:        "v1 does not exist for group — no GA violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}, Kinds: []string{"KindX"}}},
+			},
+		},
+
+		// Kinds set — highest pre-release version (check 2)
+		{
+			name:        "highest pre-release is listed — no violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}}},
+			},
+		},
+		{
+			name:        "entry version is not the highest pre-release — violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
+			}},
+		},
+		{
+			name:        "each kind flags its own highest version independently",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindC", "KindD"}}},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindC", Message: `kind "KindC" highest pre-release version is testgroup/v1beta2 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`},
+				{FeatureGate: "TestGate", Kind: "KindD", Message: `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`},
+			},
+		},
+		{
+			name:        "lower version entry is stale even if highest is also listed",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
+			}},
+		},
+
+		// Kube version range filtering
+		{
+			name:        "entry filtered by kube version range — skipped",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{
+					KubeVersionRange: semver.MustParseRange("< 1.30.0"),
+					GroupVersion:     schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"},
+					Kinds:            []string{"KindD"},
+				}},
+			},
+		},
+		{
+			name:        "all entries filtered out — no violations",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{KubeVersionRange: semver.MustParseRange("< 1.30.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{KubeVersionRange: semver.MustParseRange(">= 1.40.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+		},
+		{
+			name:        "overlapping ranges, lower version entry is stale",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{KubeVersionRange: semver.MustParseRange(">= 1.33.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindD"}},
+					{KubeVersionRange: semver.MustParseRange(">= 1.34.0"), GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"KindD"}},
+				},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "KindD",
+				Message:     `kind "KindD" highest pre-release version is testgroup/v1beta1 but entry lists testgroup/v1alpha1 (kube 1.35.0) — update or remove the entry`,
+			}},
+		},
+
+		// Unregistered GV or kind
+		{
+			name:        "GV not registered in scheme — violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "nonexistent", Version: "v1alpha1"}, Kinds: []string{"Foo"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Message:     "API version nonexistent/v1alpha1 is not registered in the scheme (kube 1.35.0) — the version may have been removed",
+			}},
+		},
+		{
+			name:        "kind not in listed GV — violation",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1beta1"}, Kinds: []string{"NoSuchKind"}}},
+			},
+			wantViolations: []violation{{
+				FeatureGate: "TestGate",
+				Kind:        "NoSuchKind",
+				Message:     `kind "NoSuchKind" is not registered in testgroup/v1beta1 (kube 1.35.0) — the kind may have been removed or renamed`,
+			}},
+		},
+		{
+			name:        "same kind in different groups — checked independently",
+			scheme:      newTestScheme(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"TestGate": {
+					{GroupVersion: schema.GroupVersion{Group: "testgroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}},
+					{GroupVersion: schema.GroupVersion{Group: "othergroup", Version: "v1alpha1"}, Kinds: []string{"KindA"}},
+				},
+			},
+			wantViolations: []violation{
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" exists in stable testgroup/v1 (kube 1.35.0) — remove pre-release entries`},
+				{FeatureGate: "TestGate", Kind: "KindA", Message: `kind "KindA" is not registered in othergroup/v1alpha1 (kube 1.35.0) — the kind may have been removed or renamed`},
+			},
+		},
+		{
+			// Two pre-release versions of the same group can be served simultaneously via overlapping
+			// kube version ranges as long as their kind sets are disjoint — each version is then the
+			// highest pre-release for its own kinds and neither entry is stale. This mirrors the
+			// MutatingAdmissionPolicy pattern that existed before the feature graduated to GA
+			// (v1alpha1 >=1.33 <1.37, v1beta1 >=1.34 <1.37).
+			name: "overlapping ranges with disjoint kinds — both versions active, no violation",
+			scheme: func() *runtime.Scheme {
+				s := runtime.NewScheme()
+				s.AddKnownTypeWithName(schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Kind: "MutatingAdmissionPolicy"}, &runtime.Unknown{})
+				s.AddKnownTypeWithName(schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingAdmissionPolicyBinding"}, &runtime.Unknown{})
+				if err := s.SetVersionPriority(
+					schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
+					schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+				); err != nil {
+					panic(err)
+				}
+				return s
+			}(),
+			kubeVersion: semver.MustParse("1.35.0"),
+			entries: map[configv1.FeatureGateName][]groupVersionKindsByOpenshiftVersion{
+				"MutatingAdmissionPolicy": {
+					{KubeVersionRange: semver.MustParseRange(">=1.33.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1alpha1"}, Kinds: []string{"MutatingAdmissionPolicy"}},
+					{KubeVersionRange: semver.MustParseRange(">=1.34.0 <1.37.0"), GroupVersion: schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1beta1"}, Kinds: []string{"MutatingAdmissionPolicyBinding"}},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			violations := findStaleGroupVersionEntries(tc.entries, tc.scheme, tc.kubeVersion)
+			if diff := cmp.Diff(tc.wantViolations, violations); diff != "" {
+				t.Errorf("unexpected violations (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Test types for synthetic scheme.
+
+type KindA struct{ metav1.TypeMeta }
+type KindB struct{ metav1.TypeMeta }
+type KindC struct{ metav1.TypeMeta }
+type KindD struct{ metav1.TypeMeta }
+type KindX struct{ metav1.TypeMeta }
+
+func (o *KindA) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindB) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindC) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindD) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+func (o *KindX) DeepCopyObject() runtime.Object { cp := *o; return &cp }
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	testGroup := "testgroup"
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1"}, &KindA{}, &KindB{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1beta2"}, &KindA{}, &KindB{}, &KindC{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1beta1"}, &KindA{}, &KindB{}, &KindC{}, &KindD{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: testGroup, Version: "v1alpha1"}, &KindA{}, &KindB{}, &KindC{}, &KindD{})
+
+	if err := scheme.SetVersionPriority(
+		schema.GroupVersion{Group: testGroup, Version: "v1"},
+		schema.GroupVersion{Group: testGroup, Version: "v1beta2"},
+		schema.GroupVersion{Group: testGroup, Version: "v1beta1"},
+		schema.GroupVersion{Group: testGroup, Version: "v1alpha1"},
+	); err != nil {
+		panic(err)
+	}
+
+	otherGroup := "othergroup"
+	scheme.AddKnownTypes(schema.GroupVersion{Group: otherGroup, Version: "v1alpha1"}, &KindX{})
+
+	if err := scheme.SetVersionPriority(
+		schema.GroupVersion{Group: otherGroup, Version: "v1alpha1"},
+	); err != nil {
+		panic(err)
+	}
+
+	return scheme
+}


### PR DESCRIPTION
Add a Kinds field to groupVersionKindsByOpenshiftVersion and a
findStaleGroupVersionEntries helper that checks whether listed
API versions are stale. It detects:
- unregistered GV or kind (removed during a rebase)
- kind graduated to v1 (served by default, override is stale)
- highest pre-release version not listed (version bump missed)

When Kinds is unset, a simpler check flags any entry whose group
has a higher-priority version registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to detect stale feature-gated API entries, including missing registrations, API graduation, and version-selection behavior.
  * Added validation to ensure default API mappings remain compatible with the Kubernetes version and registered resource types.
* **Refactor**
  * Improved API mapping support to account for resource kinds alongside group/version and version-range information.
  * Preserved existing group/version selection behavior while strengthening compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->