### PR TITLE
CNTRLPLANE-3237: encryptionstatusprovider: use KubeAPIServersGetter instead of Clientset

### DIFF
--- a/pkg/operator/encryptionstatusprovider/provider.go
+++ b/pkg/operator/encryptionstatusprovider/provider.go
@@ -10,6 +10,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
+	operatorv1typed "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/kms"
 )
@@ -17,19 +18,19 @@ import (
 // NewKubeAPIServerEncryptionStatusProviderFromConfig builds a kms.EncryptionStatusProvider for
 // KubeAPIServer/cluster from a rest.Config.
 func NewKubeAPIServerEncryptionStatusProviderFromConfig(restConfig *rest.Config) (kms.EncryptionStatusProvider, error) {
-	client, err := operatorclient.NewForConfig(restConfig)
+	opClient, err := operatorclient.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("build operator client: %w", err)
 	}
-	return &kubeAPIServerEncryptionStatusProvider{client: client}, nil
+	return &kubeAPIServerEncryptionStatusProvider{client: opClient.OperatorV1().KubeAPIServers()}, nil
 }
 
 type kubeAPIServerEncryptionStatusProvider struct {
-	client *operatorclient.Clientset
+	client operatorv1typed.KubeAPIServerInterface
 }
 
 func (p *kubeAPIServerEncryptionStatusProvider) GetKMSEncryptionStatus(ctx context.Context) (*operatorv1.KMSEncryptionStatus, error) {
-	obj, err := p.client.OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	obj, err := p.client.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +38,7 @@ func (p *kubeAPIServerEncryptionStatusProvider) GetKMSEncryptionStatus(ctx conte
 }
 
 func (p *kubeAPIServerEncryptionStatusProvider) ApplyKMSEncryptionStatus(ctx context.Context, fieldManager string, status *applyoperatorv1.KMSEncryptionStatusApplyConfiguration) error {
-	_, err := p.client.OperatorV1().KubeAPIServers().ApplyStatus(
+	_, err := p.client.ApplyStatus(
 		ctx,
 		applyoperatorv1.KubeAPIServer("cluster").WithStatus(applyoperatorv1.KubeAPIServerStatus().WithEncryptionStatus(status)),
 		metav1.ApplyOptions{FieldManager: fieldManager, Force: true},


### PR DESCRIPTION
`kubeAPIServerEncryptionStatusProvider` was storing  `*operatorclient.Clientset` and calling `OperatorV1().KubeAPIServers()` on every method invocation, creating a new client each time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of KMS encryption status operations without changing user-visible behavior.
  * Existing encryption status retrieval and updates continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->