### PR TITLE
starter: restructure RunOperator into five-phase layout

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -83,6 +83,10 @@ import (
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+
+	// -- PHASE 1: Clients and Initialization --
+	// All NewForConfig calls, version parsing, direct API calls that read bootstrap state.
+
 	// This kube client use protobuf, do not use it for CR
 	kubeClient, err := kubernetes.NewForConfig(controllerContext.ProtoKubeConfig)
 	if err != nil {
@@ -112,6 +116,11 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+	operatorV1Client, err := operatorv1client.NewForConfig(controllerContext.KubeConfig)
+	if err != nil {
+		return err
+	}
+
 	operandKubernetesVersion, err := semver.Parse(status.VersionForOperandFromEnv())
 	if err != nil {
 		return err
@@ -121,19 +130,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
-		kubeClient,
-		operatorclient.GlobalUserSpecifiedConfigNamespace,
-		operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		operatorclient.TargetNamespace,
-		operatorclient.OperatorNamespace,
-		"kube-system", // system:openshift:controller:kube-apiserver-check-endpoints role binding
-		"openshift-etcd",
-		"openshift-apiserver",
-	)
-	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
+	desiredVersion := status.VersionForOperatorFromEnv()
+	missingVersion := "0.0.1-snapshot"
 
-	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
 	operatorClient, dynamicInformersForAllNamespaces, err := genericoperatorclient.NewStaticPodOperatorClient(
 		controllerContext.Clock,
 		controllerContext.KubeConfig,
@@ -145,63 +144,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
-
-	securityInformers := securityvnformers.NewSharedInformerFactory(securityClient, 10*time.Minute)
-
-	desiredVersion := status.VersionForOperatorFromEnv()
-	missingVersion := "0.0.1-snapshot"
-
-	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		desiredVersion, missingVersion,
-		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
-		controllerContext.EventRecorder,
-	)
-	go featureGateAccessor.Run(ctx)
-	go configInformers.Start(ctx.Done())
-
-	var featureGates featuregates.FeatureGate
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, _ = featureGateAccessor.CurrentFeatureGates()
-		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
-	case <-time.After(1 * time.Minute):
-		klog.Errorf("timed out waiting for FeatureGate detection")
-		return fmt.Errorf("timed out waiting for FeatureGate detection")
-	}
-
-	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
-		operatorClient,
-		kubeInformersForNamespaces,
-		kubeClient,
-		controllerContext.EventRecorder,
-	)
-	if err != nil {
-		return err
-	}
-
-	operatorV1Client, err := operatorv1client.NewForConfig(controllerContext.KubeConfig)
-	if err != nil {
-		return err
-	}
-	operatorInformers := operatorv1informers.NewSharedInformerFactory(operatorV1Client, 10*time.Minute)
-
-	configObserver := configobservercontroller.NewConfigObserver(
-		operatorClient,
-		kubeInformersForNamespaces,
-		configInformers,
-		operatorInformers,
-		resourceSyncController,
-		featureGateAccessor,
-		controllerContext.EventRecorder,
-		groupVersionsByFeatureGate,
-	)
-
-	serviceAccountIssuerController := serviceaccountissuercontroller.NewController(operatorV1Client.OperatorV1().KubeAPIServers(), operatorInformers, configInformers, controllerContext.EventRecorder)
-
-	eventWatcher := eventwatch.New().
-		WithEventHandler(operatorclient.TargetNamespace, "LateConnections", terminationobserver.ProcessLateConnectionEvents).
-		ToController(kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace), kubeClient.CoreV1(), controllerContext.EventRecorder)
 
 	// TODO: use informer instead of direct api call
 	// Also, in the future there is a plan to make infrastructure type dynamic
@@ -227,6 +169,91 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	var requireMultipleEtcdEndpoints resourceapply.ConditionalFunction = func() bool {
 		return isMultipleEtcdEndpointsRequired
 	}
+
+	// don't change any versions until we sync
+	versionRecorder := status.NewVersionGetter()
+	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-apiserver", metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	for _, version := range clusterOperator.Status.Versions {
+		versionRecorder.SetVersion(version.Name, version.Version)
+	}
+	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
+
+	// -- PHASE 2: Informer Factories --
+	// All SharedInformerFactory and KubeInformersForNamespaces creation.
+
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.TargetNamespace,
+		operatorclient.OperatorNamespace,
+		"kube-system", // system:openshift:controller:kube-apiserver-check-endpoints role binding
+		"openshift-etcd",
+		"openshift-apiserver",
+	)
+	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
+
+	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
+	securityInformers := securityvnformers.NewSharedInformerFactory(securityClient, 10*time.Minute)
+	operatorInformers := operatorv1informers.NewSharedInformerFactory(operatorV1Client, 10*time.Minute)
+	dynamicInformersForTargetNamespace := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 12*time.Hour, operatorclient.TargetNamespace, nil)
+	apiextensionsInformers := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClient, 10*time.Minute)
+	migrationInformer := migrationv1alpha1informer.NewSharedInformerFactory(migrationClient, time.Minute*30)
+
+	// -- PHASE 3: Feature Gates --
+	// FeatureGateAccess creation, config informers early start, blocking wait.
+
+	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
+	featureGateAccessor := featuregates.NewFeatureGateAccess(
+		desiredVersion, missingVersion,
+		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
+		controllerContext.EventRecorder,
+	)
+	go featureGateAccessor.Run(ctx)
+	go configInformers.Start(ctx.Done())
+
+	var featureGates featuregates.FeatureGate
+	select {
+	case <-featureGateAccessor.InitialFeatureGatesObserved():
+		featureGates, _ = featureGateAccessor.CurrentFeatureGates()
+		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+	case <-time.After(1 * time.Minute):
+		klog.Errorf("timed out waiting for FeatureGate detection")
+		return fmt.Errorf("timed out waiting for FeatureGate detection")
+	}
+
+	// -- PHASE 4: Controllers --
+	// All controller construction.
+
+	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
+		operatorClient,
+		kubeInformersForNamespaces,
+		kubeClient,
+		controllerContext.EventRecorder,
+	)
+	if err != nil {
+		return err
+	}
+
+	configObserver := configobservercontroller.NewConfigObserver(
+		operatorClient,
+		kubeInformersForNamespaces,
+		configInformers,
+		operatorInformers,
+		resourceSyncController,
+		featureGateAccessor,
+		controllerContext.EventRecorder,
+		groupVersionsByFeatureGate,
+	)
+
+	serviceAccountIssuerController := serviceaccountissuercontroller.NewController(operatorV1Client.OperatorV1().KubeAPIServers(), operatorInformers, configInformers, controllerContext.EventRecorder)
+
+	eventWatcher := eventwatch.New().
+		WithEventHandler(operatorclient.TargetNamespace, "LateConnections", terminationobserver.ProcessLateConnectionEvents).
+		ToController(kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace), kubeClient.CoreV1(), controllerContext.EventRecorder)
 
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
 		"KubeAPIServerStaticResources",
@@ -277,8 +304,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml"}, notOnSingleReplicaTopology, nil).
 		AddKubeInformers(kubeInformersForNamespaces)
 
-	dynamicInformersForTargetNamespace := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 12*time.Hour, operatorclient.TargetNamespace, nil)
-
 	highCpuUsageAlertController := highcpuusagealertcontroller.NewHighCPUUsageAlertController(
 		configInformers.Config().V1(),
 		dynamicInformersForTargetNamespace,
@@ -307,7 +332,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	apiextensionsInformers := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClient, 10*time.Minute)
 	connectivityCheckController := connectivitycheckcontroller.NewKubeAPIServerConnectivityCheckController(
 		kubeClient,
 		operatorClient,
@@ -319,17 +343,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		apiextensionsInformers,
 		controllerContext.EventRecorder,
 	)
-
-	// don't change any versions until we sync
-	versionRecorder := status.NewVersionGetter()
-	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-apiserver", metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	for _, version := range clusterOperator.Status.Versions {
-		versionRecorder.SetVersion(version.Name, version.Version)
-	}
-	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
 
 	staticPodControllers, err := staticpod.NewBuilder(operatorClient, kubeClient, kubeInformersForNamespaces, clusterInformers.InformersFor(""), configInformers, controllerContext.Clock).
 		WithEvents(controllerContext.EventRecorder).
@@ -401,7 +414,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	migrationInformer := migrationv1alpha1informer.NewSharedInformerFactory(migrationClient, time.Minute*30)
 	migrator := migrators.NewKubeStorageVersionMigrator(migrationClient, migrationInformer.Migration().V1alpha1(), kubeClient.Discovery())
 
 	encryptionControllers, err := encryption.NewControllers(
@@ -516,6 +528,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+
+	// -- PHASE 5: Start --
+	// Metrics registration, informer starts, controller goroutine launches.
 
 	// register termination metrics
 	terminationobserver.RegisterMetrics()


### PR DESCRIPTION
## Summary
- Reorganize `RunOperator` into five clearly delineated phases: Clients and Initialization, Informer Factories, Feature Gates, Controllers, and Start
- Pure code motion with phase marker comments — no logic or constructor signatures change
- Moves interleaved client creation, informer factory creation, and bootstrap state reads into their correct phases

## Test plan
- [x] `make build` passes
- [x] `make test` passes — all unit tests pass unchanged
- [x] No behavioral changes — pure code motion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized operator startup into clearly defined initialization and startup phases.
  * Streamlined setup ordering for clients, informers, cluster topology, version tracking, and migration handling.
  * Removed duplicated initialization steps to make startup behavior more consistent and maintainable.
* **Bug Fixes**
  * Improved coordination of cluster state and configuration during operator startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->