### PR TITLE
Fake bump for kms to kms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,4 +135,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+replace (
+	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+	github.com/openshift/library-go => github.com/ardaguclu/library-go v0.0.0-20260615055813-c299071bcf84
+)

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
+github.com/ardaguclu/library-go v0.0.0-20260615055813-c299071bcf84 h1:m9O8J5EpVaFryyxVVWOVuj/d+wsXSFin0VeZ6ms+fYM=
+github.com/ardaguclu/library-go v0.0.0-20260615055813-c299071bcf84/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -165,8 +167,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a h1:EKx2XhOKehd1C5ptY7IrLl4WV35E8kP0pRPnG5BUZXk=
 github.com/openshift/client-go v0.0.0-20260512113608-deb4dc54551a/go.mod h1:V933kvY/cb/Un7UCEOhXHUySNX327u7Epe8g9KNqg2Q=
-github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f h1:1wVATH1wpPdtryIhjtngrHKi4d0ucrN2o0IIZAoHPTw=
-github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -3,7 +3,6 @@ package e2e_encryption_kms
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"testing"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -82,7 +81,7 @@ func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
 		ResourceName:                   "SecretOfLife",
 		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
 			librarykms.DefaultVaultEncryptionProvider(ctx, t),
-			library.SupportedStaticEncryptionProviders[rand.IntN(len(library.SupportedStaticEncryptionProviders))],
+			librarykms.SecondaryVaultEncryptionProvider(ctx, t),
 		}),
 	})
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -199,9 +199,18 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	// fills up the state with all resources and set identity write key if write key secrets
 	// are missing.
 
+	var providerCfg kmsProviderConfig = noopKMSProviderConfig{}
+	if currentMode == state.KMS {
+		var err error
+		providerCfg, err = newKMSProviderConfig(apiEncryptionConfiguration.KMS)
+		if err != nil {
+			return err
+		}
+	}
+
 	var commonReason *string
 	for gr, grKeys := range desiredEncryptionState {
-		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs)
+		latestKeyID, internalReason, needed := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, providerCfg)
 		if !needed {
 			continue
 		}
@@ -228,7 +237,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 
 	sort.Sort(sort.StringSlice(reasons))
 	internalReason := strings.Join(reasons, ", ")
-	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, internalReason, externalReason)
+	keySecret, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, providerCfg, internalReason, externalReason)
 	if err != nil {
 		return fmt.Errorf("failed to create key: %v", err)
 	}
@@ -265,7 +274,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 	return nil // we made this key earlier
 }
 
-func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, internalReason, externalReason string) (*corev1.Secret, error) {
+func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, providerCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -285,11 +294,6 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 				Timeout:    &metav1.Duration{Duration: defaultKMSTimeout},
 			},
 			Plugin: apiServerEncryption.KMS,
-		}
-
-		providerCfg, err := newKMSProviderConfig(apiServerEncryption.KMS)
-		if err != nil {
-			return nil, err
 		}
 
 		if secretName, expectedKeys, err := providerCfg.referencedSecretName(); err != nil {
@@ -363,7 +367,7 @@ func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Cont
 
 // needsNewKey checks whether a new key must be created for the given resource. If true, it also returns the latest
 // used key ID and a reason string.
-func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource) (uint64, string, bool) {
+func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, externalReason string, encryptedGRs []schema.GroupResource, providerCfg kmsProviderConfig) (uint64, string, bool) {
 	// we always need to have some encryption keys unless we are turned off
 	if len(grKeys.ReadKeys) == 0 {
 		return 0, "key-does-not-exist", currentMode != state.Identity
@@ -408,13 +412,19 @@ func needsNewKey(grKeys state.GroupResourceState, currentMode state.Mode, extern
 
 	if currentMode == state.KMS {
 		// We are here because Encryption Mode is not changed
+		// However, we need to create a new key if migration-triggering fields
+		// in the KMS provider configuration have changed.
+		if latestKey.KMS == nil {
+			// A KMS-mode key without KMS state indicates a corrupted key secret.
+			// Trigger a new key to self-heal; the reason surfaces in events and logs.
+			return latestKeyID, "kms-state-missing-from-latest-key", true
+		}
+		if providerCfg.migrationRequired(latestKey.KMS.Plugin) {
+			return latestKeyID, "kms-provider-changed", true
+		}
 
-		// For now in Tech Preview v1, we don't support configurational changes. Therefore,
-		// it is pointless comparing the secrets.
-
-		// For KMS mode, we don't do time-based rotation. Therefore, we shortcut here
-		// KMS keys are rotated externally by the KMS system.
-		// Moreover, we don't trigger new key when external reason is changed.
+		// For KMS mode, we don't do time-based rotation. KMS keys are rotated
+		// externally by the KMS provider. Moreover, we don't trigger new key when external reason is changed.
 		// Because it would lead to duplicate providers which is not allowed.
 		return 0, "", false
 	}
@@ -440,7 +450,18 @@ type kmsProviderConfig interface {
 	// config and the specific data keys to carry from that configmap. Only the listed keys
 	// are copied into the Key Secret; any other data in the referenced configmap is ignored.
 	referencedConfigMapName() (string, []string, error)
+	// migrationRequired reports whether switching from latest (stored in
+	// the key secret) to this provider config requires a new encryption key.
+	migrationRequired(latest configv1.KMSPluginConfig) bool
 }
+
+// noopKMSProviderConfig is a safe zero-value implementation used for non-KMS modes.
+// All methods return empty/false so callers never need nil checks.
+type noopKMSProviderConfig struct{}
+
+func (noopKMSProviderConfig) referencedSecretName() (string, []string, error)    { return "", nil, nil }
+func (noopKMSProviderConfig) referencedConfigMapName() (string, []string, error) { return "", nil, nil }
+func (noopKMSProviderConfig) migrationRequired(configv1.KMSPluginConfig) bool    { return false }
 
 func newKMSProviderConfig(plugin configv1.KMSPluginConfig) (kmsProviderConfig, error) {
 	switch plugin.Type {
@@ -471,6 +492,30 @@ func (v *vaultProviderConfig) referencedConfigMapName() (string, []string, error
 		return "", nil, nil
 	}
 	return v.vault.TLS.CABundle.Name, []string{"ca-bundle.crt"}, nil
+}
+
+func (v *vaultProviderConfig) migrationRequired(latest configv1.KMSPluginConfig) bool {
+	if latest.Type != configv1.VaultKMSProvider {
+		klog.V(2).Infof("KMS migration required: provider type changed from %q to %q", latest.Type, configv1.VaultKMSProvider)
+		return true
+	}
+	if v.vault.VaultAddress != latest.Vault.VaultAddress {
+		klog.V(2).Infof("KMS migration required: VaultAddress changed from %q to %q", latest.Vault.VaultAddress, v.vault.VaultAddress)
+		return true
+	}
+	if v.vault.VaultNamespace != latest.Vault.VaultNamespace {
+		klog.V(2).Infof("KMS migration required: VaultNamespace changed from %q to %q", latest.Vault.VaultNamespace, v.vault.VaultNamespace)
+		return true
+	}
+	if v.vault.TransitMount != latest.Vault.TransitMount {
+		klog.V(2).Infof("KMS migration required: TransitMount changed from %q to %q", latest.Vault.TransitMount, v.vault.TransitMount)
+		return true
+	}
+	if v.vault.TransitKey != latest.Vault.TransitKey {
+		klog.V(2).Infof("KMS migration required: TransitKey changed from %q to %q", latest.Vault.TransitKey, v.vault.TransitKey)
+		return true
+	}
+	return false
 }
 
 // TODO make this un-settable once set

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -107,7 +107,7 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 		t.Logf("APIServer is already configured to use %q mode", provider.Type)
 	}
 
-	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)
+	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, needsUpdate, defaultTargetGRs, namespace, labelSelector)
 	return clientSet
 }
 
@@ -126,7 +126,7 @@ func GetClients(t testing.TB) ClientSet {
 	return ClientSet{Etcd: etcdClient, ApiServerConfig: apiServerConfigClient, Kube: kubeClient}
 }
 
-func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, encryptionType configv1.EncryptionType, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) {
+func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, prevKeyMeta EncryptionKeyMeta, encryptionType configv1.EncryptionType, configChanged bool, defaultTargetGRs []schema.GroupResource, namespace, labelSelector string) {
 	encryptionMode := string(encryptionType)
 	if encryptionMode == "" {
 		encryptionMode = defaultEncryptionMode
@@ -135,7 +135,7 @@ func WaitForEncryptionKeyBasedOn(t testing.TB, kubeClient kubernetes.Interface, 
 		prevKeyMeta.Mode = defaultEncryptionMode
 	}
 
-	if prevKeyMeta.Mode == encryptionMode {
+	if prevKeyMeta.Mode == encryptionMode && !configChanged {
 		WaitForNoNewEncryptionKey(t, kubeClient, prevKeyMeta, namespace, labelSelector)
 		return
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -407,7 +407,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f
+# github.com/openshift/library-go v0.0.0-20260612181855-acbfa3c5590f => github.com/ardaguclu/library-go v0.0.0-20260615055813-c299071bcf84
 ## explicit; go 1.25.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -1699,3 +1699,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+# github.com/openshift/library-go => github.com/ardaguclu/library-go v0.0.0-20260615055813-c299071bcf84


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded KMS encryption migration coverage by adding a secondary vault encryption provider to the randomized provider-order test scenarios.

* **Chores**
  * Updated module dependency replacement handling in `go.mod`, consolidating an existing replacement into a parenthesized block and adding a new redirect for `github.com/openshift/library-go` to `github.com/ardaguclu/library-go` (version unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->