### PR TITLE
CNTRLPLANE-3518: add openshift/kms parent to kms test suites

### DIFF
--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -87,6 +87,7 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/cluster-kube-apiserver-operator/encryption-kms",
+		Parents:     []string{"openshift/kms"},
 		Parallelism: 1,
 		Qualifiers: []string{
 			`name.contains("KMSEncryption")`,
@@ -95,6 +96,7 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/cluster-kube-apiserver-operator/encryption-kms-rotation",
+		Parents:     []string{"openshift/kms"},
 		Parallelism: 1,
 		Qualifiers: []string{
 			`name.contains("[Suite:encryption-kms-rotation]")`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved organization of encryption-kms test suites by establishing proper hierarchy within the test registry structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->