### PR TITLE
CNTRLPLANE-3237: encryptionstatusprovider: implement UpdateKMSEncryptionStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20260715165912-72066cc9718b
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec
-	github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a
+	github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec h1:UDjX+mot5IVLpcChyBqLXG1oSB29s4UkqFmgNb0Xsqc=
 github.com/openshift/client-go v0.0.0-20260715172546-dac61734e0ec/go.mod h1:iMHec0APKVjOH8GfL/RxddX8DuiuSvPlRe+s7KDqlyA=
-github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a h1:86Mj1eP0RtYtwPRpdkGbzf6h1Tn+uuYiR6XKZXsWWn8=
-github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
+github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb h1:YcPGRGfuAMMZb1qJxLBBNWbr51c9UVog0CdBCOM6dNs=
+github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/encryptionstatusprovider/provider.go
+++ b/pkg/operator/encryptionstatusprovider/provider.go
@@ -24,6 +24,8 @@ func NewKubeAPIServerEncryptionStatusProviderFromConfig(restConfig *rest.Config)
 	return &kubeAPIServerEncryptionStatusProvider{client: client}, nil
 }
 
+var _ kms.EncryptionStatusProvider = &kubeAPIServerEncryptionStatusProvider{}
+
 type kubeAPIServerEncryptionStatusProvider struct {
 	client *operatorclient.Clientset
 }
@@ -42,5 +44,15 @@ func (p *kubeAPIServerEncryptionStatusProvider) ApplyKMSEncryptionStatus(ctx con
 		applyoperatorv1.KubeAPIServer("cluster").WithStatus(applyoperatorv1.KubeAPIServerStatus().WithEncryptionStatus(status)),
 		metav1.ApplyOptions{FieldManager: fieldManager, Force: true},
 	)
+	return err
+}
+
+func (p *kubeAPIServerEncryptionStatusProvider) UpdateKMSEncryptionStatus(ctx context.Context, mutateFn func(*operatorv1.KMSEncryptionStatus)) error {
+	obj, err := p.client.OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	mutateFn(&obj.Status.EncryptionStatus)
+	_, err = p.client.OperatorV1().KubeAPIServers().UpdateStatus(ctx, obj, metav1.UpdateOptions{})
 	return err
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/encryption_status_provider.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/encryption_status_provider.go
@@ -15,4 +15,13 @@ type EncryptionStatusProvider interface {
 	// ApplyKMSEncryptionStatus uses Server-Side Apply. Each caller owns only
 	// the fields it explicitly sets, identified by fieldManager.
 	ApplyKMSEncryptionStatus(ctx context.Context, fieldManager string, status *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error
+
+	// UpdateKMSEncryptionStatus reads the current status, applies the mutation,
+	// and writes it back. A conflict (409) is returned as-is.
+	//
+	// Note: use this instead of ApplyKMSEncryptionStatus when the controller is
+	// the sole owner of a field. Apply requires re-sending every owned field on
+	// every sync, omitting one causes the server to remove it, which is
+	// cumbersome for a controller that only writes a field once.
+	UpdateKMSEncryptionStatus(ctx context.Context, mutate func(*operatorv1.KMSEncryptionStatus)) error
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -435,7 +435,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a
+# github.com/openshift/library-go v0.0.0-20260722123119-050c1a9af6bb
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
requires https://github.com/openshift/library-go/pull/2372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to update and persist the Kubernetes API server’s KMS encryption status, using a caller-provided mutation and returning errors if retrieval or update fails.
* **Chores**
  * Updated the `library-go` dependency version in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->