### PR TITLE
API-1768: e2e network policy tests (alternative implementation)

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -59,148 +59,11 @@ func createTestNamespace(client corev1client.NamespaceInterface, prefix string) 
 
 // Network Policy validation helpers
 
-// getNetworkPolicy retrieves a NetworkPolicy by namespace and name.
-// Fails the test if the policy cannot be retrieved.
 func getNetworkPolicy(ctx context.Context, client kubernetes.Interface, namespace, name string) *networkingv1.NetworkPolicy {
 	g.GinkgoHelper()
 	policy, err := client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NetworkPolicy %s/%s", namespace, name)
 	return policy
-}
-
-// requireDefaultDenyAll asserts that a NetworkPolicy is a default-deny policy:
-// - empty podSelector (selects all pods in the namespace)
-// - includes both Ingress and Egress policy types
-// - no allow rules (empty Ingress and Egress slices)
-func requireDefaultDenyAll(policy *networkingv1.NetworkPolicy) {
-	g.GinkgoHelper()
-	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
-		g.Fail(fmt.Sprintf("%s/%s: expected empty podSelector", policy.Namespace, policy.Name))
-	}
-
-	policyTypes := sets.New[string]()
-	for _, policyType := range policy.Spec.PolicyTypes {
-		policyTypes.Insert(string(policyType))
-	}
-	if !policyTypes.Has(string(networkingv1.PolicyTypeIngress)) || !policyTypes.Has(string(networkingv1.PolicyTypeEgress)) {
-		g.Fail(fmt.Sprintf("%s/%s: expected both Ingress and Egress policyTypes, got %v", policy.Namespace, policy.Name, policy.Spec.PolicyTypes))
-	}
-
-	if len(policy.Spec.Ingress) != 0 {
-		g.Fail(fmt.Sprintf("%s/%s: expected empty Ingress rules for default-deny policy, got %d rules", policy.Namespace, policy.Name, len(policy.Spec.Ingress)))
-	}
-	if len(policy.Spec.Egress) != 0 {
-		g.Fail(fmt.Sprintf("%s/%s: expected empty Egress rules for default-deny policy, got %d rules", policy.Namespace, policy.Name, len(policy.Spec.Egress)))
-	}
-}
-
-// requirePodSelectorLabel asserts that a NetworkPolicy's podSelector contains a specific label.
-func requirePodSelectorLabel(policy *networkingv1.NetworkPolicy, key, value string) {
-	g.GinkgoHelper()
-	actual, ok := policy.Spec.PodSelector.MatchLabels[key]
-	if !ok || actual != value {
-		g.Fail(fmt.Sprintf("%s/%s: expected podSelector %s=%s, got %v", policy.Namespace, policy.Name, key, value, policy.Spec.PodSelector.MatchLabels))
-	}
-}
-
-// requirePodSelectorExpression asserts that a NetworkPolicy's podSelector contains a matchExpression
-// with the given key and values using the In operator.
-func requirePodSelectorExpression(policy *networkingv1.NetworkPolicy, key string, values []string) {
-	g.GinkgoHelper()
-	found := false
-	for _, expr := range policy.Spec.PodSelector.MatchExpressions {
-		if expr.Key == key && expr.Operator == metav1.LabelSelectorOpIn {
-			if sets.New[string](expr.Values...).Equal(sets.New[string](values...)) {
-				found = true
-				break
-			}
-		}
-	}
-	if !found {
-		g.Fail(fmt.Sprintf("%s/%s: expected podSelector expression %s in %v", policy.Namespace, policy.Name, key, values))
-	}
-}
-
-// requireIngressPort asserts that a NetworkPolicy allows ingress traffic on the specified protocol and port.
-func requireIngressPort(policy *networkingv1.NetworkPolicy, protocol corev1.Protocol, port int32) {
-	g.GinkgoHelper()
-	if !hasPortInIngress(policy.Spec.Ingress, protocol, port) {
-		g.Fail(fmt.Sprintf("%s/%s: expected ingress port %s/%d", policy.Namespace, policy.Name, protocol, port))
-	}
-}
-
-// requireIngressAllowAll asserts that a NetworkPolicy allows ingress from any source on the specified port.
-func requireIngressAllowAll(policy *networkingv1.NetworkPolicy, port int32) {
-	g.GinkgoHelper()
-	if !hasIngressAllowAll(policy.Spec.Ingress, port) {
-		g.Fail(fmt.Sprintf("%s/%s: expected ingress allow-all on port %d", policy.Namespace, policy.Name, port))
-	}
-}
-
-// requireEgressAllowAllTCP asserts that a NetworkPolicy has an egress allow-all TCP rule.
-// The rule should have no destination restrictions (empty To field) and allow TCP traffic.
-func requireEgressAllowAllTCP(policy *networkingv1.NetworkPolicy) {
-	g.GinkgoHelper()
-	o.Expect(hasEgressAllowAllTCP(policy.Spec.Egress)).To(o.BeTrue(),
-		fmt.Sprintf("NetworkPolicy %s/%s should have egress allow-all TCP rule", policy.Namespace, policy.Name))
-}
-
-func hasIngressAllowAll(rules []networkingv1.NetworkPolicyIngressRule, port int32) bool {
-	for _, rule := range rules {
-		if !hasPort(rule.Ports, corev1.ProtocolTCP, port) {
-			continue
-		}
-		if len(rule.From) == 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func hasEgressAllowAllTCP(rules []networkingv1.NetworkPolicyEgressRule) bool {
-	for _, rule := range rules {
-		if len(rule.To) != 0 {
-			continue
-		}
-		if hasAnyTCPPort(rule.Ports) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasAnyTCPPort(ports []networkingv1.NetworkPolicyPort) bool {
-	if len(ports) == 0 {
-		return true
-	}
-	for _, p := range ports {
-		if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
-			continue
-		}
-		return true
-	}
-	return false
-}
-
-func hasPortInIngress(rules []networkingv1.NetworkPolicyIngressRule, protocol corev1.Protocol, port int32) bool {
-	for _, rule := range rules {
-		if hasPort(rule.Ports, protocol, port) {
-			return true
-		}
-	}
-	return false
-}
-
-func hasPort(ports []networkingv1.NetworkPolicyPort, protocol corev1.Protocol, port int32) bool {
-	for _, p := range ports {
-		if p.Port == nil || p.Port.IntValue() != int(port) {
-			continue
-		}
-		if p.Protocol == nil || *p.Protocol == protocol {
-			return true
-		}
-	}
-	return false
 }
 
 // deleteAndWaitForAllRestored deletes all given NetworkPolicies at once, then
@@ -280,8 +143,6 @@ func mutateAndWaitForAllReconciled(ctx context.Context, client kubernetes.Interf
 		states = append(states, mutationState{namespace: p.namespace, name: p.name, original: original.Spec})
 	}
 
-	time.Sleep(2 * time.Second)
-
 	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
 		allReconciled := true
 		for i := range states {
@@ -342,7 +203,7 @@ func isPodReady(pod *corev1.Pod) bool {
 func logNetworkPolicyEvents(ctx context.Context, client kubernetes.Interface, namespaces []string, policyName string) {
 	g.GinkgoHelper()
 	found := false
-	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		for _, namespace := range namespaces {
 			events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
@@ -492,8 +353,8 @@ func netexecPod(name, namespace string, labels map[string]string, port int32) *c
 		Spec: corev1.PodSpec{
 			ServiceAccountName: "netpolicy-test-sa",
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot:   boolptr(true),
-				RunAsUser:      int64ptr(1001),
+				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      ptr.To[int64](1001),
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 			Containers: []corev1.Container{
@@ -501,10 +362,10 @@ func netexecPod(name, namespace string, labels map[string]string, port int32) *c
 					Name:  "netexec",
 					Image: agnhostImage,
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: boolptr(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-						RunAsNonRoot:             boolptr(true),
-						RunAsUser:                int64ptr(1001),
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To[int64](1001),
 					},
 					Command: []string{"/agnhost"},
 					Args:    []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
@@ -591,8 +452,8 @@ func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Inte
 			ServiceAccountName: "netpolicy-test-sa",
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot:   boolptr(true),
-				RunAsUser:      int64ptr(1001),
+				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      ptr.To[int64](1001),
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 			Containers: []corev1.Container{
@@ -600,10 +461,10 @@ func createConnectivityClientPod(ctx context.Context, kubeClient kubernetes.Inte
 					Name:  "connect",
 					Image: agnhostImage,
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: boolptr(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-						RunAsNonRoot:             boolptr(true),
-						RunAsUser:                int64ptr(1001),
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To[int64](1001),
 					},
 					Command: []string{"/bin/sh", "-c"},
 					Args: []string{
@@ -773,12 +634,4 @@ func formatIPPort(ip string, port int32) string {
 
 func protocolPtr(protocol corev1.Protocol) *corev1.Protocol {
 	return &protocol
-}
-
-func boolptr(value bool) *bool {
-	return &value
-}
-
-func int64ptr(value int64) *int64 {
-	return &value
 }

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -6,7 +6,6 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -48,28 +47,26 @@ func testKubeAPIServerNetworkPolicies() {
 	operatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, defaultDenyAllPolicyName)
 	logNetworkPolicySummary("kube-apiserver-operator/default-deny-all", operatorDefaultDeny)
 	logNetworkPolicyDetails("kube-apiserver-operator/default-deny-all", operatorDefaultDeny)
-	requireDefaultDenyAll(operatorDefaultDeny)
+	o.Expect(operatorDefaultDeny).To(BeDefaultDenyPolicy())
 
 	operatorAllowPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, operatorAllowPolicyName)
 	logNetworkPolicySummary("kube-apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
 	logNetworkPolicyDetails("kube-apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
-	requirePodSelectorLabel(operatorAllowPolicy, "app", "kube-apiserver-operator")
-	requireIngressPort(operatorAllowPolicy, corev1.ProtocolTCP, 8443)
-	requireIngressAllowAll(operatorAllowPolicy, 8443)
-	requireEgressAllowAllTCP(operatorAllowPolicy)
+	o.Expect(operatorAllowPolicy).To(SelectPods("app", "kube-apiserver-operator"))
+	o.Expect(operatorAllowPolicy).To(AllowIngressOnPort(8443))
+	o.Expect(operatorAllowPolicy).To(AllowAllTCPEgress())
 
 	g.By("Validating NetworkPolicies in openshift-kube-apiserver")
 	operandDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, defaultDenyAllPolicyName)
 	logNetworkPolicySummary("kube-apiserver/default-deny-all", operandDefaultDeny)
 	logNetworkPolicyDetails("kube-apiserver/default-deny-all", operandDefaultDeny)
-	requireDefaultDenyAll(operandDefaultDeny)
+	o.Expect(operandDefaultDeny).To(BeDefaultDenyPolicy())
 
 	operandAllowPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, operandAllowPolicyName)
 	logNetworkPolicySummary("kube-apiserver/"+operandAllowPolicyName, operandAllowPolicy)
 	logNetworkPolicyDetails("kube-apiserver/"+operandAllowPolicyName, operandAllowPolicy)
-	// Verify it selects guard, installer, pruner, and openshift-kms-preflight pods with In expression
-	requirePodSelectorExpression(operandAllowPolicy, "app", []string{"guard", "installer", "pruner", "openshift-kms-preflight"})
-	requireEgressAllowAllTCP(operandAllowPolicy)
+	o.Expect(operandAllowPolicy).To(SelectPodsExpression("app", []string{"guard", "installer", "pruner", "openshift-kms-preflight"}))
+	o.Expect(operandAllowPolicy).To(AllowAllTCPEgress())
 
 	g.By("Verifying pods are ready in kube-apiserver namespaces")
 	waitForPodsReadyByLabel(ctx, kubeClient, kubeAPIServerOperatorNamespace, "app=kube-apiserver-operator")

--- a/test/e2e/network_policy.go
+++ b/test/e2e/network_policy.go
@@ -7,6 +7,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -14,96 +15,105 @@ import (
 )
 
 const (
-	kubeAPIServerNamespace         = "openshift-kube-apiserver"
-	kubeAPIServerOperatorNamespace = "openshift-kube-apiserver-operator"
-	defaultDenyAllPolicyName       = "default-deny"
-	operatorAllowPolicyName        = "allow-all-egress-and-metrics-ingress"
-	operandAllowPolicyName         = "allow-all-egress"
+	kasNamespace         = "openshift-kube-apiserver"
+	kasOperatorNamespace = "openshift-kube-apiserver-operator"
 )
 
-var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
-	g.It("[Serial][Operator][Feature:NetworkPolicy] should ensure kube-apiserver NetworkPolicies are defined", func() {
-		testKubeAPIServerNetworkPolicies()
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator [Serial][Operator][Feature:NetworkPolicy]", func() {
+	var (
+		ctx          context.Context
+		kubeClient   kubernetes.Interface
+		configClient configclient.ConfigV1Interface
+	)
+
+	g.BeforeEach(func() {
+		ctx = context.Background()
+		config := getClientConfigForTest()
+		var err error
+		kubeClient, err = kubernetes.NewForConfig(config)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		configClient, err = configclient.NewForConfig(config)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for kube-apiserver ClusterOperator to be stable")
+		err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(configClient, "kube-apiserver")
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
-	g.It("[Serial][Operator][Feature:NetworkPolicy] should restore kube-apiserver NetworkPolicies after delete or mutation", func() {
-		testKubeAPIServerNetworkPolicyReconcile()
+
+	getPolicy := func(ns, name string) *networkingv1.NetworkPolicy {
+		g.GinkgoHelper()
+		p, err := kubeClient.NetworkingV1().NetworkPolicies(ns).Get(ctx, name, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "get NetworkPolicy %s/%s", ns, name)
+		return p
+	}
+
+	g.Context("conformance", func() {
+		g.Context("in the operator namespace", func() {
+			g.It("should have a default-deny-all policy", func() {
+				policy := getPolicy(kasOperatorNamespace, "default-deny")
+				logNetworkPolicyDetails("operator/default-deny", policy)
+				o.Expect(policy).To(BeDefaultDenyPolicy())
+			})
+
+			g.It("should allow egress and metrics ingress for the operator pod", func() {
+				policy := getPolicy(kasOperatorNamespace, "allow-all-egress-and-metrics-ingress")
+				logNetworkPolicyDetails("operator/allow-all-egress-and-metrics-ingress", policy)
+				o.Expect(policy).To(SelectPods("app", "kube-apiserver-operator"))
+				o.Expect(policy).To(AllowIngressOnPort(8443))
+				o.Expect(policy).To(AllowAllTCPEgress())
+			})
+
+			g.It("should have ready operator pods", func() {
+				waitForPodsReadyByLabel(ctx, kubeClient, kasOperatorNamespace, "app=kube-apiserver-operator")
+			})
+		})
+
+		g.Context("in the operand namespace", func() {
+			g.It("should have a default-deny-all policy", func() {
+				policy := getPolicy(kasNamespace, "default-deny")
+				logNetworkPolicyDetails("operand/default-deny", policy)
+				o.Expect(policy).To(BeDefaultDenyPolicy())
+			})
+
+			g.It("should allow egress for guard, installer, pruner, and preflight pods", func() {
+				policy := getPolicy(kasNamespace, "allow-all-egress")
+				logNetworkPolicyDetails("operand/allow-all-egress", policy)
+				o.Expect(policy).To(SelectPodsExpression("app", []string{
+					"guard", "installer", "pruner", "openshift-kms-preflight",
+				}))
+				o.Expect(policy).To(AllowAllTCPEgress())
+			})
+		})
+	})
+
+	g.Context("reconciliation", func() {
+		g.It("should restore deleted NetworkPolicies", func() {
+			policies := []*networkingv1.NetworkPolicy{
+				getPolicy(kasOperatorNamespace, "default-deny"),
+				getPolicy(kasOperatorNamespace, "allow-all-egress-and-metrics-ingress"),
+				getPolicy(kasNamespace, "default-deny"),
+				getPolicy(kasNamespace, "allow-all-egress"),
+			}
+
+			g.By("Deleting all policies and waiting for restoration")
+			deleteAndWaitForAllRestored(ctx, kubeClient, policies)
+		})
+
+		g.It("should reconcile mutated NetworkPolicies", func() {
+			policies := []struct{ namespace, name string }{
+				{kasOperatorNamespace, "default-deny"},
+				{kasOperatorNamespace, "allow-all-egress-and-metrics-ingress"},
+				{kasNamespace, "default-deny"},
+				{kasNamespace, "allow-all-egress"},
+			}
+
+			g.By("Mutating all policies and waiting for reconciliation")
+			mutateAndWaitForAllReconciled(ctx, kubeClient, policies)
+
+			g.By("Checking NetworkPolicy-related events (best-effort)")
+			logNetworkPolicyEvents(ctx, kubeClient,
+				[]string{kasOperatorNamespace, kasNamespace},
+				"allow-all-egress-and-metrics-ingress")
+		})
 	})
 })
-
-func testKubeAPIServerNetworkPolicies() {
-	ctx := context.Background()
-	g.By("Creating Kubernetes clients")
-	kubeConfig := getClientConfigForTest()
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	configClient, err := configclient.NewForConfig(kubeConfig)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	g.By("Waiting for kube-apiserver ClusterOperator to be stable")
-	err = test.WaitForClusterOperatorAvailableNotProgressingNotDegraded(configClient, "kube-apiserver")
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	g.By("Validating NetworkPolicies in openshift-kube-apiserver-operator")
-	operatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, defaultDenyAllPolicyName)
-	logNetworkPolicySummary("kube-apiserver-operator/default-deny-all", operatorDefaultDeny)
-	logNetworkPolicyDetails("kube-apiserver-operator/default-deny-all", operatorDefaultDeny)
-	o.Expect(operatorDefaultDeny).To(BeDefaultDenyPolicy())
-
-	operatorAllowPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, operatorAllowPolicyName)
-	logNetworkPolicySummary("kube-apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
-	logNetworkPolicyDetails("kube-apiserver-operator/"+operatorAllowPolicyName, operatorAllowPolicy)
-	o.Expect(operatorAllowPolicy).To(SelectPods("app", "kube-apiserver-operator"))
-	o.Expect(operatorAllowPolicy).To(AllowIngressOnPort(8443))
-	o.Expect(operatorAllowPolicy).To(AllowAllTCPEgress())
-
-	g.By("Validating NetworkPolicies in openshift-kube-apiserver")
-	operandDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, defaultDenyAllPolicyName)
-	logNetworkPolicySummary("kube-apiserver/default-deny-all", operandDefaultDeny)
-	logNetworkPolicyDetails("kube-apiserver/default-deny-all", operandDefaultDeny)
-	o.Expect(operandDefaultDeny).To(BeDefaultDenyPolicy())
-
-	operandAllowPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, operandAllowPolicyName)
-	logNetworkPolicySummary("kube-apiserver/"+operandAllowPolicyName, operandAllowPolicy)
-	logNetworkPolicyDetails("kube-apiserver/"+operandAllowPolicyName, operandAllowPolicy)
-	o.Expect(operandAllowPolicy).To(SelectPodsExpression("app", []string{"guard", "installer", "pruner", "openshift-kms-preflight"}))
-	o.Expect(operandAllowPolicy).To(AllowAllTCPEgress())
-
-	g.By("Verifying pods are ready in kube-apiserver namespaces")
-	waitForPodsReadyByLabel(ctx, kubeClient, kubeAPIServerOperatorNamespace, "app=kube-apiserver-operator")
-}
-
-func testKubeAPIServerNetworkPolicyReconcile() {
-	ctx := context.Background()
-	g.By("Creating Kubernetes clients")
-	kubeConfig := getClientConfigForTest()
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	g.By("Capturing expected NetworkPolicy specs across all namespaces")
-	expectedOperatorPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, operatorAllowPolicyName)
-	expectedOperandPolicy := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, operandAllowPolicyName)
-	expectedOperatorDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerOperatorNamespace, defaultDenyAllPolicyName)
-	expectedOperandDefaultDeny := getNetworkPolicy(ctx, kubeClient, kubeAPIServerNamespace, defaultDenyAllPolicyName)
-
-	policiesToDelete := []*networkingv1.NetworkPolicy{
-		expectedOperatorPolicy,
-		expectedOperandPolicy,
-		expectedOperatorDefaultDeny,
-		expectedOperandDefaultDeny,
-	}
-
-	g.By("Deleting all NetworkPolicies simultaneously and waiting for restoration")
-	deleteAndWaitForAllRestored(ctx, kubeClient, policiesToDelete)
-
-	g.By("Mutating all NetworkPolicies simultaneously and waiting for reconciliation")
-	policiesToMutate := []struct{ namespace, name string }{
-		{kubeAPIServerOperatorNamespace, operatorAllowPolicyName},
-		{kubeAPIServerNamespace, operandAllowPolicyName},
-		{kubeAPIServerOperatorNamespace, defaultDenyAllPolicyName},
-		{kubeAPIServerNamespace, defaultDenyAllPolicyName},
-	}
-	mutateAndWaitForAllReconciled(ctx, kubeClient, policiesToMutate)
-
-	g.By("Checking NetworkPolicy-related events (best-effort)")
-	logNetworkPolicyEvents(ctx, kubeClient, []string{kubeAPIServerOperatorNamespace, kubeAPIServerNamespace}, operatorAllowPolicyName)
-}

--- a/test/e2e/network_policy_enforcement.go
+++ b/test/e2e/network_policy_enforcement.go
@@ -10,100 +10,156 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
-	g.It("[Serial][Operator][Feature:NetworkPolicy] should enforce NetworkPolicy allow/deny basics in a test namespace", func() {
-		testGenericNetworkPolicyEnforcement()
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator [Serial][Operator][Feature:NetworkPolicy] enforcement", func() {
+	var (
+		ctx        context.Context
+		kubeClient kubernetes.Interface
+	)
+
+	g.BeforeEach(func() {
+		ctx = context.Background()
+		config := getClientConfigForTest()
+		var err error
+		kubeClient, err = kubernetes.NewForConfig(config)
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
-	g.It("[Serial][Operator][Feature:NetworkPolicy] should enforce kube-apiserver-operator NetworkPolicies for cross-namespace traffic", func() {
-		testKubeAPIServerOperatorNetworkPolicyEnforcement()
+
+	withServiceAccount := func(namespace string) {
+		g.GinkgoHelper()
+		_, cleanup := ensureTestServiceAccount(ctx, kubeClient, namespace)
+		g.DeferCleanup(cleanup)
+	}
+
+	g.Context("cross-namespace connectivity to operator metrics port", func() {
+		var operatorPodIPs []string
+
+		g.BeforeEach(func() {
+			g.By("Getting operator pod IPs")
+			pods, err := kubeClient.CoreV1().Pods(kasOperatorNamespace).List(ctx,
+				metav1.ListOptions{LabelSelector: "app=kube-apiserver-operator"})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(pods.Items).NotTo(o.BeEmpty(), "expected at least one operator pod")
+			operatorPodIPs = podIPs(&pods.Items[0])
+		})
+
+		type connectivityCase struct {
+			sourceNS string
+			labels   map[string]string
+			port     int32
+			allowed  bool
+		}
+
+		g.DescribeTable("",
+			func(tc connectivityCase) {
+				withServiceAccount(tc.sourceNS)
+				expectConnectivity(ctx, kubeClient, tc.sourceNS, tc.labels,
+					operatorPodIPs, tc.port, tc.allowed)
+			},
+			g.Entry("monitoring (prometheus) → :8443 (allowed: open ingress, monitoring permits egress)",
+				connectivityCase{
+					sourceNS: "openshift-monitoring",
+					labels:   map[string]string{"app.kubernetes.io/name": "prometheus"},
+					port:     8443,
+					allowed:  true,
+				}),
+			g.Entry("monitoring (any label) → :8443 (allowed: open ingress on 8443)",
+				connectivityCase{
+					sourceNS: "openshift-monitoring",
+					labels:   map[string]string{"app": "any-label"},
+					port:     8443,
+					allowed:  true,
+				}),
+			g.Entry("console → :8443 (allowed: console permits egress)",
+				connectivityCase{
+					sourceNS: "openshift-console",
+					labels:   map[string]string{"custom-app": "test-client"},
+					port:     8443,
+					allowed:  true,
+				}),
+			g.Entry("default → :8443 (allowed: no egress restrictions in default namespace)",
+				connectivityCase{
+					sourceNS: "default",
+					labels:   map[string]string{"test": "client"},
+					port:     8443,
+					allowed:  true,
+				}),
+		)
+	})
+
+	g.Context("basic NetworkPolicy enforcement in a test namespace", func() {
+		var nsName string
+
+		g.BeforeEach(func() {
+			nsName = createTestNamespace(kubeClient.CoreV1().Namespaces(), "np-test-")
+			g.DeferCleanup(func() {
+				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+			})
+			ensureTestServiceAccount(ctx, kubeClient, nsName)
+		})
+
+		g.It("should allow all traffic when no policies exist", func() {
+			serverIPs, cleanup := createServerPod(ctx, kubeClient, nsName,
+				"server", map[string]string{"app": "server"}, 8080)
+			g.DeferCleanup(cleanup)
+
+			expectConnectivity(ctx, kubeClient, nsName,
+				map[string]string{"app": "client"}, serverIPs, 8080, true)
+		})
+
+		g.It("should block traffic after applying default-deny", func() {
+			serverIPs, cleanup := createServerPod(ctx, kubeClient, nsName,
+				"server", map[string]string{"app": "server"}, 8080)
+			g.DeferCleanup(cleanup)
+
+			g.By("Applying default-deny policy")
+			_, err := kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx,
+				defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			expectConnectivity(ctx, kubeClient, nsName,
+				map[string]string{"app": "client"}, serverIPs, 8080, false)
+		})
+
+		g.It("should allow traffic when both ingress and egress rules match", func() {
+			serverLabels := map[string]string{"app": "server"}
+			clientLabels := map[string]string{"app": "client"}
+
+			serverIPs, cleanup := createServerPod(ctx, kubeClient, nsName,
+				"server", serverLabels, 8080)
+			g.DeferCleanup(cleanup)
+
+			g.By("Applying default-deny, then ingress+egress allow rules")
+			_, err := kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx,
+				defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx,
+				allowIngressPolicy("allow-in", nsName, serverLabels, clientLabels, 8080),
+				metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx,
+				allowEgressPolicy("allow-out", nsName, clientLabels, serverLabels, 8080),
+				metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			expectConnectivity(ctx, kubeClient, nsName,
+				clientLabels, serverIPs, 8080, true)
+		})
 	})
 })
 
-func testGenericNetworkPolicyEnforcement() {
-	ctx := context.Background()
-	kubeConfig := getClientConfigForTest()
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+func createServerPod(ctx context.Context, client kubernetes.Interface, namespace, name string, labels map[string]string, port int32) ([]string, func()) {
+	g.GinkgoHelper()
+	pod := netexecPod(name, namespace, labels, port)
+	_, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(waitForPodReady(ctx, client, namespace, name)).NotTo(o.HaveOccurred())
 
-	g.By("Creating a temporary namespace for policy enforcement checks")
-	nsName := createTestNamespace(kubeClient.CoreV1().Namespaces(), "np-enforcement-")
-	g.DeferCleanup(func() {
-		g.GinkgoWriter.Printf("deleting test namespace %s\n", nsName)
-		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
-	})
-
-	g.By("Creating test service account")
-	_, _ = ensureTestServiceAccount(ctx, kubeClient, nsName)
-	// No need to defer cleanup - the entire namespace will be deleted
-
-	serverName := "np-server"
-	clientLabels := map[string]string{"app": "np-client"}
-	serverLabels := map[string]string{"app": "np-server"}
-
-	g.GinkgoWriter.Printf("creating netexec server pod %s/%s\n", nsName, serverName)
-	serverPod := netexecPod(serverName, nsName, serverLabels, 8080)
-	_, err = kubeClient.CoreV1().Pods(nsName).Create(ctx, serverPod, metav1.CreateOptions{})
+	created, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(waitForPodReady(ctx, kubeClient, nsName, serverName)).NotTo(o.HaveOccurred())
+	o.Expect(created.Status.PodIPs).NotTo(o.BeEmpty())
 
-	server, err := kubeClient.CoreV1().Pods(nsName).Get(ctx, serverName, metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(server.Status.PodIPs).NotTo(o.BeEmpty())
-	serverIPs := podIPs(server)
-	g.GinkgoWriter.Printf("server pod %s/%s ips=%v\n", nsName, serverName, serverIPs)
-
-	g.By("Verifying allow-all when no policies select the pod")
-	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
-
-	g.By("Applying default deny and verifying traffic is blocked")
-	g.GinkgoWriter.Printf("creating default-deny policy in %s\n", nsName)
-	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, defaultDenyPolicy("default-deny", nsName), metav1.CreateOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	g.By("Adding ingress allow only and verifying traffic is still blocked")
-	g.GinkgoWriter.Printf("creating allow-ingress policy in %s\n", nsName)
-	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowIngressPolicy("allow-ingress", nsName, serverLabels, clientLabels, 8080), metav1.CreateOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, false)
-
-	g.By("Adding egress allow and verifying traffic is permitted")
-	g.GinkgoWriter.Printf("creating allow-egress policy in %s\n", nsName)
-	_, err = kubeClient.NetworkingV1().NetworkPolicies(nsName).Create(ctx, allowEgressPolicy("allow-egress", nsName, clientLabels, serverLabels, 8080), metav1.CreateOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	expectConnectivity(ctx, kubeClient, nsName, clientLabels, serverIPs, 8080, true)
-}
-
-func testKubeAPIServerOperatorNetworkPolicyEnforcement() {
-	ctx := context.Background()
-	kubeConfig := getClientConfigForTest()
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	g.By("Creating test service accounts in required namespaces")
-	_, cleanupMonitoring := ensureTestServiceAccount(ctx, kubeClient, "openshift-monitoring")
-	g.DeferCleanup(cleanupMonitoring)
-	_, cleanupConsole := ensureTestServiceAccount(ctx, kubeClient, "openshift-console")
-	g.DeferCleanup(cleanupConsole)
-	_, cleanupDefault := ensureTestServiceAccount(ctx, kubeClient, "default")
-	g.DeferCleanup(cleanupDefault)
-
-	g.By("Getting IP of real kube-apiserver-operator pod")
-	pods, err := kubeClient.CoreV1().Pods("openshift-kube-apiserver-operator").List(ctx, metav1.ListOptions{
-		LabelSelector: "app=kube-apiserver-operator",
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(pods.Items).NotTo(o.BeEmpty(), "should have at least one operator pod")
-	kasOperatorIPs := podIPs(&pods.Items[0])
-
-	g.By("Verifying monitoring namespace with prometheus label can access operator metrics")
-	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app.kubernetes.io/name": "prometheus"}, kasOperatorIPs, 8443, true)
-
-	g.By("Verifying monitoring namespace with any label can access operator metrics")
-	expectConnectivity(ctx, kubeClient, "openshift-monitoring", map[string]string{"app": "any-label"}, kasOperatorIPs, 8443, true)
-
-	g.By("Verifying console namespace can access operator metrics")
-	expectConnectivity(ctx, kubeClient, "openshift-console", map[string]string{"custom-app": "test-client"}, kasOperatorIPs, 8443, true)
-
-	g.By("Verifying default namespace can access operator metrics")
-	expectConnectivity(ctx, kubeClient, "default", map[string]string{"test": "client"}, kasOperatorIPs, 8443, true)
+	ips := podIPs(created)
+	return ips, func() {
+		_ = client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
 }

--- a/test/e2e/network_policy_matchers.go
+++ b/test/e2e/network_policy_matchers.go
@@ -1,0 +1,204 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func BeDefaultDenyPolicy() types.GomegaMatcher {
+	return &defaultDenyMatcher{}
+}
+
+type defaultDenyMatcher struct {
+	reason string
+}
+
+func (m *defaultDenyMatcher) Match(actual interface{}) (bool, error) {
+	policy, ok := actual.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return false, fmt.Errorf("expected *NetworkPolicy, got %T", actual)
+	}
+	if len(policy.Spec.PodSelector.MatchLabels) != 0 || len(policy.Spec.PodSelector.MatchExpressions) != 0 {
+		m.reason = fmt.Sprintf("podSelector is not empty: %v", policy.Spec.PodSelector)
+		return false, nil
+	}
+	policyTypes := sets.New[string]()
+	for _, pt := range policy.Spec.PolicyTypes {
+		policyTypes.Insert(string(pt))
+	}
+	if !policyTypes.Has("Ingress") || !policyTypes.Has("Egress") {
+		m.reason = fmt.Sprintf("expected both Ingress and Egress policyTypes, got %v", policy.Spec.PolicyTypes)
+		return false, nil
+	}
+	if len(policy.Spec.Ingress) != 0 {
+		m.reason = fmt.Sprintf("expected no ingress rules, got %d", len(policy.Spec.Ingress))
+		return false, nil
+	}
+	if len(policy.Spec.Egress) != 0 {
+		m.reason = fmt.Sprintf("expected no egress rules, got %d", len(policy.Spec.Egress))
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *defaultDenyMatcher) FailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s to be a default-deny-all policy: %s", p.Namespace, p.Name, m.reason)
+}
+
+func (m *defaultDenyMatcher) NegatedFailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s not to be a default-deny-all policy", p.Namespace, p.Name)
+}
+
+func SelectPods(key, value string) types.GomegaMatcher {
+	return &podSelectorLabelMatcher{key: key, value: value}
+}
+
+type podSelectorLabelMatcher struct {
+	key, value string
+}
+
+func (m *podSelectorLabelMatcher) Match(actual interface{}) (bool, error) {
+	policy, ok := actual.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return false, fmt.Errorf("expected *NetworkPolicy, got %T", actual)
+	}
+	v, ok := policy.Spec.PodSelector.MatchLabels[m.key]
+	return ok && v == m.value, nil
+}
+
+func (m *podSelectorLabelMatcher) FailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s podSelector to have %s=%s, got %v",
+		p.Namespace, p.Name, m.key, m.value, p.Spec.PodSelector.MatchLabels)
+}
+
+func (m *podSelectorLabelMatcher) NegatedFailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s podSelector not to have %s=%s",
+		p.Namespace, p.Name, m.key, m.value)
+}
+
+func SelectPodsExpression(key string, values []string) types.GomegaMatcher {
+	return &podSelectorExprMatcher{key: key, values: values}
+}
+
+type podSelectorExprMatcher struct {
+	key    string
+	values []string
+}
+
+func (m *podSelectorExprMatcher) Match(actual interface{}) (bool, error) {
+	policy, ok := actual.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return false, fmt.Errorf("expected *NetworkPolicy, got %T", actual)
+	}
+	expected := sets.New[string](m.values...)
+	for _, expr := range policy.Spec.PodSelector.MatchExpressions {
+		if expr.Key == m.key && expr.Operator == "In" {
+			if sets.New[string](expr.Values...).Equal(expected) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (m *podSelectorExprMatcher) FailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s podSelector to have expression %s In %v",
+		p.Namespace, p.Name, m.key, m.values)
+}
+
+func (m *podSelectorExprMatcher) NegatedFailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s podSelector not to have expression %s In %v",
+		p.Namespace, p.Name, m.key, m.values)
+}
+
+func AllowIngressOnPort(port int32) types.GomegaMatcher {
+	return &ingressPortMatcher{port: port}
+}
+
+type ingressPortMatcher struct {
+	port int32
+}
+
+func (m *ingressPortMatcher) Match(actual interface{}) (bool, error) {
+	policy, ok := actual.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return false, fmt.Errorf("expected *NetworkPolicy, got %T", actual)
+	}
+	for _, rule := range policy.Spec.Ingress {
+		if len(rule.From) != 0 {
+			continue
+		}
+		for _, p := range rule.Ports {
+			if p.Port != nil && p.Port.IntValue() == int(m.port) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (m *ingressPortMatcher) FailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s to allow ingress from any source on port %d",
+		p.Namespace, p.Name, m.port)
+}
+
+func (m *ingressPortMatcher) NegatedFailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s not to allow ingress from any source on port %d",
+		p.Namespace, p.Name, m.port)
+}
+
+func AllowAllTCPEgress() types.GomegaMatcher {
+	return &egressAllowAllTCPMatcher{}
+}
+
+type egressAllowAllTCPMatcher struct{}
+
+func (m *egressAllowAllTCPMatcher) Match(actual interface{}) (bool, error) {
+	policy, ok := actual.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return false, fmt.Errorf("expected *NetworkPolicy, got %T", actual)
+	}
+	for _, rule := range policy.Spec.Egress {
+		if len(rule.To) != 0 {
+			continue
+		}
+		if len(rule.Ports) == 0 {
+			return true, nil
+		}
+		for _, p := range rule.Ports {
+			if p.Protocol == nil || *p.Protocol == corev1.ProtocolTCP {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (m *egressAllowAllTCPMatcher) FailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	var rules []string
+	for i, rule := range p.Spec.Egress {
+		rules = append(rules, fmt.Sprintf("rule[%d]: to=%d ports=%d", i, len(rule.To), len(rule.Ports)))
+	}
+	return fmt.Sprintf("expected %s/%s to have an allow-all TCP egress rule, got: %s",
+		p.Namespace, p.Name, strings.Join(rules, "; "))
+}
+
+func (m *egressAllowAllTCPMatcher) NegatedFailureMessage(actual interface{}) string {
+	p := actual.(*networkingv1.NetworkPolicy)
+	return fmt.Sprintf("expected %s/%s not to have an allow-all TCP egress rule",
+		p.Namespace, p.Name)
+}


### PR DESCRIPTION
## Summary

Alternative implementation of the NetworkPolicy e2e tests from #2097, restructured for readability:

- **Custom Gomega matchers** (`BeDefaultDenyPolicy()`, `SelectPods()`, `AllowIngressOnPort()`, `AllowAllTCPEgress()`) replace nested helper function chains — assertions read like specs
- **Idiomatic Ginkgo structure** with nested `Describe`/`Context`/`It` and `BeforeEach` for shared setup
- **`DescribeTable`** for the cross-namespace connectivity matrix — each entry documents *why* traffic is allowed or blocked (source namespace egress policies vs operator ingress policy)
- **Proper cleanup** via `DeferCleanup` for service accounts created in system namespaces
- **No global timeout changes** — the shared `WaitPollTimeout` stays at 10m

### Files

| File | Purpose |
|------|---------|
| `test/e2e/network_policy_matchers.go` | Custom Gomega matchers for NetworkPolicy assertions |
| `test/e2e/network_policy_helpers.go` | Connectivity probing, pod creation, reconciliation helpers |
| `test/e2e/network_policy.go` | Conformance + reconciliation tests |
| `test/e2e/network_policy_enforcement.go` | Enforcement tests using DescribeTable |
| `test/library/cluster_operator.go` | Generic `WaitForClusterOperatorAvailableNotProgressingNotDegraded` |
| `cmd/.../main.go` | OTE parallel suite registration |

### Relationship to #2097

This is a sketch/alternative — @kaleemsiddiqu is free to adopt any or all of this in his PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader end-to-end coverage for network policy behavior, including default-deny, pod selection, ingress, and TCP egress checks.
  * Added validation for cross-namespace access to the kube-apiserver metrics endpoint.

* **Bug Fixes**
  * Improved reconciliation checks to confirm deleted or changed network policies are restored correctly.
  * Tightened test coverage for network policy enforcement in temporary namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->