### PR TITLE
CNTRLPLANE-3721: Add developer/agent documentation: CONTRIBUTING.md, AGENTS.md, ARCHITECTURE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,5 +66,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines. Key rules:
 ## Testing
 
 - **Unit tests:** co-located `*_test.go` files, table-driven, `go test ./pkg/... ./cmd/...`
-- **E2E tests:** suites under `test/e2e*/`, each with its own Makefile target. `test/e2e/` and `test/e2e-encryption-kms/` use Ginkgo v2; the rest use standard Go testing.
+- **E2E tests:** suites under `test/e2e*/`, each with its own Makefile target. `test/e2e/` and `test/e2e-encryption-kms/` contain Ginkgo v2 specs for the OTE framework; `test/e2e/` also has standard Go test files. The remaining directories use standard Go testing only.
 - **OTE framework:** `cluster-kube-apiserver-operator-tests-ext` binary. See [CONTRIBUTING.md](CONTRIBUTING.md#openshift-tests-extension-ote) for usage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ make verify                      # Formatting, vetting, golang version checks
 make test-e2e                    # E2E operator tests (3h timeout, serial)
 make test-e2e-encryption-aescbc  # Encryption tests with aescbc provider (4h)
 make test-e2e-encryption-kms     # KMS encryption tests (4h)
+make update-bindata-v4.1.0       # Copy apirequestcounts CRD from vendor/
+make verify-bindata-v4.1.0       # Verify apirequestcounts CRD is in sync
 ```
 
 Go version: see `go.mod`.
@@ -21,12 +23,12 @@ Go version: see `go.mod`.
 
 | Directory | Purpose |
 |-----------|---------|
-| `cmd/cluster-kube-apiserver-operator/` | Operator binary entry point (operator, render, installer, pruner, startup-monitor, cert controllers) |
-| `cmd/cluster-kube-apiserver-operator-tests-ext/` | OTE test runner entry point |
+| `cmd/cluster-kube-apiserver-operator/` | Operator binary entry point (operator, render, installer, pruner, startup-monitor, cert controllers, and more) |
+| `cmd/cluster-kube-apiserver-operator-tests-ext/` | OpenShift Tests Extension (OTE) test runner entry point |
 | `pkg/operator/starter.go` | Operator initialization — creates clients, informers, and starts all controllers |
 | `pkg/operator/targetconfigcontroller/` | Renders observed config + defaults into kube-apiserver ConfigMaps/Secrets |
-| `pkg/operator/configobservation/` | Configuration observers — each subdirectory watches a cluster resource type |
-| `pkg/operator/certrotationcontroller/` | Certificate rotation for serving, LB, aggregator, and kubelet certs |
+| `pkg/operator/configobservation/` | Configuration observers — each observer watches a cluster state to infer the operand config |
+| `pkg/operator/certrotationcontroller/` | Certificate rotation for serving, LB, aggregator, kubelet, etc. certs |
 | `pkg/operator/resourcesynccontroller/` | Syncs ConfigMaps/Secrets between namespaces |
 | `pkg/operator/operatorclient/` | Namespace constants and operator client interfaces |
 | `pkg/cmd/render/` | Bootstrap manifest renderer for cluster installation |
@@ -48,8 +50,7 @@ Config observers follow a specific pattern: each observer function receives the 
 - **Logging:** `k8s.io/klog/v2` with verbosity levels
 - **Error handling:** wrap with `fmt.Errorf("context: %w", err)`
 - **Feature gates:** controllers that depend on feature gates use `FeatureGateAccessor` from library-go; wait for gates before starting
-- **Cert rotation:** `Refresh` should be ~80% of `Validity`. The `certificates.openshift.io/refresh-period` annotation is informational — actual rotation is decided by `notBefore`/`notAfter` on the secret. Cert rotation logic lives in `library-go/pkg/operator/certrotation/`.
-- **API enablement:** `defaultGroupVersionsByFeatureGate` in `pkg/operator/configobservation/apienablement/` maps feature gates to API GroupVersions for `--runtime-config`. The vendored kube version is `k8s.io/component-base/version.DefaultKubeBinaryVersion`. Do not use `Scheme.PrioritizedVersionsForGroup` for version ordering — it returns registration order, not semantic order.
+- **Cert rotation:** `Refresh` relative to `Validity` varies per certificate (e.g. ~50% for short-lived certs, ~80% for long-lived ones). The `certificates.openshift.io/refresh-period` annotation is informational — actual rotation is decided by `notBefore`/`notAfter` on the secret. Cert rotation logic lives in `library-go/pkg/operator/certrotation/`.
 - **Upstream changes:** controllers that wrap library-go functionality should have fixes made upstream in [library-go](https://github.com/openshift/library-go), not here
 
 ## Contributing
@@ -58,9 +59,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines. Key rules:
 
 - Do not modify files under `vendor/`. Use `go mod tidy && go mod vendor`.
 - `bindata/assets.go` uses Go's `embed` directive to embed asset files — update the embedded files, not this file.
-- The `apirequestcounts` CRD in bindata is copied from `vendor/`; use `make update-bindata-v4.1.0` to refresh and `make verify-bindata-v4.1.0` to check.
 - Write unit tests for every change. E2E tests for significant features.
 - Backwards compatibility matters — deprecate before removing.
+- Before modifying the operator API, ensure there is a corresponding enhancement proposal in [openshift/enhancements](https://github.com/openshift/enhancements). API changes require design review and approval.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Cluster Kube API Server Operator
+
+A static pod operator that manages the lifecycle of `kube-apiserver` on OpenShift control plane nodes. Built on the [library-go](https://github.com/openshift/library-go) static pod operator framework, it observes cluster configuration, rotates certificates, manages encryption at rest, and reconciles the target kube-apiserver config into static pod manifests. Installed by the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full design and data flow.
+
+## Build and Test
+
+```bash
+make build                       # Build all binaries (operator + OTE test runner)
+make test                        # Unit tests (./pkg/... ./cmd/...)
+make verify                      # Formatting, vetting, golang version checks
+make test-e2e                    # E2E operator tests (3h timeout, serial)
+make test-e2e-encryption-aescbc  # Encryption tests with aescbc provider (4h)
+make test-e2e-encryption-kms     # KMS encryption tests (4h)
+```
+
+Go version: see `go.mod`.
+
+## Project Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `cmd/cluster-kube-apiserver-operator/` | Operator binary entry point (operator, render, installer, pruner, startup-monitor, cert controllers) |
+| `cmd/cluster-kube-apiserver-operator-tests-ext/` | OTE test runner entry point |
+| `pkg/operator/starter.go` | Operator initialization — creates clients, informers, and starts all controllers |
+| `pkg/operator/targetconfigcontroller/` | Renders observed config + defaults into kube-apiserver ConfigMaps/Secrets |
+| `pkg/operator/configobservation/` | Configuration observers — each subdirectory watches a cluster resource type |
+| `pkg/operator/certrotationcontroller/` | Certificate rotation for serving, LB, aggregator, and kubelet certs |
+| `pkg/operator/resourcesynccontroller/` | Syncs ConfigMaps/Secrets between namespaces |
+| `pkg/operator/operatorclient/` | Namespace constants and operator client interfaces |
+| `pkg/cmd/render/` | Bootstrap manifest renderer for cluster installation |
+| `pkg/recovery/` | Disaster recovery API server pod generation |
+| `bindata/` | Embedded assets: default config, static pod template, alerts, RBAC, bootstrap manifests |
+| `manifests/` | CVO deployment manifests (namespace, deployment, RBAC, ServiceMonitors) |
+| `test/e2e*/` | E2E test suites (operator, encryption, encryption-rotation, encryption-perf, KMS, SNO) |
+| `test/library/` | Shared test utilities |
+
+## Controller Pattern
+
+Controllers use the library-go `factory.Controller` base. Each controller has a `sync(ctx, syncContext)` method called by the framework on informer events or periodic resyncs. The operator wires them in `pkg/operator/starter.go` via `RunOperator()`.
+
+Config observers follow a specific pattern: each observer function receives the existing config and returns `(observedConfig, errors)`. Observers are registered in `pkg/operator/configobservation/configobservercontroller/observe_config_controller.go`.
+
+## Key Conventions
+
+- **Namespaces:** `openshift-kube-apiserver-operator` (operator), `openshift-kube-apiserver` (operand), `openshift-config` (user config), `openshift-config-managed` (platform config). Constants in `pkg/operator/operatorclient/interfaces.go`.
+- **Logging:** `k8s.io/klog/v2` with verbosity levels
+- **Error handling:** wrap with `fmt.Errorf("context: %w", err)`
+- **Feature gates:** controllers that depend on feature gates use `FeatureGateAccessor` from library-go; wait for gates before starting
+- **Cert rotation:** `Refresh` should be ~80% of `Validity`. The `certificates.openshift.io/refresh-period` annotation is informational — actual rotation is decided by `notBefore`/`notAfter` on the secret. Cert rotation logic lives in `library-go/pkg/operator/certrotation/`.
+- **API enablement:** `defaultGroupVersionsByFeatureGate` in `pkg/operator/configobservation/apienablement/` maps feature gates to API GroupVersions for `--runtime-config`. The vendored kube version is `k8s.io/component-base/version.DefaultKubeBinaryVersion`. Do not use `Scheme.PrioritizedVersionsForGroup` for version ordering — it returns registration order, not semantic order.
+- **Upstream changes:** controllers that wrap library-go functionality should have fixes made upstream in [library-go](https://github.com/openshift/library-go), not here
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines. Key rules:
+
+- Do not modify files under `vendor/`. Use `go mod tidy && go mod vendor`.
+- `bindata/assets.go` uses Go's `embed` directive to embed asset files — update the embedded files, not this file.
+- The `apirequestcounts` CRD in bindata is copied from `vendor/`; use `make update-bindata-v4.1.0` to refresh and `make verify-bindata-v4.1.0` to check.
+- Write unit tests for every change. E2E tests for significant features.
+- Backwards compatibility matters — deprecate before removing.
+
+## Testing
+
+- **Unit tests:** co-located `*_test.go` files, table-driven, `go test ./pkg/... ./cmd/...`
+- **E2E tests:** suites under `test/e2e*/`, each with its own Makefile target. `test/e2e/` and `test/e2e-encryption-kms/` use Ginkgo v2; the rest use standard Go testing.
+- **OTE framework:** `cluster-kube-apiserver-operator-tests-ext` binary. See [CONTRIBUTING.md](CONTRIBUTING.md#openshift-tests-extension-ote) for usage.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,7 @@ The operator uses library-go's `staticpod.NewBuilder()` to manage kube-apiserver
 - **Pruner** — removes old static pod revisions to free disk space.
 - **PDB guard** — ensures availability during upgrades (only on multi-node clusters; disabled for single-node).
 - **Min ready duration** — waits 30 seconds before considering a pod ready.
-- **Startup monitor** — tracks kube-apiserver startup progress, with KMS-awareness.
+- **Startup monitor** — tracks kube-apiserver startup progress and can trigger rollback on failed revisions. Enabled on single-node clusters or via unsupported config override.
 
 Resources are split into two categories:
 - **Revisioned** — ConfigMaps and Secrets that trigger a new revision when changed (config, pod manifest, certs, audit policies, encryption config).
@@ -122,6 +122,12 @@ The target config controller validates that required configuration is present (e
 - **Internal load balancer cert** — HTTPS serving for internal LB (dynamically tracks hostnames)
 - **Aggregator client cert** — client cert for aggregated API servers
 - **Kubelet client cert** — client cert for kubelet communication
+- **Localhost recovery serving cert** — HTTPS serving for the localhost recovery SNI endpoint
+- **Kube-controller-manager client cert** — client cert for KCM to authenticate to kube-apiserver
+- **Kube-scheduler client cert** — client cert for KS to authenticate to kube-apiserver
+- **Control plane node admin client cert** — client cert for the control plane node kubeconfig
+- **Check-endpoints client cert** — client cert for the network connectivity checker
+- **Node system admin client cert** — long-lived `system:admin` client cert placed on each master for debugging
 
 Load balancer certificates use dynamic hostname tracking (`externalloadbalancer.go`, `internalloadbalancer.go`) to add SANs as new endpoints appear.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,169 @@
+# Architecture
+
+## Overview
+
+The cluster-kube-apiserver-operator is a static pod operator that manages the `kube-apiserver` on OpenShift control plane nodes. It is deployed by the Cluster Version Operator (CVO) and uses the [library-go](https://github.com/openshift/library-go) static pod operator framework.
+
+The operator's primary responsibilities:
+- Observe cluster configuration from multiple sources and synthesize kube-apiserver config
+- Manage kube-apiserver static pods across control plane nodes (install, revision, prune)
+- Rotate certificates (serving, load balancer, aggregator, kubelet)
+- Manage encryption at rest (secrets, configmaps) with optional KMS support
+- Report status via the `ClusterOperator/kube-apiserver` resource
+
+## Data Flow
+
+```text
+ config.openshift.io resources          Secrets/ConfigMaps
+ (APIServer, Authentication, Network,   (etcd certs, SA signing keys,
+  Images, Infrastructure, Nodes, ...)    user-provided CAs, ...)
+              │                                    │
+              ▼                                    ▼
+   ┌──────────────────────────────────────────────────┐
+   │              Config Observer Controllers          │
+   │  (observe external state, produce observedConfig) │
+   └──────────────────────┬───────────────────────────┘
+                          │ observedConfig (sparse JSON)
+                          ▼
+   ┌──────────────────────────────────────────────────┐
+   │           Target Config Controller                │
+   │  (merge defaults + observedConfig + overrides     │
+   │   → render ConfigMaps/Secrets in target ns)       │
+   └──────────────────────┬───────────────────────────┘
+                          │ ConfigMaps, Secrets
+                          ▼
+   ┌──────────────────────────────────────────────────┐
+   │          Static Pod Controllers (library-go)      │
+   │  Installer → Revision Controller → Pruner         │
+   │  (roll out new revisions to each control plane    │
+   │   node as static pod manifests)                   │
+   └──────────────────────┬───────────────────────────┘
+                          │
+                          ▼
+              kube-apiserver static pods
+              (one per control plane node)
+```
+
+## Operator Startup
+
+Entry point: `cmd/cluster-kube-apiserver-operator/main.go` → `pkg/cmd/operator/cmd.go` → `pkg/operator/starter.go:RunOperator()`.
+
+Startup sequence:
+1. Create clients (Kubernetes, dynamic, config, security, operator control plane, API extensions, migration)
+2. Create informers for watched namespaces (see [Namespaces](#namespaces))
+3. Detect infrastructure topology (single-replica, dual-replica, HA) for conditional behavior
+4. Initialize feature gates via `FeatureGateAccessor` and wait for observation (1-minute timeout)
+5. Create and start all controllers concurrently
+6. Block until context cancellation
+
+## Namespaces
+
+| Namespace | Constant | Purpose |
+|-----------|----------|---------|
+| `openshift-config` | `GlobalUserSpecifiedConfigNamespace` | User-provided configuration (certs, CAs, auth config) |
+| `openshift-config-managed` | `GlobalMachineSpecifiedConfigNamespace` | Platform-managed configuration (generated CAs, signing certs) |
+| `openshift-kube-apiserver-operator` | `OperatorNamespace` | Operator deployment and its resources |
+| `openshift-kube-apiserver` | `TargetNamespace` | Operand: kube-apiserver pods, config, certs |
+
+The `ResourceSyncController` copies ConfigMaps and Secrets between these namespaces as needed (e.g. etcd certs from `openshift-config` to the target namespace).
+
+## Static Pod Management
+
+The operator uses library-go's `staticpod.NewBuilder()` to manage kube-apiserver static pods. This framework provides:
+
+- **Installer controller** — creates new static pod revisions on each control plane node. Uses a custom installer command (`cluster-kube-apiserver-operator installer`) with error injection support for testing.
+- **Revision controller** — tracks revisions of ConfigMaps and Secrets. When any revisioned resource changes, a new revision is created. The first ConfigMap in the list (`kube-apiserver-pod`) contains the static pod manifest template.
+- **Pruner** — removes old static pod revisions to free disk space.
+- **PDB guard** — ensures availability during upgrades (only on multi-node clusters; disabled for single-node).
+- **Min ready duration** — waits 30 seconds before considering a pod ready.
+- **Startup monitor** — tracks kube-apiserver startup progress, with KMS-awareness.
+
+Resources are split into two categories:
+- **Revisioned** — ConfigMaps and Secrets that trigger a new revision when changed (config, pod manifest, certs, audit policies, encryption config).
+- **Unrevisioned certs** — ConfigMaps and Secrets managed by `WithUnrevisionedCerts` that are updated in-place without triggering a revision (CA bundles, serving certs, client certs, signing keys, user-provided serving certs). See `CertConfigMaps` and `CertSecrets` in `starter.go` for the full list.
+
+## Configuration Observers
+
+Configuration observers watch external cluster resources and produce a sparse JSON config (`observedConfig`) that gets merged into the kube-apiserver configuration. Each observer function receives the existing config and returns `(observedConfig, errors)`.
+
+Observers are registered in `pkg/operator/configobservation/configobservercontroller/observe_config_controller.go`. They are organized by the resource type they watch:
+
+| Package | Watches | Config paths set |
+|---------|---------|-----------------|
+| `apiserver/` | `APIServer` CR | Named certificates, CORS, TLS profile, shutdown delay, graceful termination, admission plugins, event TTL, GOAWAY chance |
+| `auth/` | `Authentication` CR | Auth metadata, SA issuer, webhook authenticator, external OIDC, pod security enforcement |
+| `etcdendpoints/` | etcd endpoints in `openshift-etcd` | `etcd-servers` |
+| `images/` | `Image` CR | Internal/external registry hostnames, allowed registries for import |
+| `network/` | `Network` CR | Restricted CIDRs, services subnet, external IP policy, NodePort range |
+| `node/` | `Node` CR | Minimum kubelet version, authorization modes, latency profile |
+| `scheduler/` | `Scheduler` CR | Default node selector |
+| `apienablement/` | `FeatureGate` CR | `runtime-config`, `feature-gates` (Kubernetes API enablement) |
+
+Several observers are feature-gated and only activate when the corresponding feature gate is enabled.
+
+## Target Config Controller
+
+`pkg/operator/targetconfigcontroller/` takes the merged configuration (defaults + observedConfig + unsupportedConfigOverrides) and renders it into concrete resources in the target namespace:
+
+- `config` ConfigMap — the main kube-apiserver configuration
+- `kube-apiserver-pod` ConfigMap — the static pod manifest template
+- CA bundle and server CA ConfigMaps
+- Recovery serving cert and client token Secrets
+
+The target config controller validates that required configuration is present (etcd servers, certs, admission plugins) before rendering.
+
+## Certificate Rotation
+
+`pkg/operator/certrotationcontroller/` manages certificate rotation for:
+
+- **Localhost serving cert** — HTTPS serving on localhost
+- **Service network serving cert** — HTTPS serving on the service network
+- **External load balancer cert** — HTTPS serving for external LB (dynamically tracks hostnames)
+- **Internal load balancer cert** — HTTPS serving for internal LB (dynamically tracks hostnames)
+- **Aggregator client cert** — client cert for aggregated API servers
+- **Kubelet client cert** — client cert for kubelet communication
+
+Load balancer certificates use dynamic hostname tracking (`externalloadbalancer.go`, `internalloadbalancer.go`) to add SANs as new endpoints appear.
+
+A separate `CertRotationTimeUpgradeableController` blocks cluster upgrades if certificates are about to expire during the upgrade window.
+
+## Encryption
+
+The operator manages encryption at rest for `secrets` and `configmaps` resources using library-go's encryption framework:
+
+- **Providers** — supports `aescbc` and `aesgcm` encryption providers, plus optional KMS
+- **Deployer** — `RevisionLabelPodDeployer` deploys encryption config via static pod revisions
+- **Migrator** — uses `kube-storage-version-migrator` to re-encrypt existing resources when keys rotate
+- **KMS support** — dedicated commands for KMS health checking (`kms-health`) and preflight validation (`kms-preflight`)
+
+## Recovery
+
+`pkg/recovery/` provides a disaster recovery mechanism that creates a temporary recovery kube-apiserver pod:
+
+- Copies the main kube-apiserver pod manifest and modifies it for recovery
+- Generates short-lived (7-day) self-signed certificates
+- Creates an admin kubeconfig for recovery access
+- Stores recovery resources in `{StaticPodResourcesDir}/recovery-kube-apiserver-pod/`
+
+## Render Command
+
+`pkg/cmd/render/` is a bootstrap manifest renderer used during cluster installation. It takes installer-provided inputs (etcd URLs, images, cluster CIDRs, feature gates) and renders the initial set of manifests needed to bootstrap kube-apiserver before the operator is running. The templates live in `bindata/bootkube/`.
+
+## Other Controllers
+
+| Controller | Purpose |
+|-----------|---------|
+| `StaticResourceController` | Applies static manifests from `bindata/` (namespace, service, RBAC, alerts, network policies) |
+| `ClusterOperatorStatus` | Reports operator status, versions, and related objects to `ClusterOperator/kube-apiserver` |
+| `ConnectivityCheckController` | Validates API server endpoint connectivity from pods |
+| `KubeletVersionSkewController` | Validates kubelet version compatibility with the API server |
+| `BoundSATokenSignerController` | Manages bound service account token signing keys |
+| `AuditPolicyController` | Manages audit policy configuration |
+| `TerminationObserver` | Tracks graceful termination metrics and late connection events |
+| `WebhookSupportabilityController` | Validates webhook configurations and reports issues |
+| `ServiceAccountIssuerController` | Syncs service account issuer configuration |
+| `PodSecurityReadinessController` | Tracks pod security admission readiness |
+| `HighCpuUsageAlertController` | Monitors and alerts on high API server CPU usage |
+| `SCCReconcileController` | Reconciles SecurityContextConstraints |
+| `LatencyProfileController` | Applies latency profile settings from node configuration |
+| `NodeKubeconfigController` | Generates per-node kubeconfigs |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Observers are registered in `pkg/operator/configobservation/configobservercontro
 
 | Package | Watches | Config paths set |
 |---------|---------|-----------------|
-| `apiserver/` | `APIServer` CR | Named certificates, CORS, TLS profile, shutdown delay, graceful termination, admission plugins, event TTL, GOAWAY chance |
+| `apiserver/` | `APIServer` CR | Named certificates, user client CA bundle, CORS, shutdown delay, graceful termination, send-retry-after, admission plugins, event TTL, GOAWAY chance |
 | `auth/` | `Authentication` CR | Auth metadata, SA issuer, webhook authenticator, external OIDC, pod security enforcement |
 | `etcdendpoints/` | etcd endpoints in `openshift-etcd` | `etcd-servers` |
 | `images/` | `Image` CR | Internal/external registry hostnames, allowed registries for import |
@@ -98,6 +98,10 @@ Observers are registered in `pkg/operator/configobservation/configobservercontro
 | `node/` | `Node` CR | Minimum kubelet version, authorization modes, latency profile |
 | `scheduler/` | `Scheduler` CR | Default node selector |
 | `apienablement/` | `FeatureGate` CR | `runtime-config`, `feature-gates` (Kubernetes API enablement) |
+| *(library-go)* `cloudprovider` | `Infrastructure` CR | Cloud provider configuration |
+| *(library-go)* `proxy` | `Proxy` CR | Proxy configuration |
+| *(library-go)* `encryption` | Encryption config Secret | Encryption config path |
+| *(library-go)* `apiserver` | `APIServer` CR | TLS security profile |
 
 Several observers are feature-gated and only activate when the corresponding feature gate is enabled.
 
@@ -110,7 +114,7 @@ Several observers are feature-gated and only activate when the corresponding fea
 - CA bundle and server CA ConfigMaps
 - Recovery serving cert and client token Secrets
 
-The target config controller validates that required configuration is present (etcd servers, certs, admission plugins) before rendering.
+The target config controller validates that required configuration is present (etcd servers, named serving certificates, RestrictedEndpointsAdmission plugin config) before rendering.
 
 ## Certificate Rotation
 
@@ -146,7 +150,7 @@ The operator manages encryption at rest for `secrets` and `configmaps` resources
 
 `pkg/recovery/` provides a disaster recovery mechanism that creates a temporary recovery kube-apiserver pod:
 
-- Copies the main kube-apiserver pod manifest and modifies it for recovery
+- Reads the main kube-apiserver pod manifest to extract the container image, then renders a recovery pod from a separate template (`bindata/assets/kube-apiserver/recovery-pod.yaml`)
 - Generates short-lived (7-day) self-signed certificates
 - Creates an admin kubeconfig for recovery access
 - Stores recovery resources in `{StaticPodResourcesDir}/recovery-kube-apiserver-pod/`
@@ -173,3 +177,5 @@ The operator manages encryption at rest for `secrets` and `configmaps` resources
 | `SCCReconcileController` | Reconciles SecurityContextConstraints |
 | `LatencyProfileController` | Applies latency profile settings from node configuration |
 | `NodeKubeconfigController` | Generates per-node kubeconfigs |
+| `StaleConditionsController` | Removes stale operator conditions |
+| `EventWatcher` | Watches `LateConnections` events and processes late connection metrics |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,212 @@
+# Contributing to the OpenShift Control Plane Components/Repositories
+
+This document serves as a guide for contributing to the OpenShift components/repositories
+that the OpenShift Control Plane group is responsible for maintaining.
+
+This document is explicitly for contributions to individual component repositories and not for high-level
+feature proposals within OpenShift.
+
+Feature proposals should follow the OpenShift Enhancement Proposal process outlined in https://github.com/openshift/enhancements/blob/master/dev-guide/feature-zero-to-hero.md#openshift-feature-development-zero-to-hero-guide.
+If you are looking for a review on an OpenShift Enhancement Proposal that involves changes to components
+maintained by the control plane group, please request a review in the [`#forum-ocp-apiserver`](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel. Requests for review may be redirected to more appropriate and/or more focused channels for discussion.
+
+This document contains the following sections:
+
+- [Code conventions](#code-conventions) - A collection of guidelines, style suggestions, and tips for writing code.
+- [Testing guidelines](#testing-guidelines) - Guidelines and expectations for testing of contributions.
+- [Pull Request process/guidelines](#pull-request-process-and-guidelines) - Guidelines and expectations of pull requests containing contributions.
+- [Review expectations](#review-expectations) - Guidelines and expectations for requesting reviews and interacting with reviewers.
+
+## Code Conventions
+
+We largely follow the [Kubernetes Code Conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md#code-conventions).
+
+Review both the Kubernetes Code Conventions and the ones specified here.
+There will be some overlap. If any conventions are at odds with one another, prefer the conventions explicitly documented here.
+
+### Bash
+
+- Follow the [shell styleguide](https://google.github.io/styleguide/shellguide.html).
+- Use [`shellcheck`](https://github.com/koalaman/shellcheck) to identify common mistakes or caveats.
+- Ensure that all scripts run consistently across Linux and macOS.
+
+### Golang (Go)
+
+- Review [Effective Go](https://go.dev/doc/effective_go).
+- Review common [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Review and avoid [Go Landmines](https://gist.github.com/lavalamp/4bd23295a9f32706a48f)
+- Comment your code following the [Go comment conventions](https://go.dev/doc/comment).
+  - Comments should be meaningful and add context and/or explain choices that cannot be expressed through clear code.
+  - All exported types, functions, and methods must have descriptive comments.
+  - All unexported types, functions, and methods should have descriptive comments.
+- When adding command-line flags, use dashes/hyphens (`-`) and not underscores (`_`).
+- Naming
+  - Please consider package name when selecting an interface name, and avoid redundancy. For example, `storage.Interface` is better than `storage.StorageInterface`.
+  - Do not use uppercase characters, underscores, or dashes in package names.
+  - Please consider parent directory name when choosing a package name. For example, `pkg/controllers/autoscaler/foo.go` should say `package autoscaler` not `package autoscalercontroller`.
+    - Unless there's a good reason, the package foo line should match the name of the directory in which the .go file exists.
+    - Importers can use a different name if they need to disambiguate.
+  - Locks should be called `lock` and should never be embedded (always `lock sync.Mutex`). When multiple locks are present, give each lock a distinct name following Go conventions: `stateLock`, `mapLock` etc.
+- Error handling
+  - Wrap errors with meaningful context before returning or logging them.
+- When logging, follow the [Kubernetes Logging Conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/logging.md).
+- When patching OpenShift-maintained forks of "upstream" repositories, patches should be as small as reasonably possible and should minimize touch points with code that is likely to change and impact the rebasing process.
+- Dependencies must be vendored. When making changes to dependencies, ensure you've run `go mod tidy` and `go mod vendor`.
+
+### General
+
+Regardless of the programming language, make sure to take the following into consideration:
+- Keep readability / maintainability in mind when writing code.
+  - Clever code and abstractions are often harder to reason about after the fact. Keep clever code and abstractions to the minimum necessary to accomplish the end-goal.
+- Do not reinvent the wheel. Where possible, use existing standard library or vendored library functionality. If you are adding a net-new dependency, stop and think if you _really_ need to add the new dependency to achieve your goals.
+- When writing tests, focus on testing the functional behaviors your code exercises. Avoid writing tests that are testing that the standard library works as expected or is trivial. Do not write tests just for line coverage.
+
+### Directory and File Conventions
+
+- Avoid package sprawl. Find an appropriate subdirectory for new packages.
+  - Libraries with no appropriate home belong in new package subdirectories of `pkg/util`.
+- Avoid general utility packages. Packages called "util" are suspect. Instead, derive a name that describes your desired function. For example, the utility functions dealing with waiting for operations are in the `wait` package and include functionality like `Poll`. The full name is `wait.Poll`.
+- All filenames should be lowercase.
+- Go source files and directories use underscores, not dashes.
+  - Package directories should generally avoid using separators as much as possible. When package names are multiple words, they usually should be in nested subdirectories.
+
+## Testing Guidelines
+
+These are high-level testing guidelines. Where individual component repositories may have
+additional testing guidelines to follow when making contributions.
+
+- All changes must include unit test additions/changes.
+  - Exceptions are at reviewer/approver discretion.
+- Table-driven unit tests are preferred for testing multiple scenarios/inputs. For an example, see https://github.com/openshift/cluster-authentication-operator/blob/a493799952e9b6838021ccc7d15d3d37d7ad3508/pkg/controllers/externaloidc/externaloidc_controller_test.go#L108 .
+- Unit tests must pass on all platforms (at the very least, Linux + macOS).
+- Significant features should come with integration and/or end-to-end (e2e) tests where appropriate.
+  - End-to-end tests _may_ be scoped as a separate work item when the end-to-end tests for the component must be added to the openshift/origin repository instead of the component repository. Adding e2e tests to the component repository is preferred where possible. It is up to reviewer/approver discretion whether a contribution can be merged without end-to-end tests being implemented.
+- Do not expect an asynchronous thing to happen immediately. Do not wait for one second and expect a pod to be running. Wait and retry instead.
+
+
+If necessary, manual integration testing can be done by creating a cluster using the [`Cluster Bot` Slack App](https://redhat.enterprise.slack.com/archives/D03KX7M1CRJ).
+Once you have a cluster created, you can follow some of the instructions in https://github.com/openshift/enhancements/blob/master/dev-guide/operators.md for guidance on how to
+build component images and modify cluster-operators to deploy those images.
+
+Most component repos have existing tooling to run unit tests. Check for Makefiles and shell scripts that might run the unit tests. If none exist, you should be able to use standard testing tooling like `go test ./...` to run all tests for the project. https://pkg.go.dev/cmd/go/internal/test is a good reference for how the `go test` command works.
+
+## Pull Request Process and Guidelines
+
+This section assumes that you have a functional understanding of `git` and how to create a pull request on GitHub.
+
+If you do not, start with [GitHub's "Getting Started" guide](https://docs.github.com/en/get-started/start-your-journey).
+
+### Prerequisites
+
+Before you commit any changes or create any pull requests, you must adhere to OpenShift contribution policies.
+Currently, that means enabling commit signature verification.
+
+See https://docs.google.com/document/d/1184EPSGunUkcSQYUK8T4a6iyawwi6f2zxdbB2jtG9nQ/edit?usp=sharing for more details on
+how to adhere to the commit signature verification policy of OpenShift.
+
+### Creating a Pull Request
+
+When creating a pull request, include the following:
+
+- A brief, but descriptive, title.
+  - All pull requests _should_ link to a Jira ticket associated with the work. There is automation that performs this linking when prefixing the title with the Jira ticket identifier like: `CNTRLPLANE-XXXX: my pull request title`. For pull requests that have no Jira ticket associated with it, you can prefix it with `NO-JIRA:` to signal that there is not a Jira ticket associated with it.
+- A useful description of the changes being made and why they are important. Include links to supporting documents and any additional context that reviewers may need.
+
+### CI / CD
+
+For CI/CD, OpenShift uses Prow to run various checks. This can include unit tests, e2e tests, linters, etc.
+
+The jobs configured for each repository are in https://github.com/openshift/release/tree/main/ci-operator/config/openshift . If you find yourself needing to add additional jobs, review the documentation at https://docs.ci.openshift.org/how-tos/contributing-openshift-release/ .
+
+There are often a mixture of required and optional checks as well as merge criteria that must be met before a pull request can merge.
+When any of these checks fail, the GitHub Prow bot will leave a comment on the PR with links to the run of that check that failed.
+
+As the PR author, it is your responsibility to evaluate the failed checks and determine if there are any changes necessary to pass the checks.
+If you suspect that the check failure was a flake, you can trigger retests by commenting `/retest` (or `/retest-required` for retesting only the required checks) on the PR.
+
+### Verifying your changes / Creating an OpenShift cluster from a PR
+
+As part of merging a PR, there is a requirement to verify that the changes you've made are working as expected using the `/verified` comment command.
+
+While there are a lot of scenarios where the existing CI/CD checks may be sufficient to verify your changes are working (and can be denoted by commenting `/verified by ci`),
+there may be scenarios where manual verification is required.
+
+You can use the `Cluster Bot` Slack App to create a cluster from a PR by sending it a message in the format of `launch ${OCP_VERSION},${PR_LINK} ${PLATFORM},${VARIANT}`.
+As an example, `launch 4.23,https://github.com/openshift/cluster-authentication-operator/pull/928 aws,techpreview` would launch an OpenShift 4.23 cluster with the changes made in openshift/cluster-authentication-operator#928 running on AWS with the TechPreviewNoUpgrade feature-set enabled.
+For more information on what `Cluster Bot` can do, you can send it a message saying `help` and it will respond with additional documentation on how it can be used.
+
+Once you've verified your changes work as expected, you can mark the PR as verified by commenting `/verified by @{your_github_handle}` on the PR.
+
+### Additional Resources
+
+For more information regarding more general OpenShift pull request processes, the following resources are helpful:
+
+- https://docs.ci.openshift.org/architecture/jira
+- https://docs.ci.openshift.org/
+- https://steps.ci.openshift.org/
+
+## Review Expectations
+
+### Requesting a review
+
+If you are not a member of the OpenShift control plane team and you need a review on a PR, post it in the [#forum-ocp-apiserver](https://redhat.enterprise.slack.com/archives/CB48XQ4KZ) Slack channel or
+reach out to folks outlined in the OWNERS file directly.
+
+If you are a member of the OpenShift control plane team, reviews should come from your feature team. In the event your feature team does not have someone that can approve
+a PR, post it in the [#control-plane](https://redhat.enterprise.slack.com/archives/CC3CZCQHM) Slack channel.
+
+OpenShift uses AI code review tools as part of the code review process.
+Before requesting a review, address all feedback from the code review agent(s).
+It is up to your discretion as the contributor how you would like to address that feedback.
+Responding with an explanation as to why you are not going to take action on a comment made
+by the agent is an acceptable way to "address" its feedback.
+
+### Interacting with reviewers
+
+When interacting with reviewers/approvers:
+
+- Be professional.
+- Be respectful of differing opinions, viewpoints, and experiences.
+- Gracefully give and receive constructive feedback.
+- Focus on what is best for the product/organization, not just us as individuals.
+
+A special note on the usage of AI - to respect the time of those that are reviewing your contribution, please do not use AI to respond to review comments.
+
+## OpenShift Tests Extension (OTE)
+
+This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+The test binary and suite definitions live in [`cmd/cluster-kube-apiserver-operator-tests-ext`](cmd/cluster-kube-apiserver-operator-tests-ext/main.go).
+
+### Building the test binary
+
+```bash
+make build
+```
+
+### Running test suites and tests
+
+```bash
+# Run a suite
+./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial
+
+# Run a specific test
+./cluster-kube-apiserver-operator-tests-ext run-test "test-name"
+
+# Run a suite with concurrency limited to 1 (serial execution)
+./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial -c 1
+
+# Run with JUnit output
+./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial --junit-path=/tmp/junit.xml
+```
+
+### Listing available tests and suites
+
+```bash
+# List all test suites
+./cluster-kube-apiserver-operator-tests-ext list suites
+
+# List tests in a suite
+./cluster-kube-apiserver-operator-tests-ext list tests --suite=openshift/cluster-kube-apiserver-operator/operator/serial
+```
+
+For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).

--- a/README.md
+++ b/README.md
@@ -181,37 +181,8 @@ $ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=docker.io/sttts/origin-release:latest
 
 ## Tests
 
- This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+See the [OpenShift Tests Extension (OTE)](CONTRIBUTING.md#openshift-tests-extension-ote) section in `CONTRIBUTING.md` for instructions on building and running tests.
 
-### Building the test binary
+## Contributing
 
-```bash
-make build
-```
-
-### Running test suites and tests
-
-```bash
-# Run a specific test suite or test
-./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial
-./cluster-kube-apiserver-operator-tests-ext run-test "test-name"
-
-# To run serial suites cases serially, use the following command:
-./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial -c 1
-
-# Run with JUnit output
-./cluster-kube-apiserver-operator-tests-ext run-suite openshift/cluster-kube-apiserver-operator/operator/serial --junit-path=/tmp/junit.xml
-./cluster-kube-apiserver-operator-tests-ext run-test "test-name" --junit-path=/tmp/junit.xml
-```
-
-### Listing available tests and suites
-
-```bash
-# List all test suites
-./cluster-kube-apiserver-operator-tests-ext list suites
-
-# List tests in a suite
-./cluster-kube-apiserver-operator-tests-ext list tests --suite=openshift/cluster-kube-apiserver-operator/operator/serial
-```
-
-For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
- Add a common CONTRIBUTING.md with code conventions, testing guidelines, PR process, review expectations, and OTE test instructions tailored to this repository (correct binary name,
  suite names, command syntax)
- Add AGENTS.md as a quick-reference for developers and AI agents: build commands, project structure, controller pattern, key conventions (cert rotation, API enablement, upstream-first
  for library-go)
- Add ARCHITECTURE.md documenting the operator's design: data flow from config observers through target config to static pods, certificate rotation, encryption, recovery, and all
  controller responsibilities
- Deduplicate the Tests section from README.md, replacing it with a pointer to CONTRIBUTING.md

Creating this as a draft not to run CI unnecessarily until accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/replaced operator documentation (AGENTS.md) covering build/test guidance (including E2E and encryption/KMS variants), repository layout, controller design patterns, operational conventions, and contributing/testing expectations.
  * Added a comprehensive architecture overview (ARCHITECTURE.md) describing startup/recovery, static pod revision lifecycle, configuration rendering/validation, certificate rotation, and encryption-at-rest behavior.
  * Updated CONTRIBUTING.md with contribution and pull request guidelines, including required verification workflows and OpenShift Tests Extension (OTE) build/run instructions.
  * Refreshed README to shorten “Tests”/“Contributing” sections and link to CONTRIBUTING.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->