### PR TITLE
OCPBUGS-95186: increases termination timeouts as API LBs use /readyz of kube-apiserver for ppc64le and s390x

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -3,8 +3,10 @@ package apiserver
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
@@ -45,6 +47,7 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 		// Note this is the official number we got from AWS
 		observedShutdownDelayDuration = "129s"
 	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
+
 		// We are receiving inconsistent information from the GCP support team.
 		// In some responses, they confirm an additional ~60s delay in traffic propagation,
 		// while in others they state that no such delay exists.
@@ -107,6 +110,23 @@ func ObserveGracefulTerminationDuration(genericListers configobserver.Listers, _
 		return existingConfig, append(errs, err)
 	}
 
+	// check control-plane node architecture to detect ppc64le or s390x.
+	// Only master nodes are considered because gracefulTerminationDuration affects
+	// the kube-apiserver static pod, which runs exclusively on control-plane nodes.
+	var hasPPC64leOrS390x bool
+	if nodeLister := listers.CoreNodeLister(); nodeLister != nil {
+		masterSelector := labels.SelectorFromSet(labels.Set{"node-role.kubernetes.io/master": ""})
+		masterNodes, nodeErr := nodeLister.List(masterSelector)
+		if nodeErr != nil {
+			return existingConfig, append(errs, fmt.Errorf("unable to list master nodes to determine architecture: %w", nodeErr))
+		}
+		// control-plane nodes are homogeneous, so checking the first one is sufficient
+		if len(masterNodes) > 0 {
+			arch := masterNodes[0].Labels[corev1.LabelArchStable] // "kubernetes.io/arch"
+			hasPPC64leOrS390x = arch == "ppc64le" || arch == "s390x"
+		}
+	}
+
 	switch {
 	case infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode:
 		// reduce termination duration from 135s (default) to 15s to reach the maximum downtime for SNO:
@@ -133,6 +153,13 @@ func ObserveGracefulTerminationDuration(genericListers configobserver.Listers, _
 		// See: https://console.cloud.google.com/support/cases/detail/v2/65801689?project=openshift-gce-devel
 		// See: https://issues.redhat.com/browse/OCPBUGS-61674
 		observedGracefulTerminationDuration = "160"
+	case hasPPC64leOrS390x:
+		// 135s is calculated as follows:
+		//   the initial 70s is reserved for the minimal termination period on ppc64le and s390x -
+		//   the time needed for an LB to take an instance out of rotation on these architectures
+		//   additional 60s for finishing all in-flight requests
+		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
+		observedGracefulTerminationDuration = "135"
 	default:
 		// don't override default value
 		return map[string]interface{}{}, errs

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 
@@ -20,6 +22,23 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
+// coreNodeListerForArch returns a NodeLister with a single master node
+// carrying the given architecture label.
+func coreNodeListerForArch(t *testing.T, arch string) corelistersv1.NodeLister {
+	t.Helper()
+	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, nodeIndexer.Add(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-0",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				corev1.LabelArchStable:           arch,
+			},
+		},
+	}))
+	return corelistersv1.NewNodeLister(nodeIndexer)
+}
+
 func TestObserveWatchTerminationDuration(t *testing.T) {
 	scenarios := []struct {
 		name                    string
@@ -28,6 +47,7 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 		expectedKubeAPIConfig   map[string]interface{}
 		platformType            configv1.PlatformType
 		controlPlaneTopology    configv1.TopologyMode
+		nodeArch                string // master node arch; sets CoreNodeLister via coreNodeListerForArch
 	}{
 
 		// scenario 1
@@ -73,6 +93,22 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "160"},
 			platformType:          configv1.GCPPlatformType,
 		},
+
+		// scenario 7
+		{
+			name:                  "the gracefulTerminationDuration is extended for ppc64le architecture",
+			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "70"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+			nodeArch:              "ppc64le",
+		},
+
+		// scenario 8
+		{
+			name:                  "the gracefulTerminationDuration is extended for s390x architecture",
+			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "70"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
+			nodeArch:              "s390x",
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -87,6 +123,9 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 			})
 			listers := configobservation.Listers{
 				InfrastructureLister_: configlistersv1.NewInfrastructureLister(infrastructureIndexer),
+			}
+			if scenario.nodeArch != "" {
+				listers.CoreNodeLister_ = coreNodeListerForArch(t, scenario.nodeArch)
 			}
 
 			// act

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	kubeinformers "k8s.io/client-go/informers"
 
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation/apienablement"
@@ -38,7 +39,7 @@ type ConfigObserver struct {
 	factory.Controller
 }
 
-func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces, configInformer configinformers.SharedInformerFactory, operatorInformer operatorv1informers.SharedInformerFactory, resourceSyncer resourcesynccontroller.ResourceSyncer, featureGateAccessor featuregates.FeatureGateAccess, eventRecorder events.Recorder, groupVersionsByFeatureGate map[configv1.FeatureGateName][]schema.GroupVersion) *ConfigObserver {
+func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces, coreKubeInformers kubeinformers.SharedInformerFactory, configInformer configinformers.SharedInformerFactory, operatorInformer operatorv1informers.SharedInformerFactory, resourceSyncer resourcesynccontroller.ResourceSyncer, featureGateAccessor featuregates.FeatureGateAccess, eventRecorder events.Recorder, groupVersionsByFeatureGate map[configv1.FeatureGateName][]schema.GroupVersion) *ConfigObserver {
 	interestingNamespaces := []string{
 		operatorclient.GlobalUserSpecifiedConfigNamespace,
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
@@ -88,6 +89,7 @@ func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInf
 				ProxyLister_:          configInformer.Config().V1().Proxies().Lister(),
 				SchedulerLister:       configInformer.Config().V1().Schedulers().Lister(),
 
+				CoreNodeLister_:     coreKubeInformers.Core().V1().Nodes().Lister(),
 				SecretLister_:       kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
 				ConfigSecretLister_: kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),
 				ConfigmapLister_:    kubeInformersForNamespaces.ConfigMapLister(),
@@ -112,6 +114,7 @@ func NewConfigObserver(operatorClient v1helpers.StaticPodOperatorClient, kubeInf
 					configInformer.Config().V1().OAuths().Informer().HasSynced,
 					configInformer.Config().V1().Proxies().Informer().HasSynced,
 					configInformer.Config().V1().Schedulers().Informer().HasSynced,
+					coreKubeInformers.Core().V1().Nodes().Informer().HasSynced,
 				),
 			},
 			infomers,

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -27,6 +27,7 @@ type Listers struct {
 
 	KubeAPIServerOperatorLister_ operatorlistersv1.KubeAPIServerLister
 
+	CoreNodeLister_     corelistersv1.NodeLister
 	ConfigmapLister_    corelistersv1.ConfigMapLister
 	SecretLister_       corelistersv1.SecretLister
 	ConfigSecretLister_ corelistersv1.SecretLister
@@ -65,6 +66,10 @@ func (l Listers) ConfigSecretLister() corelistersv1.SecretLister {
 
 func (l Listers) NodeLister() configlistersv1.NodeLister {
 	return l.NodeLister_
+}
+
+func (l Listers) CoreNodeLister() corelistersv1.NodeLister {
+	return l.CoreNodeLister_
 }
 
 func (l Listers) ProxyLister() configlistersv1.ProxyLister {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -189,6 +189,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	configObserver := configobservercontroller.NewConfigObserver(
 		operatorClient,
 		kubeInformersForNamespaces,
+		clusterInformers.InformersFor(""),
 		configInformers,
 		operatorInformers,
 		resourceSyncController,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful termination timing by determining CPU architecture from control-plane/master node labels, then applying architecture-specific termination duration (including higher values for `ppc64le` and `s390x`).
  * Improved controller readiness so core node information is available before computing termination settings.
* **Tests**
  * Expanded termination-duration tests to parameterize by master node CPU architecture, adding `ppc64le` and `s390x` scenarios and validating the updated expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->