### PR TITLE
WIP: kube-apiserver: set dnsPolicy to ClusterFirstWithHostNet

### DIFF
--- a/bindata/assets/kube-apiserver/pod.yaml
+++ b/bindata/assets/kube-apiserver/pod.yaml
@@ -290,6 +290,7 @@ spec:
       readOnlyRootFilesystem: true
   terminationGracePeriodSeconds: {{.GracefulTerminationDuration}}
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   priority: 2000001000
   priorityClassName: system-node-critical
   tolerations:

--- a/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/kms/vault.go
@@ -3,7 +3,6 @@ package kms
 import (
 	"context"
 	"fmt"
-	"net"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -39,15 +38,9 @@ const (
 )
 
 // DefaultVaultEncryptionProvider returns a ready-to-use Vault KMS EncryptionProvider for e2e tests.
-// It resolves the Vault Service ClusterIP at call time to avoid DNS resolution issues,
-// and bundles the AppRole secret setup.
 func DefaultVaultEncryptionProvider(ctx context.Context, t testing.TB) library.EncryptionProvider {
-	cfg := DefaultVaultKMSPluginConfig
-	// Use the Service ClusterIP instead of DNS name because kube-apiserver pods
-	// cannot resolve cluster-local Service names (they use host network DNS).
-	cfg.KMS.Vault.VaultAddress = getVaultServiceAddress(ctx, t, defaultVaultNamespace)
 	return library.EncryptionProvider{
-		APIServerEncryption: cfg,
+		APIServerEncryption: DefaultVaultKMSPluginConfig,
 		Setup:               ensureVaultAppRoleSecret(defaultVaultNamespace, defaultVaultAppRoleSecretName),
 	}
 }
@@ -194,28 +187,4 @@ func getCurrentKeyVersion(ctx context.Context, t testing.TB) int {
 	return version
 }
 
-// getVaultServiceAddress returns the Vault address using the Service's ClusterIP
-// instead of the DNS name, reading the port and scheme from the Service spec.
-func getVaultServiceAddress(ctx context.Context, t testing.TB, ns string) string {
-	t.Helper()
-	cs := library.GetClients(t)
 
-	svc, err := cs.Kube.CoreV1().Services(ns).Get(ctx, "vault", metav1.GetOptions{})
-	require.NoError(t, err, "failed to get vault Service in namespace %s", ns)
-	require.NotEmpty(t, svc.Spec.ClusterIP, "vault Service has no ClusterIP")
-	require.NotEmpty(t, svc.Spec.Ports, "vault Service has no ports")
-
-	// The Vault Helm chart names the client port "https" (8200).
-	var port *corev1.ServicePort
-	for i := range svc.Spec.Ports {
-		if svc.Spec.Ports[i].Name == "https" {
-			port = &svc.Spec.Ports[i]
-			break
-		}
-	}
-	require.NotNil(t, port, "vault Service has no port named \"https\"")
-
-	addr := fmt.Sprintf("https://%s", net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(port.Port))))
-	t.Logf("Resolved Vault Service address: %s", addr)
-	return addr
-}


### PR DESCRIPTION
According to the Kubernetes documentation [1], pods running with `hostNetwork: true` should set the DNS policy to `ClusterFirstWithHostNet`. Otherwise, pods will fall back to the `Default` DNS policy behavior, inheriting the host's name resolution configuration. This prevents containers in the pod from resolving cluster-internal addresses.

For example, when configuring KMS encryption with a Vault instance running inside the cluster, the `vaultAddress` field in the APIServer resource may reference an in-cluster Service endpoint:

```
  oc patch apiserver cluster --type=merge -p '
    {"spec":{"encryption":{"type":"KMS","kms":{"type":"Vault","vault":{
      "vaultAddress":"https://vault.vault-namespace.svc:8200",
      ...
    }}}}}'
```

Without `ClusterFirstWithHostNet`, the `kube-apiserver` pod cannot resolve `vault.vault-namespace.svc`, causing KMS plugin connectivity failures.

Co-locating the Vault KMS instance with the cluster it serves **is not recommended**, but it is common in CI environments and should not be restricted. The DNS policy should be correct regardless of where Vault is deployed.

[1] https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * DNS policy for the API server pod changed to ClusterFirstWithHostNet when host networking is enabled, improving DNS resolution consistency and ensuring cluster DNS is used reliably for hostname and service lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->