### PR TITLE
OCPBUGS-38661: Add 10-minute degraded inertia for StaticPodsDegraded

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -566,11 +566,18 @@ func newDegradedInertia() status.Inertia {
 		2*time.Minute,
 		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
-		status.InertiaCondition{
-			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
-			Duration:             10 * time.Minute,
-		},
+		inertiaForCondition(condition.NodeControllerDegradedConditionType, 10*time.Minute),
+		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
 	).Inertia
+}
+
+func inertiaForCondition(cond string, duration time.Duration) status.InertiaCondition {
+	return status.InertiaCondition{
+		ConditionTypeMatcher: regexp.MustCompile("^" + cond + "$"),
+		Duration:             duration,
+	}
 }
 
 // installerErrorInjector mutates the given installer pod to fail or OOM depending on the propability (

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -20,6 +20,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: condition.StaticPodsDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},


### PR DESCRIPTION
Static pods may temporarily report errors during upgrades while pods restart. Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.

This is an approach we agreed upon on the arch call and the affected controller was explicitly mentioned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved degraded-status handling so an additional system condition is now tracked consistently for a 10-minute window.
  * This helps the operator more accurately recognize and retain certain transient degraded states instead of dropping them too quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->