### PR TITLE
Add vault image in image-references to embed release payload

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-hyperkube:v4.0
+  - name: vault
+    from:
+       kind: DockerImage
+       name: docker.io/hashicorp/vault-kube-kms:0.1.0-beta-ubi

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,7 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-hyperkube:v4.0
-  - name: vault-kube-kms
+  - name: vault_kube_kms
     from:
        kind: DockerImage
        name: docker.io/hashicorp/vault-kube-kms:0.1.0-beta-ubi

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,7 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-hyperkube:v4.0
-  - name: vault
+  - name: vault-kube-kms
     from:
        kind: DockerImage
        name: docker.io/hashicorp/vault-kube-kms:0.1.0-beta-ubi

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,7 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-hyperkube:v4.0
-  - name: vault_kube_kms
+  - name: vault-kube-kms
     from:
        kind: DockerImage
        name: docker.io/hashicorp/vault-kube-kms:0.1.0-beta-ubi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the HashiCorp Vault Kubernetes KMS image to the available image references (via the `vault_kube_kms` tag).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->