### PR TITLE
Add new kms to kms case test

### DIFF
--- a/test/e2e-encryption-kms/encryption_kms_2.go
+++ b/test/e2e-encryption-kms/encryption_kms_2.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	g "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/clock"
 
@@ -23,6 +24,10 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 
 	g.It("TestKMSPreflightDeploy [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m][Suite:encryption-kms-2]", func(ctx context.Context) {
 		testKMSPreflightDeploy(ctx, g.GinkgoTB())
+	})
+
+	g.It("TestKMSEncryptionImageUpdate [OCPFeatureGate:KMSEncryption][Serial][Timeout:120m][Suite:encryption-kms-2]", func(ctx context.Context) {
+		testKMSEncryptionImageUpdate(ctx, g.GinkgoTB())
 	})
 })
 
@@ -83,5 +88,56 @@ func testKMSPreflightDeploy(ctx context.Context, t testing.TB) {
 		CreateEncryptionConfigFunc: library.VaultPreflightEncryptionConfigSecret,
 		AssertDeployFunc:           library.AssertPreflightDeploy,
 		EncryptionProvider:         librarykms.DefaultVaultEncryptionProvider(ctx, t),
+	})
+}
+
+// testKMSEncryptionImageUpdate tests that upgrading kmsPluginImage is an in-place
+// change that does NOT create a new encryption key.
+// This test:
+// 1. Applies KMS encryption with the old Vault KMS plugin image
+// 2. Upgrades kmsPluginImage to the newVault KMS plugin image
+// 3. Verifies no new encryption key is created (in-place update)
+// 4. Verifies the new image propagates to the KMS plugin pods
+func testKMSEncryptionImageUpdate(ctx context.Context, t testing.TB) {
+	realProvider := librarykms.DefaultVaultEncryptionProvider(ctx, t)
+	realImage := realProvider.APIServerEncryption.KMS.Vault.KMSPluginImage
+
+	// Initial provider uses the old image with real Vault connection config.
+	initialImage := "quay.io/openshifttest/vault-kube-kms@sha256:4206f83742528de5a1cc0ff2b2e93476a1e44dc18caf595b6658d03603dcafa2"
+	initialCfg := realProvider.APIServerEncryption
+	initialCfg.KMS.Vault.KMSPluginImage = initialImage
+	initialProvider := library.EncryptionProvider{
+		APIServerEncryption: initialCfg,
+		Setup:               realProvider.Setup,
+	}
+
+	library.TestKMSInPlaceUpdate(ctx, t, library.KMSInPlaceUpdateScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       library.WellKnownKASTargetGRs,
+			AssertFunc:                      library.AssertWellKnownSecretsAndConfigMaps,
+		},
+		Provider:        initialProvider,
+		UpdatedProvider: realProvider,
+		WaitForPropagation: func(ctx context.Context, t testing.TB, keyMeta library.EncryptionKeyMeta) {
+			cs := library.GetClients(t)
+			library.WaitForPodContainerCondition(ctx, t, cs.Kube,
+				operatorclient.TargetNamespace,
+				"encryption.apiserver.operator.openshift.io/component="+operatorclient.TargetNamespace,
+				keyMeta.Name,
+				func(pod corev1.Pod, _ string) bool {
+					for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+						if c.Image == realImage {
+							return true
+						}
+					}
+					return false
+				},
+			)
+		},
 	})
 }


### PR DESCRIPTION
Add new kms to kms case test 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for updating the KMS encryption provider image in place.
  * Verifies that the updated Vault KMS plugin image propagates to running KMS plugin pods.
  * Confirms the update does not create an additional encryption key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->