### PR TITLE
NO-JIRA: Add test for kms to kms migration

### DIFF
--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -90,7 +90,7 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		Parents:     []string{"openshift/kms"},
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("KMSEncryption")`,
+			`name.contains("KMSEncryption") && !name.contains("[Suite:encryption-kms-rotation]") && !name.contains("[Suite:encryption-kms-2]")`,
 		},
 	})
 
@@ -100,6 +100,15 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		Parallelism: 1,
 		Qualifiers: []string{
 			`name.contains("[Suite:encryption-kms-rotation]")`,
+		},
+	})
+
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-apiserver-operator/encryption-kms-2",
+		Parents:     []string{"openshift/kms"},
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-kms-2]")`,
 		},
 	})
 

--- a/test/e2e-encryption-kms/encryption_kms.go
+++ b/test/e2e-encryption-kms/encryption_kms.go
@@ -22,20 +22,19 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 	g.It("TestKMSEncryptionProvidersMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m]", func(ctx context.Context) {
 		testKMSEncryptionProvidersMigration(ctx, g.GinkgoTB())
 	})
+
 })
 
 // testKMSEncryptionOnOff tests KMS encryption on/off cycle.
 // This test:
-// 1. Deploys the real Vault KMS plugin
-// 2. Creates a test secret (SecretOfLife)
-// 3. Enables KMS encryption
-// 4. Verifies secret is encrypted
-// 5. Disables encryption (Identity)
-// 6. Verifies secret is NOT encrypted
-// 7. Re-enables KMS encryption
-// 8. Verifies secret is encrypted again
-// 9. Disables encryption (Identity) again
-// 10. Verifies secret is NOT encrypted again
+// 1. Enables KMS encryption
+// 2. Verifies secret is encrypted
+// 3. Disables encryption (Identity)
+// 4. Verifies secret is NOT encrypted
+// 5. Re-enables KMS encryption
+// 6. Verifies secret is encrypted again
+// 7. Disables encryption (Identity) again
+// 8. Verifies secret is NOT encrypted again
 func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 	library.TestEncryptionTurnOnAndOff(ctx, t, library.OnOffScenario{
 		BasicScenario: library.BasicScenario{
@@ -58,12 +57,11 @@ func testKMSEncryptionOnOff(ctx context.Context, t testing.TB) {
 
 // testKMSEncryptionProvidersMigration tests migration between KMS and AES encryption providers.
 // This test:
-// 1. Deploys the real Vault KMS plugin
-// 2. Creates a test secret (SecretOfLife)
-// 3. Randomly picks one AES encryption provider (AESGCM or AESCBC)
-// 4. Shuffles the selected AES provider with KMS to create a randomized migration order
-// 5. Migrates between the providers in the shuffled order
-// 6. Verifies secret is correctly encrypted after each migration
+// 1. Creates a test secret (SecretOfLife)
+// 2. Randomly picks one AES encryption provider (AESGCM or AESCBC)
+// 3. Shuffles the selected AES provider with KMS to create a randomized migration order
+// 4. Migrates between the providers in the shuffled order
+// 5. Verifies secret is correctly encrypted after each migration
 func testKMSEncryptionProvidersMigration(ctx context.Context, t testing.TB) {
 	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
 		BasicScenario: library.BasicScenario{

--- a/test/e2e-encryption-kms/encryption_kms_2.go
+++ b/test/e2e-encryption-kms/encryption_kms_2.go
@@ -1,0 +1,50 @@
+package e2e_encryption_kms
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+	librarykms "github.com/openshift/library-go/test/library/encryption/kms"
+)
+
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
+	g.It("TestKMSEncryptionKMSToKMSMigration [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m][Suite:encryption-kms-2]", func(ctx context.Context) {
+		testKMSEncryptionKMSToKMSMigration(ctx, g.GinkgoTB())
+	})
+})
+
+// testKMSEncryptionKMSToKMSMigration tests migration between two distinct KMS providers
+// (default Vault instance and secondary Vault instance).
+// This test:
+// 1. Shuffles the two KMS providers to create a randomized migration order
+// 2. Migrates between the providers in the shuffled order
+// 3. Verifies secret is correctly encrypted after each migration
+// 4. Switches to identity (off) to verify the resource is re-written unencrypted
+func testKMSEncryptionKMSToKMSMigration(ctx context.Context, t testing.TB) {
+	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       operatorencryption.DefaultTargetGRs,
+			AssertFunc:                      operatorencryption.AssertSecretsAndConfigMaps,
+		},
+		CreateResourceFunc:             operatorencryption.CreateAndStoreSecretOfLife,
+		AssertResourceEncryptedFunc:    operatorencryption.AssertSecretOfLifeEncrypted,
+		AssertResourceNotEncryptedFunc: operatorencryption.AssertSecretOfLifeNotEncrypted,
+		ResourceFunc:                   operatorencryption.SecretOfLife,
+		ResourceName:                   "SecretOfLife",
+		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
+			librarykms.DefaultVaultEncryptionProvider(ctx, t),
+			librarykms.SecondaryVaultEncryptionProvider(ctx, t),
+		}),
+	})
+}


### PR DESCRIPTION
This PR adds new test for kms to kms migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end suite (`encryption-kms-2`) and a KMS-to-KMS migration scenario covering migration between two Vault-based KMS providers while verifying encrypted data remains accessible.
  * Updated existing KMS enable/disable/reenable scenario documentation to remove a previously listed “deploy real Vault KMS plugin” step and renumber the remaining steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->