### PR TITLE
Enable watch termination grace period (redux).

### DIFF
--- a/bindata/assets/config/defaultconfig.yaml
+++ b/bindata/assets/config/defaultconfig.yaml
@@ -161,6 +161,8 @@ apiServerArguments:
     - 70s # give SDN some time to converge: 30s for iptable lock contention, 25s for the second try and some seconds for AWS to update ELBs
   shutdown-send-retry-after:
   - "true"
+  shutdown-watch-termination-grace-period:
+    - 5s # shorter than the pod graceful termination period on single-node
   storage-backend:
     - etcd3
   storage-media-type:


### PR DESCRIPTION
This should mostly eliminate aligned informer re-lists during kube-apiserver rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new default configuration setting for API server shutdown termination grace period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->