### PR TITLE
CNTRLPLANE-3226: switch to real Vault KMS plugin in CI

### DIFF
--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 
 // testKMSEncryptionOnOff tests KMS encryption on/off cycle.
 // This test:
-// 1. Deploys the mock KMS plugin
+// 1. Deploys the real Vault KMS plugin
 // 2. Creates a test secret (SecretOfLife)
 // 3. Enables KMS encryption
 // 4. Verifies secret is encrypted
@@ -52,13 +52,13 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
-		EncryptionProvider:             librarykms.DefaultFakeVaultEncryptionProvider,
+		EncryptionProvider:             librarykms.DefaultVaultEncryptionProvider(ctx, t),
 	})
 }
 
 // testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
 // This test:
-// 1. Deploys the mock KMS plugin
+// 1. Deploys the real Vault KMS plugin
 // 2. Creates a test secret (SecretOfLife)
 // 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
 // 4. Shuffles the selected AES provider with KMS to create a randomized migration order
@@ -81,7 +81,7 @@ func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
 		ResourceFunc:                   operatorencryption.SecretOfLife,
 		ResourceName:                   "SecretOfLife",
 		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
-			librarykms.DefaultFakeVaultEncryptionProvider,
+			librarykms.DefaultVaultEncryptionProvider(ctx, t),
 			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
 		}),
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated KMS e2e encryption tests to use the real Vault KMS plugin provider instead of a mock provider, improving test reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->