### PR TITLE
OCPBUGS-86789: Enable send-retry-after-while-not-ready-once on all topologies

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_send_retry_after_while_not_ready_once.go
+++ b/pkg/operator/configobservation/apiserver/observe_send_retry_after_while_not_ready_once.go
@@ -3,35 +3,34 @@ package apiserver
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
 var sendRetryAfterWhileNotReadyOncePath = []string{"apiServerArguments", "send-retry-after-while-not-ready-once"}
 
-// ObserveSendRetryAfterWhileNotReadyOnce ensures that send-retry-after-while-not-ready-once is set for SNO clusters.
-func ObserveSendRetryAfterWhileNotReadyOnce(genericListers configobserver.Listers, _ events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
+// ObserveSendRetryAfterWhileNotReadyOnce ensures that send-retry-after-while-not-ready-once is set for all
+// control plane topologies.
+//
+// Historically this was enabled only for single-node (SNO) clusters, where the load balancer has a single
+// target and inevitably routes requests to a kube-apiserver that is not ready yet. However, it has been
+// observed (OCPBUGS-86789) that on multi-node clusters load balancers can also route requests to a
+// not-yet-ready kube-apiserver even while healthy replicas are available. Such requests could be processed
+// before RBAC and admission post-start hooks have completed. Since no load balancer implementation
+// (cloud LB, on-prem haproxy/keepalived, or the in-cluster kubernetes.default service) can be perfectly
+// synchronized with /readyz, the only robust protection is server-side: reject early requests with
+// Retry-After until the server has been ready once.
+func ObserveSendRetryAfterWhileNotReadyOnce(_ configobserver.Listers, _ events.Recorder, existingConfig map[string]interface{}) (ret map[string]interface{}, errs []error) {
 	defer func() {
 		// Prune the observed config so that it only contains apiServerArguments field.
 		ret = configobserver.Pruned(ret, sendRetryAfterWhileNotReadyOncePath)
 	}()
 
-	// read the observed value
-	listers := genericListers.(configobservation.Listers)
-	infra, err := listers.InfrastructureLister().Get("cluster")
-	if err != nil && !apierrors.IsNotFound(err) {
-		// we got an error so without the infrastructure object we are not able to determine the type of platform we are running on
-		return existingConfig, append(errs, err)
-	}
-
-	observedSendRetryAfterWhileNotReadyOnce := strconv.FormatBool(infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode)
+	// the protection is topology-independent, see the function documentation
+	observedSendRetryAfterWhileNotReadyOnce := "true"
 
 	// read the current value
 	var currentSendRetryAfterWhileNotReadyOnce string

--- a/pkg/operator/configobservation/apiserver/observe_send_retry_after_while_not_ready_once_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_send_retry_after_while_not_ready_once_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/utils/clock"
 
 	configv1 "github.com/openshift/api/config/v1"
-	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/configobservation"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -18,19 +17,29 @@ import (
 
 func TestObserveSendRetryAfterWhileNotReadyOnce(t *testing.T) {
 	scenarios := []struct {
-		name                    string
-		validateKubeAPIConfigFn func(kubecontrolplanev1.KubeAPIServerConfig) error
-		existingKubeAPIConfig   map[string]interface{}
-		expectedKubeAPIConfig   map[string]interface{}
-		controlPlaneTopology    configv1.TopologyMode
+		name                  string
+		existingKubeAPIConfig map[string]interface{}
+		expectedKubeAPIConfig map[string]interface{}
+		controlPlaneTopology  configv1.TopologyMode
 	}{
-
-		// scenario 1 - HA unset
+		// scenario 1 - HA unset, defaults to true
 		{
-			name:                 "ha: defaults to false",
+			name:                 "ha: defaults to true",
 			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
 			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"send-retry-after-while-not-ready-once": []interface{}{"true"},
+			}},
+		},
+
+		// scenario 2 - HA, update required
+		{
+			name:                 "ha: update required",
+			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
 				"send-retry-after-while-not-ready-once": []interface{}{"false"},
+			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},
 		},
 
@@ -39,35 +48,23 @@ func TestObserveSendRetryAfterWhileNotReadyOnce(t *testing.T) {
 			name:                 "ha: update not required",
 			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
 			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
-				"send-retry-after-while-not-ready-once": []interface{}{"false"},
-			}},
-			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
-				"send-retry-after-while-not-ready-once": []interface{}{"false"},
-			}},
-		},
-
-		// scenario 4 - HA, update required
-		{
-			name:                 "ha: update required",
-			controlPlaneTopology: configv1.HighlyAvailableTopologyMode,
-			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
 				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},
 			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
-				"send-retry-after-while-not-ready-once": []interface{}{"false"},
+				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},
 		},
 
-		// scenario 5 - SNO
+		// scenario 4 - SNO, defaults to true
 		{
-			name:                 "ha: defaults to true",
+			name:                 "sno: defaults to true",
 			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
 			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
 				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},
 		},
 
-		// scenario 6 - SNO, update required
+		// scenario 5 - SNO, update required
 		{
 			name:                 "sno: update required",
 			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
@@ -79,13 +76,22 @@ func TestObserveSendRetryAfterWhileNotReadyOnce(t *testing.T) {
 			}},
 		},
 
-		// scenario 7 - SNO, update not required
+		// scenario 6 - SNO, update not required
 		{
 			name:                 "sno: update not required",
 			controlPlaneTopology: configv1.SingleReplicaTopologyMode,
 			existingKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
 				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},
+			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
+				"send-retry-after-while-not-ready-once": []interface{}{"true"},
+			}},
+		},
+
+		// scenario 7 - external topology also gets the protection
+		{
+			name:                 "external: defaults to true",
+			controlPlaneTopology: configv1.ExternalTopologyMode,
 			expectedKubeAPIConfig: map[string]interface{}{"apiServerArguments": map[string]interface{}{
 				"send-retry-after-while-not-ready-once": []interface{}{"true"},
 			}},


### PR DESCRIPTION
## What

Enables the `send-retry-after-while-not-ready-once` kube-apiserver protection on all control plane topologies instead of SNO-only. The `shutdown-send-retry-after` flag is already enabled globally via `bindata/assets/config/defaultconfig.yaml`, so this PR completes the pair by making the startup-side protection topology-independent.

## Why

Investigation of OCPBUGS-86789 showed that load balancers can route requests to a not-yet-ready kube-apiserver on multi-node clusters too, even while healthy replicas are available:

- On AWS, the NLB was observed routing to a target that had been unhealthy for 50s+ with two healthy masters available (see bug comments).
- On bare metal / in-cluster traffic, the `kubernetes.default` service path can go stale: the OVN load balancer backends are only as fresh as ovn-kubernetes' EndpointSlice informers, and those informers were observed losing their API watches (via the api-int VIP) exactly during control plane rollouts — e.g. Prow run `periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-dualstack/2079715174809341952`, where ovnkube on master-0 logged ~50 watch failures in the minute preceding a `LateConnections`/early-request event.

Requests accepted before readiness may be processed before RBAC and admission post-start hooks have completed, which is the security concern flagged in the bug. Since no LB implementation (cloud LB, on-prem haproxy/keepalived, or the in-cluster service path) can be perfectly synchronized with `/readyz`, the only robust protection is server-side: reject early requests with 503 + `Retry-After` until the server has been ready once. Well-behaved clients retry transparently against a healthy replica; SNO behavior is unchanged.

This follows the suggestion in https://issues.redhat.com/browse/OCPBUGS-86789 that HA clusters should also have this protection enabled (audit logs on SNO confirm premature requests are cleanly rejected with 503).

## Impact on Component Readiness

Sippy regressions 44896 and 44949 (`[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests`) are fallout of the same root cause becoming visible after the Kube 1.36 rebase started emitting the previously-silent `LateConnections`/`NonReadyRequests` events.

## Notes

- The observer no longer needs the Infrastructure lister; the value is constant.
- Unit tests updated accordingly (all topologies expect `true`).

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * The API server now enables `send-retry-after-while-not-ready-once` by default across all cluster topology modes.
  * Configuration updates and defaults have been aligned to consistently enable this protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->