### PR TITLE
OCPBUGS-38661: Add 10-minute degraded inertia for NodeControllerDegraded

### DIFF
--- a/pkg/operator/start_test.go
+++ b/pkg/operator/start_test.go
@@ -1,6 +1,0 @@
-package operator
-
-import "testing"
-
-func TestNothing(t *testing.T) {
-}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -44,6 +45,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/webhooksupportabilitycontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/apiserver/controller/auditpolicy"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
@@ -379,7 +381,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		versionRecorder,
 		controllerContext.EventRecorder,
 		controllerContext.Clock,
-	)
+	).WithDegradedInertia(newDegradedInertia())
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
 		kubeClient,
@@ -557,6 +559,18 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 
 	<-ctx.Done()
 	return nil
+}
+
+func newDegradedInertia() status.Inertia {
+	return status.MustNewInertia(
+		2*time.Minute,
+		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		status.InertiaCondition{
+			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
+			Duration:             10 * time.Minute,
+		},
+	).Inertia
 }
 
 // installerErrorInjector mutates the given installer pod to fail or OOM depending on the propability (

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,36 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	condition "github.com/openshift/library-go/pkg/operator/condition"
+)
+
+func TestNewDegradedInertia(t *testing.T) {
+	inertia := newDegradedInertia()
+
+	tests := []struct {
+		conditionType string
+		expected      time.Duration
+	}{
+		{
+			conditionType: condition.NodeControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
+			conditionType: "TargetConfigControllerDegraded",
+			expected:      2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conditionType, func(t *testing.T) {
+			got := inertia(operatorv1.OperatorCondition{Type: tt.conditionType})
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevent transient node not-ready events from immediately marking the operator as Degraded at the ClusterOperator level. Other degraded conditions keep the default 2-minute inertia.

The 10-minute inertia approach was discussed on the arch call and accepted as the way to go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of degraded cluster conditions by applying a custom inertia window for specific controller degradation events.
  * Updated degraded-state timing behavior so the inertia duration matches expected values.
* **Tests**
  * Added unit test coverage to verify inertia durations for degraded condition types.
  * Removed an obsolete placeholder test that no longer applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->