### PR TITLE
NO-JIRA: Automatic agentic rebase: Update library-go to 0469313

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499
+	github.com/openshift/library-go v0.0.0-20260608110537-04693132679d
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499 h1:Ff5OLOVD1Kj5RYEUHaBCOWGzqdEjygIGvReaj7uIxpc=
-github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260608110537-04693132679d h1:+n/LOE9kXr8TDLV5ynhx4j3ZuOjeqMc2rKwDKB74W3g=
+github.com/openshift/library-go v0.0.0-20260608110537-04693132679d/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -416,6 +416,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		configInformers.Config().V1().APIServers(),
 		kubeInformersForNamespaces,
 		kubeClient.CoreV1(),
+		kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
 		resourceSyncController,
 	)

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
@@ -34,6 +34,7 @@ func NewControllers(
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretsClient corev1.SecretsGetter,
+	configMapClient corev1.ConfigMapsGetter,
 	eventRecorder events.Recorder,
 	resourceSyncer *resourcesynccontroller.ResourceSyncController,
 ) (Controllers, error) {
@@ -71,6 +72,7 @@ func NewControllers(
 			apiServerInformer,
 			kubeInformersForNamespaces,
 			secretsClient,
+			configMapClient,
 			encryptionSecretSelector,
 			eventRecorder,
 		),

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -75,6 +75,7 @@ type keyController struct {
 
 	deployer                 statemachine.Deployer
 	secretClient             corev1client.SecretsGetter
+	configMapClient          corev1client.ConfigMapsGetter
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
 
@@ -92,6 +93,7 @@ func NewKeyController(
 	apiServerInformer configv1informers.APIServerInformer,
 	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces,
 	secretClient corev1client.SecretsGetter,
+	configMapClient corev1client.ConfigMapsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
 ) factory.Controller {
@@ -108,6 +110,7 @@ func NewKeyController(
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
 		secretClient:             secretClient,
+		configMapClient:          configMapClient,
 	}
 
 	return factory.New().
@@ -118,7 +121,7 @@ func NewKeyController(
 			apiServerInformer.Informer(),
 			operatorClient.Informer(),
 			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
-			// TODO: add informer for openshift-config namespace to watch referenced Secrets for KMS plugin secret data changes
+			// TODO: add informers for openshift-config namespace to watch referenced Secrets and ConfigMaps for KMS plugin data changes
 			deployer,
 		).ToController(
 		c.controllerInstanceName,
@@ -301,6 +304,24 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 				}
 			}
 		}
+
+		if cmName, expectedKeys, err := referencedConfigMapName(apiServerEncryption.KMS); err != nil {
+			return nil, err
+		} else if len(cmName) > 0 {
+			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
+			}
+			for _, key := range expectedKeys {
+				v, ok := refCM.Data[key]
+				if !ok {
+					return nil, fmt.Errorf("configmap %s in %s is missing required key %q", cmName, openshiftConfigNS, key)
+				}
+				if err := ks.KMS.PluginConfigMapData.Set(cmName, key, []byte(v)); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 	return secrets.FromKeyState(c.instanceName, ks)
 }
@@ -417,6 +438,21 @@ func referencedSecretName(plugin configv1.KMSPluginConfig) (string, []string, er
 		default:
 			return "", nil, fmt.Errorf("unsupported Vault authentication type %q", plugin.Vault.Authentication.Type)
 		}
+	default:
+		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
+	}
+}
+
+// referencedConfigMapName returns the name of the configmap referenced by the KMS plugin
+// config and the specific data keys to carry from that configmap. Only the listed keys
+// are copied into the Key Secret; any other data in the referenced configmap is ignored.
+func referencedConfigMapName(plugin configv1.KMSPluginConfig) (string, []string, error) {
+	switch plugin.Type {
+	case configv1.VaultKMSProvider:
+		if plugin.Vault.TLS.CABundle.Name == "" {
+			return "", nil, nil
+		}
+		return plugin.Vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
 	default:
 		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	// Key Secrets into the encryption-config Secret.
 	// Structure: keyID → referenceName → dataKey → value.
 	KMSPluginsSecretData KMSPluginsReferenceData
+	// KMSPluginsConfigMapData maps keyID to configmap data carried from
+	// Key Secrets into the encryption-config Secret.
+	// Structure: keyID → referenceName → dataKey → value.
+	KMSPluginsConfigMapData KMSPluginsReferenceData
 }
 
 // KMSPluginsReferenceData maps keyID to reference data carried from Key Secrets into
@@ -93,6 +97,7 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 	resourceConfigs := make([]apiserverconfigv1.ResourceConfiguration, 0, len(encryptionState))
 	var kmsPlugins map[string]configv1.KMSPluginConfig
 	var kmsPluginsSecretData KMSPluginsReferenceData
+	var kmsPluginsConfigMapData KMSPluginsReferenceData
 
 	for gr, grKeys := range encryptionState {
 		resourceConfigs = append(resourceConfigs, apiserverconfigv1.ResourceConfiguration{
@@ -133,6 +138,19 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 					}
 				}
 			}
+			if key.HasKMSConfigMapData() {
+				if existing, exists := kmsPluginsConfigMapData.Get(key.Key.Name); exists {
+					if !equality.Semantic.DeepEqual(existing.FlatEntries(), key.KMS.PluginConfigMapData.FlatEntries()) {
+						return nil, fmt.Errorf("KMS configmap data mismatch for keyID %s: configmap data from different resources must be identical", key.Key.Name)
+					}
+				} else {
+					for rawKey, value := range key.KMS.PluginConfigMapData.FlatEntries() {
+						if err := kmsPluginsConfigMapData.SetFromRawKey(key.Key.Name, rawKey, value); err != nil {
+							return nil, fmt.Errorf("failed to copy configmap data for keyID %s: %w", key.Key.Name, err)
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -142,9 +160,10 @@ func FromEncryptionState(encryptionState map[schema.GroupResource]state.GroupRes
 	})
 
 	return &Config{
-		Encryption:           &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
-		KMSPlugins:           kmsPlugins,
-		KMSPluginsSecretData: kmsPluginsSecretData,
+		Encryption:              &apiserverconfigv1.EncryptionConfiguration{Resources: resourceConfigs},
+		KMSPlugins:              kmsPlugins,
+		KMSPluginsSecretData:    kmsPluginsSecretData,
+		KMSPluginsConfigMapData: kmsPluginsConfigMapData,
 	}, nil
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/encryptiondata/secret.go
@@ -49,6 +49,9 @@ const (
 	// encryptionConfigSecretDataPrefix is the data key prefix for KMS plugin secret
 	// data entries in the encryption-config Secret. Full key: "kms-plugin-secret-{secretName}_{dataKey}-{keyID}".
 	encryptionConfigSecretDataPrefix = "kms-plugin-secret-"
+	// encryptionConfigConfigMapDataPrefix is the data key prefix for KMS plugin configmap
+	// data entries in the encryption-config Secret. Full key: "kms-plugin-configmap-{cmName}_{dataKey}-{keyID}".
+	encryptionConfigConfigMapDataPrefix = "kms-plugin-configmap-"
 )
 
 func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
@@ -91,7 +94,7 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 	// which is then split on "_" to recover secretName and dataKey.
 	var kmsPluginsSecretData KMSPluginsReferenceData
 	for key, value := range encryptionConfigSecret.Data {
-		keyID, rawKey, found, err := parseKMSSecretDataKey(key)
+		keyID, rawKey, found, err := parseKMSReferenceDataKey(key, encryptionConfigSecretDataPrefix)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse secret data key %s: %w", key, err)
 		}
@@ -103,7 +106,23 @@ func FromSecret(encryptionConfigSecret *corev1.Secret) (*Config, error) {
 		}
 	}
 
-	return &Config{Encryption: encryptionConfig, KMSPlugins: kmsPlugins, KMSPluginsSecretData: kmsPluginsSecretData}, nil
+	// Extract configmap data entries from the encryption-config Secret.
+	// Data keys follow the format "kms-plugin-configmap-{cmName}_{dataKey}-{keyID}".
+	var kmsPluginsConfigMapData KMSPluginsReferenceData
+	for key, value := range encryptionConfigSecret.Data {
+		keyID, rawKey, found, err := parseKMSReferenceDataKey(key, encryptionConfigConfigMapDataPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse configmap data key %s: %w", key, err)
+		}
+		if !found {
+			continue
+		}
+		if err := kmsPluginsConfigMapData.SetFromRawKey(keyID, rawKey, value); err != nil {
+			return nil, fmt.Errorf("failed to set key %s: %w", key, err)
+		}
+	}
+
+	return &Config{Encryption: encryptionConfig, KMSPlugins: kmsPlugins, KMSPluginsSecretData: kmsPluginsSecretData, KMSPluginsConfigMapData: kmsPluginsConfigMapData}, nil
 }
 
 func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
@@ -153,6 +172,12 @@ func ToSecret(ns, name string, secretData *Config) (*corev1.Secret, error) {
 	for keyID, flatEntries := range secretData.KMSPluginsSecretData.FlatEntriesByKeyID() {
 		for rawKey, value := range flatEntries {
 			s.Data[FormatKMSSecretDataKey(rawKey, keyID)] = value
+		}
+	}
+
+	for keyID, flatEntries := range secretData.KMSPluginsConfigMapData.FlatEntriesByKeyID() {
+		for rawKey, value := range flatEntries {
+			s.Data[formatKMSConfigMapDataKey(rawKey, keyID)] = value
 		}
 	}
 
@@ -214,8 +239,20 @@ func FormatKMSSecretDataKey(rawKey, keyID string) string {
 	return fmt.Sprintf("%s%s-%s", encryptionConfigSecretDataPrefix, rawKey, keyID)
 }
 
-func parseKMSSecretDataKey(dataKey string) (keyID, rawKey string, found bool, err error) {
-	rest, found := strings.CutPrefix(dataKey, encryptionConfigSecretDataPrefix)
+// formatKMSConfigMapDataKey returns the data key used in the encryption-config Secret
+// for a KMS plugin configmap entry: "kms-plugin-configmap-{rawKey}-{keyID}",
+// where rawKey is the combined "configMapName_dataKey" from KMSReferenceData.FlatEntry.
+//
+// Note:
+//
+// It does not validate inputs. The callers are expected to use KMSReferenceData.Set,
+// which rejects empty values and underscores in referenceName.
+func formatKMSConfigMapDataKey(rawKey, keyID string) string {
+	return fmt.Sprintf("%s%s-%s", encryptionConfigConfigMapDataPrefix, rawKey, keyID)
+}
+
+func parseKMSReferenceDataKey(dataKey, prefix string) (keyID, rawKey string, found bool, err error) {
+	rest, found := strings.CutPrefix(dataKey, prefix)
 	if !found {
 		return "", "", false, nil
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -13,6 +13,9 @@ import (
 // It assumes the input data has been already been validated.
 func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
+	if secretName == "" {
+		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
+	}
 
 	roleID, err := creds.Value(secretName, "role-id")
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/secrets.go
@@ -97,6 +97,15 @@ func ToKeyState(s *corev1.Secret) (state.KeyState, error) {
 				return state.KeyState{}, fmt.Errorf("secret %s/%s has malformed secret data key %q: %w", s.Namespace, s.Name, dataKey, err)
 			}
 		}
+		for dataKey, value := range s.Data {
+			rawKey, found := strings.CutPrefix(dataKey, encryptionSecretKMSConfigMapDataPrefix)
+			if !found {
+				continue
+			}
+			if err := key.KMS.PluginConfigMapData.SetFromRawKey(rawKey, value); err != nil {
+				return state.KeyState{}, fmt.Errorf("secret %s/%s has malformed configmap data key %q: %w", s.Namespace, s.Name, dataKey, err)
+			}
+		}
 		key.Mode = keyMode
 	default:
 		return state.KeyState{}, fmt.Errorf("secret %s/%s has invalid mode: %s", s.Namespace, s.Name, keyMode)
@@ -172,6 +181,12 @@ func FromKeyState(component string, ks state.KeyState) (*corev1.Secret, error) {
 	if ks.HasKMSSecretData() {
 		for flatKey, value := range ks.KMS.PluginSecretData.FlatEntries() {
 			s.Data[encryptionSecretKMSSecretDataPrefix+flatKey] = value
+		}
+	}
+
+	if ks.HasKMSConfigMapData() {
+		for flatKey, value := range ks.KMS.PluginConfigMapData.FlatEntries() {
+			s.Data[encryptionSecretKMSConfigMapDataPrefix+flatKey] = value
 		}
 	}
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/secrets/types.go
@@ -62,6 +62,11 @@ const (
 	// fetched from the referenced secret in openshift-config. The full data key is
 	// constructed as prefix + secretName + separator + dataKey.
 	encryptionSecretKMSSecretDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-secret-"
+
+	// encryptionSecretKMSConfigMapDataPrefix is the data field key prefix for configmap data
+	// values fetched from the referenced configmap in openshift-config. The full data key is
+	// constructed as prefix + configMapName + separator + dataKey.
+	encryptionSecretKMSConfigMapDataPrefix = "encryption.apiserver.operator.openshift.io-kms-plugin-configmap-"
 )
 
 // MigratedGroupResources is the data structured stored in the

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/state/types.go
@@ -64,6 +64,10 @@ func (k *KeyState) HasKMSSecretData() bool {
 	return k != nil && k.KMS != nil && len(k.KMS.PluginSecretData.entries) > 0
 }
 
+func (k *KeyState) HasKMSConfigMapData() bool {
+	return k != nil && k.KMS != nil && len(k.KMS.PluginConfigMapData.entries) > 0
+}
+
 // KMSState stores all KMS encryption mode related configurations
 type KMSState struct {
 	// Encoded EncryptionConfig that stores the KMS related fields
@@ -74,6 +78,9 @@ type KMSState struct {
 
 	// PluginSecretData stores data key-value pairs fetched from referenced secrets.
 	PluginSecretData KMSReferenceData
+
+	// PluginConfigMapData stores data key-value pairs fetched from referenced configmaps.
+	PluginConfigMapData KMSReferenceData
 }
 
 // KMSReferenceData stores data key-value pairs fetched from referenced secrets or configmaps.

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -136,13 +136,13 @@ func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, 
 	}
 
 	if prevKeyMeta.Mode == encryptionMode {
-		waitForNoNewEncryptionKey(t, kubeClient, prevKeyMeta, namespace, labelSelector)
+		WaitForNoNewEncryptionKey(t, kubeClient, prevKeyMeta, namespace, labelSelector)
 		return
 	}
 	WaitForNextMigratedKey(t, kubeClient, prevKeyMeta, defaultTargetGRs, namespace, labelSelector)
 }
 
-func waitForNoNewEncryptionKey(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, namespace, labelSelector string) {
+func WaitForNoNewEncryptionKey(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, namespace, labelSelector string) {
 	t.Helper()
 	// given that the happy path scenario needs ~30 min
 	// waiting 5 min to see if a new key hasn't been created seems to be enough.
@@ -371,5 +371,65 @@ func setUpTearDown(namespace string) func(testing.TB, bool) {
 				t.Logf("Last seen: %-15v Type: %-10v Reason: %-40v Source: %-55v Message: %v", now.Sub(ev.LastTimestamp.Time), ev.Type, ev.Reason, ev.Source.Component, ev.Message)
 			}
 		}
+	}
+}
+
+// WaitForPodImagePullBackOff polls pods in the given namespace until at least one pod
+// has a container stuck in ImagePullBackOff or ErrImagePull.
+// When a KMS plugin image is invalid, the operator cannot progress because the
+// sidecar container fails to start. The operator does not report Degraded in this
+// case — it only gets stuck in Progressing. This function detects that stuck state
+// by observing the pod-level image pull failure, which is the earliest signal that
+// the invalid config has taken effect.
+func WaitForPodImagePullBackOff(ctx context.Context, t testing.TB, kubeClient kubernetes.Interface, namespace, labelSelector string, timeout time.Duration) {
+	t.Helper()
+	t.Logf("Waiting up to %s for a pod in %s (selector=%s) to enter ImagePullBackOff", timeout, namespace, labelSelector)
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			t.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+				if cs.State.Waiting != nil && (cs.State.Waiting.Reason == "ImagePullBackOff" || cs.State.Waiting.Reason == "ErrImagePull") {
+					t.Logf("Pod %s container %s is in %s", pod.Name, cs.Name, cs.State.Waiting.Reason)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "timed out waiting for pod to enter ImagePullBackOff in namespace %s", namespace)
+}
+
+// WaitForCurrentKeyMigrated waits until the current (latest) encryption key has completed
+// migration for all target group resources. It fails if the key changes unexpectedly
+// (i.e. a different key than prevKeyMeta appears).
+func WaitForCurrentKeyMigrated(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, targetGRs []schema.GroupResource, namespace, labelSelector string) {
+	t.Helper()
+
+	t.Logf("Waiting up to %s for key %q to complete migration of %v", waitPollTimeout.String(), prevKeyMeta.Name, targetGRs)
+	if err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
+		currentKeyMeta, err := GetLastKeyMeta(t, kubeClient, namespace, labelSelector)
+		if err != nil {
+			return false, err
+		}
+		if currentKeyMeta.Name != prevKeyMeta.Name {
+			return false, fmt.Errorf("unexpected key observed %q, expected no new key", currentKeyMeta.Name)
+		}
+		if len(currentKeyMeta.Migrated) < len(targetGRs) {
+			return false, nil
+		}
+		for _, expectedGR := range targetGRs {
+			if !hasResource(expectedGR, currentKeyMeta.Migrated) {
+				return false, nil
+			}
+		}
+		t.Logf("Key %q has completed migration of %v", currentKeyMeta.Name, currentKeyMeta.Migrated)
+		return true, nil
+	}); err != nil {
+		newErr := fmt.Errorf("timed out waiting for key %q to complete migration of %v: %v", prevKeyMeta.Name, targetGRs, err)
+		require.NoError(t, newErr)
 	}
 }

--- a/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/scenarios.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -280,4 +280,76 @@ func TestEncryptionRotation(ctx context.Context, t testing.TB, scenario Rotation
 	}
 
 	// TODO: assert conditions - operator and encryption migration controller must report status as active not progressing, and not failing for all scenarios
+}
+
+// ApplyEncryption applies the given encryption config to apiserver/cluster
+// without waiting for completion.
+func ApplyEncryption(ctx context.Context, t testing.TB, encryption configv1.APIServerEncryption) {
+	t.Helper()
+	cs := GetClients(t)
+	apiServer, err := cs.ApiServerConfig.Get(ctx, "cluster", metav1.GetOptions{})
+	require.NoError(t, err)
+	apiServer.Spec.Encryption = encryption
+	_, err = cs.ApiServerConfig.Update(ctx, apiServer, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	t.Logf("Applied encryption config (type=%s)", encryption.Type)
+}
+
+type KMSInvalidEncryptionRecoveryScenario struct {
+	BasicScenario
+	InvalidProvider EncryptionProvider
+	ValidProvider   EncryptionProvider
+	WaitForStuck    func(ctx context.Context, t testing.TB)
+}
+
+// TestInvalidEncryptionRecovery validates recovery from an invalid encryption config:
+//  1. Apply invalid config — operator stuck (e.g. ImagePullBackOff, connection timeout)
+//  2. Switch to AESCBC — verify no new encryption key is created (revisions stuck)
+//  3. Apply valid config — verify recovery and successful encryption
+func TestKMSInvalidEncryptionRecovery(ctx context.Context, t testing.TB, scenario KMSInvalidEncryptionRecoveryScenario) {
+	e := NewE(t, PrintEventsOnFailure(scenario.OperatorNamespace))
+	clientSet := GetClients(e)
+
+	require.NotNil(t, scenario.InvalidProvider.Setup, "InvalidProvider.Setup must not be nil")
+	require.NotNil(t, scenario.ValidProvider.Setup, "ValidProvider.Setup must not be nil")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.InvalidProvider.Type, "InvalidProvider must use KMS encryption type")
+	require.Equal(t, configv1.EncryptionTypeKMS, scenario.ValidProvider.Type, "ValidProvider must use KMS encryption type")
+
+	steps := []testStep{
+		{name: "ApplyInvalidConfig", testFunc: func(t testing.TB) {
+			scenario.InvalidProvider.Setup(ctx, t)
+			ApplyEncryption(ctx, t, scenario.InvalidProvider.APIServerEncryption)
+		}},
+		{name: "WaitForStuck", testFunc: func(t testing.TB) {
+			scenario.WaitForStuck(ctx, t)
+		}},
+		{name: "SwitchToAESCBCAndVerifyNoNewKey", testFunc: func(t testing.TB) {
+			prevKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			ApplyEncryption(ctx, t, configv1.APIServerEncryption{Type: configv1.EncryptionTypeAESCBC})
+			WaitForNoNewEncryptionKey(t, clientSet.Kube, prevKeyMeta,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+		{name: "ApplyValidConfigAndVerifyRecovery", testFunc: func(t testing.TB) {
+			scenario.ValidProvider.Setup(ctx, t)
+			prevKeyMeta, err := GetLastKeyMeta(t, clientSet.Kube,
+				scenario.Namespace, scenario.LabelSelector)
+			require.NoError(t, err)
+			ApplyEncryption(ctx, t, scenario.ValidProvider.APIServerEncryption)
+			WaitForCurrentKeyMigrated(t, clientSet.Kube, prevKeyMeta,
+				scenario.TargetGRs, scenario.Namespace, scenario.LabelSelector)
+			scenario.AssertFunc(t, clientSet, scenario.ValidProvider.Type,
+				scenario.Namespace, scenario.LabelSelector)
+		}},
+	}
+
+	for _, step := range steps {
+		t.Logf("=== STEP: %s ===", step.name)
+		step.testFunc(e)
+		if t.Failed() {
+			t.Errorf("stopping the test as %q step failed", step.name)
+			return
+		}
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260604143514-ba2b9a3a3499
+# github.com/openshift/library-go v0.0.0-20260608110537-04693132679d
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
## Summary

Automated dependency update for `github.com/openshift/library-go`.

## Details

- **library-go commit**: [`0469313`](https://github.com/openshift/library-go/commit/04693132679d63a73f022752bf9e1a995e1a851b)
- **Update date**: 2026-06-08
- **Generated by**: Claude Code agentic workflow

## Changes

- Updated `go.mod` and `go.sum`
- Refreshed vendor directory
- Fixed API signature change in `WithEncryptionControllers` (added separate `configMapClient` parameter)

## Testing

- [x] `make verify` passes
- [x] `make test` passes
- [ ] CI tests pass
- [ ] Manual verification recommended

---

🤖 This PR was created automatically by an AI agent using Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external dependencies to latest versions.
  * Internal improvements to operator initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->