### PR TITLE
CNTRLPLANE-3545: bump library-go to get CA bundle wiring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/api v0.0.0-20260521125114-09730f85d883
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a
-	github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33
+	github.com/openshift/library-go v0.0.0-20260612140105-3fa3bb604fd6
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33 h1:k7zdFrfi8699bfWL+ykAn3GF7r2hzIFmMBM8onHrLY0=
-github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
+github.com/openshift/library-go v0.0.0-20260612140105-3fa3bb604fd6 h1:4XQkleE6UqSF9D9QeNWnubGkst5OOs+KHCh2cPcdKXU=
+github.com/openshift/library-go v0.0.0-20260612140105-3fa3bb604fd6/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -287,7 +287,12 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			Plugin: apiServerEncryption.KMS,
 		}
 
-		if secretName, expectedKeys, err := referencedSecretName(apiServerEncryption.KMS); err != nil {
+		providerCfg, err := newKMSProviderConfig(apiServerEncryption.KMS)
+		if err != nil {
+			return nil, err
+		}
+
+		if secretName, expectedKeys, err := providerCfg.referencedSecretName(); err != nil {
 			return nil, err
 		} else if len(secretName) > 0 {
 			refSecret, err := c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
@@ -305,7 +310,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 			}
 		}
 
-		if cmName, expectedKeys, err := referencedConfigMapName(apiServerEncryption.KMS); err != nil {
+		if cmName, expectedKeys, err := providerCfg.referencedConfigMapName(); err != nil {
 			return nil, err
 		} else if len(cmName) > 0 {
 			refCM, err := c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
@@ -424,38 +429,48 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 	return latestKeyID, "rotation-interval-has-passed", time.Since(latestKey.Migrated.Timestamp) > encryptionSecretMigrationInterval
 }
 
-// referencedSecretName returns the name of the secret referenced by the KMS plugin
-// config and the specific data keys to carry from that secret. Only the listed keys
-// are copied into the Key Secret; any other data in the referenced secret is ignored.
-func referencedSecretName(plugin configv1.KMSPluginConfig) (string, []string, error) {
+// kmsProviderConfig abstracts provider-specific KMS logic so that every
+// provider-type switch lives in a single factory (newKMSProviderConfig).
+type kmsProviderConfig interface {
+	// referencedSecretName returns the name of the secret referenced by the KMS plugin
+	// config and the specific data keys to carry from that secret. Only the listed keys
+	// are copied into the Key Secret; any other data in the referenced secret is ignored.
+	referencedSecretName() (string, []string, error)
+	// referencedConfigMapName returns the name of the configmap referenced by the KMS plugin
+	// config and the specific data keys to carry from that configmap. Only the listed keys
+	// are copied into the Key Secret; any other data in the referenced configmap is ignored.
+	referencedConfigMapName() (string, []string, error)
+}
+
+func newKMSProviderConfig(plugin configv1.KMSPluginConfig) (kmsProviderConfig, error) {
 	switch plugin.Type {
 	case configv1.VaultKMSProvider:
-		switch plugin.Vault.Authentication.Type {
-		case configv1.VaultAuthenticationTypeAppRole:
-			// The Vault AppRole secret must contain "role-id" and "secret-id" keys.
-			// These are the only keys carried into the encryption key secret.
-			return plugin.Vault.Authentication.AppRole.Secret.Name, []string{"role-id", "secret-id"}, nil
-		default:
-			return "", nil, fmt.Errorf("unsupported Vault authentication type %q", plugin.Vault.Authentication.Type)
-		}
+		return &vaultProviderConfig{plugin.Vault}, nil
 	default:
-		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
+		return nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
 	}
 }
 
-// referencedConfigMapName returns the name of the configmap referenced by the KMS plugin
-// config and the specific data keys to carry from that configmap. Only the listed keys
-// are copied into the Key Secret; any other data in the referenced configmap is ignored.
-func referencedConfigMapName(plugin configv1.KMSPluginConfig) (string, []string, error) {
-	switch plugin.Type {
-	case configv1.VaultKMSProvider:
-		if plugin.Vault.TLS.CABundle.Name == "" {
-			return "", nil, nil
-		}
-		return plugin.Vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
+type vaultProviderConfig struct {
+	vault configv1.VaultKMSPluginConfig
+}
+
+func (v *vaultProviderConfig) referencedSecretName() (string, []string, error) {
+	switch v.vault.Authentication.Type {
+	case configv1.VaultAuthenticationTypeAppRole:
+		// The Vault AppRole secret must contain "role-id" and "secret-id" keys.
+		// These are the only keys carried into the encryption key secret.
+		return v.vault.Authentication.AppRole.Secret.Name, []string{"role-id", "secret-id"}, nil
 	default:
-		return "", nil, fmt.Errorf("unsupported KMS provider type %q", plugin.Type)
+		return "", nil, fmt.Errorf("unsupported Vault authentication type %q", v.vault.Authentication.Type)
 	}
+}
+
+func (v *vaultProviderConfig) referencedConfigMapName() (string, []string, error) {
+	if v.vault.TLS.CABundle.Name == "" {
+		return "", nil, nil
+	}
+	return v.vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
 }
 
 // TODO make this un-settable once set

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/credentials.go
@@ -7,16 +7,17 @@ import (
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
 )
 
-// credentialResolver resolves KMS plugin credentials for a specific keyID
-// by looking up secret data and mapping it to values or file paths on disk.
-type credentialResolver struct {
-	keyID             string
-	credentialsDir    string
-	pluginsSecretData encryptiondata.KMSPluginsReferenceData
+// referenceDataResolver resolves KMS plugin reference data for a specific keyID
+// by looking up secret and configMap data and mapping it to values or file paths on disk.
+type referenceDataResolver struct {
+	keyID                string
+	referenceDataDir     string
+	pluginsSecretData    encryptiondata.KMSPluginsReferenceData
+	pluginsConfigMapData encryptiondata.KMSPluginsReferenceData
 }
 
-// Value returns the credential value for the given secret name and data key.
-func (r *credentialResolver) Value(secretName, dataKey string) (string, error) {
+// SecretValue returns the value for the given secret name and data key.
+func (r *referenceDataResolver) SecretValue(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -28,8 +29,8 @@ func (r *credentialResolver) Value(secretName, dataKey string) (string, error) {
 	return string(v), nil
 }
 
-// FilePath returns the on-disk path where the credential for the given secret name and data key is mounted.
-func (r *credentialResolver) FilePath(secretName, dataKey string) (string, error) {
+// SecretFilePath returns the on-disk path where the data for the given secret name and data key is mounted.
+func (r *referenceDataResolver) SecretFilePath(secretName, dataKey string) (string, error) {
 	sd, ok := r.pluginsSecretData.Get(r.keyID)
 	if !ok {
 		return "", fmt.Errorf("missing secret data for keyID %s", r.keyID)
@@ -39,5 +40,19 @@ func (r *credentialResolver) FilePath(secretName, dataKey string) (string, error
 		return "", fmt.Errorf("missing %s in secret %s for keyID %s", dataKey, secretName, r.keyID)
 	}
 	secretDataKey := encryptiondata.FormatKMSSecretDataKey(rawKey, r.keyID)
-	return filepath.Join(r.credentialsDir, secretDataKey), nil
+	return filepath.Join(r.referenceDataDir, secretDataKey), nil
+}
+
+// ConfigMapFilePath returns the on-disk path where the data for the given configMap name and data key is mounted.
+func (r *referenceDataResolver) ConfigMapFilePath(configMapName, dataKey string) (string, error) {
+	cd, ok := r.pluginsConfigMapData.Get(r.keyID)
+	if !ok {
+		return "", fmt.Errorf("missing configMap data for keyID %s", r.keyID)
+	}
+	rawKey, ok := cd.FlatEntry(configMapName, dataKey)
+	if !ok {
+		return "", fmt.Errorf("missing %s in configMap %s for keyID %s", dataKey, configMapName, r.keyID)
+	}
+	configMapDataKey := encryptiondata.FormatKMSConfigMapDataKey(rawKey, r.keyID)
+	return filepath.Join(r.referenceDataDir, configMapDataKey), nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/sidecar.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	resourceDirVolumeName = "resource-dir"
-	credentialsVolumeName = "kms-plugin-credentials"
-	credentialsMountPath  = "/var/run/secrets/kms-plugin"
-	resourcesDir          = "/etc/kubernetes/static-pod-resources"
+	resourceDirVolumeName   = "resource-dir"
+	referenceDataVolumeName = "kms-plugins-data"
+	referenceDataMountPath  = "/var/run/secrets/kms-plugin"
+	resourcesDir            = "/etc/kubernetes/static-pod-resources"
 )
 
 const (
@@ -39,11 +39,11 @@ type sidecarProvider interface {
 }
 
 // newSidecarProvider creates a provider-specific sidecarProvider for the given keyID and plugin configuration,
-// wiring in credentials via the credentialResolver.
-func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, creds *credentialResolver) (sidecarProvider, error) {
+// wiring in reference data (secrets, configmaps) via the referenceDataResolver.
+func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSPluginConfig, refData *referenceDataResolver) (sidecarProvider, error) {
 	switch pluginConfig.Type {
 	case configv1.VaultKMSProvider:
-		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, creds)
+		return newVaultSidecarProvider("vault-kms-plugin", keyID, udsPath, pluginConfig.Vault, refData)
 	default:
 		return nil, fmt.Errorf("unsupported KMS plugin configuration")
 	}
@@ -51,7 +51,7 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 
 // AddKMSPluginSidecarToStaticPodSpec injects KMS plugin sidecar containers into a kube-apiserver static pod spec.
 //
-// Static pods access credentials through the resource-dir volume, which the static pod revision controller
+// Static pods access KMS plugin data through the resource-dir volume, which the static pod revision controller
 // populates on disk from the encryption-config Secret. Because those files are owned by root, each sidecar
 // is configured to run as UID 0.
 //
@@ -59,9 +59,9 @@ func newSidecarProvider(keyID string, udsPath string, pluginConfig configv1.KMSP
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
 	// The static pod revision controller copies secret data to disk under resourcesDir/secrets/<secretName>/.
-	credentialsDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
+	referenceDataDir := filepath.Join(resourcesDir, "secrets", encryptionConfigSecretName)
 
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsDir)
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataDir)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
 			return err
 		}
-		// The resource-dir files are owned by root, so the sidecar needs root to read credential files.
+		// The resource-dir files are owned by root, so the sidecar needs root to read files in that directory.
 		if err := setRunAsUser(podSpec.InitContainers, name, 0); err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func AddKMSPluginSidecarToStaticPodSpec(ctx context.Context, podSpec *corev1.Pod
 // It is a no-op when the KMSEncryption feature gate is not enabled or the encryption-config secret does not exist.
 // The secretClient should be uncached to avoid injecting sidecars based on a stale encryption configuration.
 func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess) error {
-	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, credentialsMountPath)
+	sidecarNames, err := addKMSPluginSidecars(ctx, podSpec, containerName, encryptionConfigNamespace, encryptionConfigSecretName, secretClient, featureGateAccessor, referenceDataMountPath)
 	if err != nil {
 		return err
 	}
@@ -101,15 +101,15 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 	}
 
 	for _, name := range sidecarNames {
-		volumeMount := corev1.VolumeMount{Name: credentialsVolumeName, MountPath: credentialsMountPath, ReadOnly: true}
+		volumeMount := corev1.VolumeMount{Name: referenceDataVolumeName, MountPath: referenceDataMountPath, ReadOnly: true}
 		if err := ensureVolumeMountInContainer(podSpec.InitContainers, name, volumeMount); err != nil {
 			return err
 		}
 	}
 
-	// Unlike static pods, aggregated API servers access credentials by mounting the encryption-config Secret directly as a volume.
+	// Unlike static pods, aggregated API servers access KMS plugin data by mounting the encryption-config Secret directly as a volume.
 	// Callers include the revision number in encryptionConfigSecretName (e.g. "encryption-config-7"), so each revision maps to a distinct Secret and volume.
-	if err := ensureCredentialsVolume(podSpec, encryptionConfigSecretName); err != nil {
+	if err := ensureReferenceDataVolume(podSpec, encryptionConfigSecretName); err != nil {
 		return err
 	}
 
@@ -118,7 +118,7 @@ func AddKMSPluginSidecarToPodSpec(ctx context.Context, podSpec *corev1.PodSpec, 
 
 // addKMSPluginSidecars contains the shared logic for discovering KMS plugins and injecting sidecar containers.
 // It returns the names of the sidecar containers that were injected, so callers can add deployment-mode-specific volume mounts.
-func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, credentialsDir string) ([]string, error) {
+func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containerName string, encryptionConfigNamespace string, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, featureGateAccessor featuregates.FeatureGateAccess, referenceDataDir string) ([]string, error) {
 	if podSpec == nil {
 		return nil, fmt.Errorf("pod spec cannot be nil")
 	}
@@ -177,13 +177,14 @@ func addKMSPluginSidecars(ctx context.Context, podSpec *corev1.PodSpec, containe
 			return nil, fmt.Errorf("missing plugin config for keyID %s", keyID)
 		}
 
-		creds := &credentialResolver{
-			pluginsSecretData: encryptionConfig.KMSPluginsSecretData,
-			credentialsDir:    credentialsDir,
-			keyID:             keyID,
+		refData := &referenceDataResolver{
+			pluginsConfigMapData: encryptionConfig.KMSPluginsConfigMapData,
+			pluginsSecretData:    encryptionConfig.KMSPluginsSecretData,
+			referenceDataDir:     referenceDataDir,
+			keyID:                keyID,
 		}
 
-		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, creds)
+		provider, err := newSidecarProvider(keyID, udsPath, pluginConfig, refData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a sidecar provider for keyID %s: %w", keyID, err)
 		}
@@ -277,9 +278,9 @@ func ensureSocketVolume(podSpec *corev1.PodSpec) error {
 	return ensureVolume(podSpec, volume)
 }
 
-func ensureCredentialsVolume(podSpec *corev1.PodSpec, secretName string) error {
+func ensureReferenceDataVolume(podSpec *corev1.PodSpec, secretName string) error {
 	volume := corev1.Volume{
-		Name: credentialsVolumeName,
+		Name: referenceDataVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: secretName,

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/vault.go
@@ -11,13 +11,13 @@ import (
 
 // newVaultSidecarProvider creates a Vault sidecar provider from the given KMS plugin data.
 // It assumes the input data has been already been validated.
-func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, creds *credentialResolver) (*vault, error) {
+func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.VaultKMSPluginConfig, refData *referenceDataResolver) (*vault, error) {
 	secretName := vaultConfig.Authentication.AppRole.Secret.Name
 	if secretName == "" {
 		return nil, fmt.Errorf("vault AppRole authentication secret name cannot be empty")
 	}
 
-	roleID, err := creds.Value(secretName, "role-id")
+	roleID, err := refData.SecretValue(secretName, "role-id")
 	if err != nil {
 		return nil, err
 	}
@@ -26,13 +26,21 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		return nil, fmt.Errorf("role ID cannot be empty")
 	}
 
-	secretIDPath, err := creds.FilePath(secretName, "secret-id")
+	secretIDPath, err := refData.SecretFilePath(secretName, "secret-id")
 	if err != nil {
 		return nil, err
 	}
 
 	if secretIDPath == "" {
 		return nil, fmt.Errorf("secret ID path cannot be empty")
+	}
+
+	var caBundlePath string
+	if configMapName := vaultConfig.TLS.CABundle.Name; configMapName != "" {
+		caBundlePath, err = refData.ConfigMapFilePath(configMapName, "ca-bundle.crt")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &vault{
@@ -42,6 +50,7 @@ func newVaultSidecarProvider(name, keyID, udsPath string, vaultConfig configv1.V
 		config:       vaultConfig,
 		roleID:       roleID,
 		secretIDPath: secretIDPath,
+		caBundlePath: caBundlePath,
 	}, nil
 }
 
@@ -53,6 +62,7 @@ type vault struct {
 	config       configv1.VaultKMSPluginConfig
 	roleID       string
 	secretIDPath string
+	caBundlePath string
 }
 
 // Name returns the sidecar name appended by the key id.
@@ -74,14 +84,18 @@ func (v *vault) BuildSidecarContainer() (corev1.Container, error) {
 	}
 
 	// Optional fields: only pass non-empty values.
+	if v.caBundlePath != "" {
+		args = append(args, fmt.Sprintf("-tls-ca-file=%s", v.caBundlePath))
+	}
+	if v.config.TLS.ServerName != "" {
+		args = append(args, fmt.Sprintf("-tls-sni=%s", v.config.TLS.ServerName))
+	}
 	if v.config.VaultNamespace != "" {
 		args = append(args, fmt.Sprintf("-vault-namespace=%s", v.config.VaultNamespace))
 	}
 
 	// Temporary workarounds. These should go away as we progress with the feature.
 	args = append(args,
-		// TODO: remove before GA once the CA bundle is wired into the encryption config secret.
-		"-tls-skip-verify=true",
 		// TODO: remove once we support scraping metrics from each KMS plugin sidecar independently.
 		// Set the port to zero to disable metrics serving.
 		// Slack discussion: https://redhat-external.slack.com/archives/C09KZ5QCBUH/p1780926464635219

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	defaultVaultNamespace          = "vault-kms"
+	defaultVaultServiceName        = "vault"
 	defaultVaultPodName            = "vault-0"
 	defaultVaultCredentialsSecret  = "vault-credentials"
 	defaultVaultAppRoleSecretName  = "vault-approle-secret"
@@ -36,6 +37,15 @@ const (
 	defaultVaultTransitKey         = "kms-key"
 	defaultAppRoleTargetNamespace  = "openshift-config"
 	vaultCommandTimeout            = 30 * time.Second
+
+	// Secondary Vault instance constants for KMS-to-KMS migration testing.
+	secondaryVaultNamespace         = "vault-kms-secondary"
+	secondaryVaultServiceName       = "vault-secondary"
+	secondaryVaultPodName           = "vault-secondary-0"
+	secondaryVaultAppRoleSecretName = "vault-approle-secret-secondary"
+	secondaryVaultConfigMapName     = "vault-ca-bundle-secondary"
+	secondaryVaultAddress           = "https://vault-secondary.vault-kms-secondary.svc:8200"
+	secondaryVaultTransitKey        = "kms-key-secondary"
 )
 
 // DefaultVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider for e2e tests.
@@ -45,7 +55,7 @@ func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.E
 	cfg := DefaultVaultKMSPluginConfig
 	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
 	// cannot resolve cluster-local Service names (they use host network DNS).
-	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, defaultVaultNamespace)
+	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, defaultVaultNamespace, defaultVaultServiceName)
 	return library.EncryptionProvider{
 		APIServerEncryption: cfg,
 		Setup:               ensureVaultAppRoleSecret(defaultVaultNamespace, defaultVaultAppRoleSecretName),
@@ -99,10 +109,52 @@ var DefaultFakeKMSPluginConfig = configv1.APIServerEncryption{
 					Secret: configv1.VaultSecretReference{Name: defaultVaultAppRoleSecretName},
 				},
 			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{Name: defaultVaultConfigMapName},
+			},
 			TransitKey:   "test-transit-key",
 			TransitMount: defaultVaultTransitMount,
 		},
 	},
+}
+
+// SecondaryVaultKMSPluginConfig is the Vault KMS encryption config for the
+// secondary Vault instance, used in KMS-to-KMS migration e2e tests.
+var SecondaryVaultKMSPluginConfig = configv1.APIServerEncryption{
+	Type: configv1.EncryptionTypeKMS,
+	KMS: configv1.KMSPluginConfig{
+		Type: configv1.VaultKMSProvider,
+		Vault: configv1.VaultKMSPluginConfig{
+			KMSPluginImage: defaultVaultKMSPluginImage,
+			VaultAddress:   secondaryVaultAddress,
+			VaultNamespace: defaultVaultEnterpriseNS,
+			TransitMount:   defaultVaultTransitMount,
+			TransitKey:     secondaryVaultTransitKey,
+			Authentication: configv1.VaultAuthentication{
+				Type: configv1.VaultAuthenticationTypeAppRole,
+				AppRole: configv1.VaultAppRoleAuthentication{
+					Secret: configv1.VaultSecretReference{Name: secondaryVaultAppRoleSecretName},
+				},
+			},
+			TLS: configv1.VaultTLSConfig{
+				CABundle: configv1.VaultConfigMapReference{
+					Name: secondaryVaultConfigMapName,
+				},
+				ServerName: fmt.Sprintf("vault-secondary.%s.svc", secondaryVaultNamespace),
+			},
+		},
+	},
+}
+
+// SecondaryVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider
+// for the secondary Vault instance, used in KMS-to-KMS migration e2e tests.
+func SecondaryVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
+	cfg := SecondaryVaultKMSPluginConfig
+	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, secondaryVaultNamespace, secondaryVaultServiceName)
+	return library.EncryptionProvider{
+		APIServerEncryption: cfg,
+		Setup:               ensureVaultAppRoleSecret(secondaryVaultNamespace, secondaryVaultAppRoleSecretName),
+	}
 }
 
 func ensureVaultAppRoleSecret(vaultNamespace, appRoleSecretName string) func(ctx context.Context, t testing.TB) {
@@ -196,11 +248,11 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 
 // getVaultServiceAddress returns the Vault address using the Service's ClusterIP
 // instead of the DNS name, reading the port and scheme from the Service spec.
-func getVaultServiceAddress(ctx context.Context, t testing.TB, ns string) string {
+func getVaultServiceAddress(ctx context.Context, t testing.TB, ns, serviceName string) string {
 	t.Helper()
 	cs := library.GetClients(t)
 
-	svc, err := cs.Kube.CoreV1().Services(ns).Get(ctx, "vault", metav1.GetOptions{})
+	svc, err := cs.Kube.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
 	require.NoError(t, err, "failed to get vault Service in namespace %s", ns)
 	require.NotEmpty(t, svc.Spec.ClusterIP, "vault Service has no ClusterIP")
 	require.NotEmpty(t, svc.Spec.Ports, "vault Service has no ports")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260611070125-7fd5f333df33
+# github.com/openshift/library-go v0.0.0-20260612140105-3fa3bb604fd6
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal library dependency used by the build and runtime toolchain.
  * No user-facing features were added or removed.
  * Expected impact: builds and maintenance use the newer upstream library; functionality and user experience remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->