### PR TITLE
starter: move warning-aware client creation to starter.go

### DIFF
--- a/pkg/cmd/certregenerationcontroller/cmd.go
+++ b/pkg/cmd/certregenerationcontroller/cmd.go
@@ -131,8 +131,10 @@ func (o *Options) Run(ctx context.Context, clock clock.Clock) error {
 	}
 
 	kubeAPIServerCertRotationController, err := certrotationcontroller.NewCertRotationControllerOnlyWhenExpired(
-		kubeClient,
+		kubeClient.CoreV1(),
 		operatorClient,
+		configInformers.Config().V1().Networks(),
+		configInformers.Config().V1().Infrastructures(),
 		configInformers,
 		kubeAPIServerInformersForNamespaces,
 		o.controllerContext.EventRecorder,

--- a/pkg/operator/boundsatokensignercontroller/controller.go
+++ b/pkg/operator/boundsatokensignercontroller/controller.go
@@ -16,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/keyutil"
 	"k8s.io/klog/v2"
@@ -56,14 +55,14 @@ type BoundSATokenSignerController struct {
 func NewBoundSATokenSignerController(
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	kubeClient kubernetes.Interface,
+	coreClient corev1client.CoreV1Interface,
 	eventRecorder events.Recorder,
 ) factory.Controller {
 
 	ret := &BoundSATokenSignerController{
 		operatorClient:  operatorClient,
-		secretClient:    v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		configMapClient: v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		secretClient:    v1helpers.CachedSecretGetter(coreClient, kubeInformersForNamespaces),
+		configMapClient: v1helpers.CachedConfigMapGetter(coreClient, kubeInformersForNamespaces),
 	}
 
 	return factory.New().WithInformers(

--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
+++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
@@ -9,13 +9,14 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/client-go/kubernetes"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	features "github.com/openshift/api/features"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlisterv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
 
@@ -48,8 +49,10 @@ type CertRotationController struct {
 }
 
 func NewCertRotationController(
-	kubeClient kubernetes.Interface,
+	kubeClient coreclientv1.CoreV1Interface,
 	operatorClient v1helpers.StaticPodOperatorClient,
+	networkInformer configv1informers.NetworkInformer,
+	infraInformer configv1informers.InfrastructureInformer,
 	configInformer configinformers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventRecorder events.Recorder,
@@ -58,6 +61,8 @@ func NewCertRotationController(
 	return newCertRotationController(
 		kubeClient,
 		operatorClient,
+		networkInformer,
+		infraInformer,
 		configInformer,
 		kubeInformersForNamespaces,
 		eventRecorder,
@@ -67,8 +72,10 @@ func NewCertRotationController(
 }
 
 func NewCertRotationControllerOnlyWhenExpired(
-	kubeClient kubernetes.Interface,
+	kubeClient coreclientv1.CoreV1Interface,
 	operatorClient v1helpers.StaticPodOperatorClient,
+	networkInformer configv1informers.NetworkInformer,
+	infraInformer configv1informers.InfrastructureInformer,
 	configInformer configinformers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventRecorder events.Recorder,
@@ -77,6 +84,8 @@ func NewCertRotationControllerOnlyWhenExpired(
 	return newCertRotationController(
 		kubeClient,
 		operatorClient,
+		networkInformer,
+		infraInformer,
 		configInformer,
 		kubeInformersForNamespaces,
 		eventRecorder,
@@ -86,8 +95,10 @@ func NewCertRotationControllerOnlyWhenExpired(
 }
 
 func newCertRotationController(
-	kubeClient kubernetes.Interface,
+	kubeClient coreclientv1.CoreV1Interface,
 	operatorClient v1helpers.StaticPodOperatorClient,
+	networkInformer configv1informers.NetworkInformer,
+	infraInformer configv1informers.InfrastructureInformer,
 	configInformer configinformers.SharedInformerFactory,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
 	eventRecorder events.Recorder,
@@ -95,8 +106,8 @@ func newCertRotationController(
 	refreshOnlyWhenExpired bool,
 ) (*CertRotationController, error) {
 	ret := &CertRotationController{
-		networkLister:        configInformer.Config().V1().Networks().Lister(),
-		infrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
+		networkLister:        networkInformer.Lister(),
+		infrastructureLister: infraInformer.Lister(),
 
 		serviceHostnamesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ServiceHostnames"),
 		serviceNetwork:        &DynamicServingRotation{hostnamesChanged: make(chan struct{}, 10)},
@@ -109,13 +120,13 @@ func newCertRotationController(
 
 		recorder: eventRecorder,
 		cachesToSync: []cache.InformerSynced{
-			configInformer.Config().V1().Networks().Informer().HasSynced,
-			configInformer.Config().V1().Infrastructures().Informer().HasSynced,
+			networkInformer.Informer().HasSynced,
+			infraInformer.Informer().HasSynced,
 		},
 	}
 
-	configInformer.Config().V1().Networks().Informer().AddEventHandler(ret.serviceHostnameEventHandler())
-	configInformer.Config().V1().Infrastructures().Informer().AddEventHandler(ret.externalLoadBalancerHostnameEventHandler())
+	networkInformer.Informer().AddEventHandler(ret.serviceHostnameEventHandler())
+	infraInformer.Informer().AddEventHandler(ret.externalLoadBalancerHostnameEventHandler())
 
 	foreverPeriod := 10 * 365 * 24 * time.Hour
 	foreverRefreshPeriod := 8 * 365 * 24 * time.Hour
@@ -170,7 +181,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -185,7 +196,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -207,7 +218,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -235,7 +246,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -250,7 +261,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -272,7 +283,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -304,7 +315,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -321,7 +332,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -343,7 +354,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -375,7 +386,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -392,7 +403,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -415,7 +426,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -447,7 +458,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -464,7 +475,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -487,7 +498,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -519,7 +530,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -536,7 +547,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -559,7 +570,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -591,7 +602,7 @@ func newCertRotationController(
 			Refresh:       foreverRefreshPeriod,
 			Informer:      kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:        kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:        kubeClient.CoreV1(),
+			Client:        kubeClient,
 			EventRecorder: eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -608,7 +619,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -635,7 +646,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		eventRecorder,
@@ -661,7 +672,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -676,7 +687,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -698,7 +709,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -724,7 +735,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -739,7 +750,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -761,7 +772,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -787,7 +798,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -802,7 +813,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -824,7 +835,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -850,7 +861,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -865,7 +876,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -887,7 +898,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,
@@ -915,7 +926,7 @@ func newCertRotationController(
 			PKIProfileProvider:     pkiProvider,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.CABundleConfigMap{
@@ -930,7 +941,7 @@ func newCertRotationController(
 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps(),
 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister(),
-			Client:                 kubeClient.CoreV1(),
+			Client:                 kubeClient,
 			EventRecorder:          eventRecorder,
 		},
 		certrotation.RotatedSelfSignedCertKeySecret{
@@ -959,7 +970,7 @@ func newCertRotationController(
 			PKIProfileProvider: pkiProvider,
 			Informer:           kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
 			Lister:             kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
-			Client:             kubeClient.CoreV1(),
+			Client:             kubeClient,
 			EventRecorder:      eventRecorder,
 		},
 		eventRecorder,

--- a/pkg/operator/highcpuusagealertcontroller/highcpuusagealert_controller.go
+++ b/pkg/operator/highcpuusagealertcontroller/highcpuusagealert_controller.go
@@ -35,15 +35,16 @@ type highCPUUsageAlertController struct {
 }
 
 func NewHighCPUUsageAlertController(
-	configInformer configv1informers.Interface,
+	infraInformer configv1informers.InfrastructureInformer,
+	clusterVersionInformer configv1informers.ClusterVersionInformer,
 	dynamicInformersForTargetNamespace dynamicinformer.DynamicSharedInformerFactory,
 	client dynamic.Interface,
 	recorder events.Recorder,
 ) factory.Controller {
 	c := &highCPUUsageAlertController{
 		client:               client,
-		infraLister:          configInformer.Infrastructures().Lister(),
-		clusterVersionLister: configInformer.ClusterVersions().Lister(),
+		infraLister:          infraInformer.Lister(),
+		clusterVersionLister: clusterVersionInformer.Lister(),
 	}
 
 	prometheusAlertInformerForTargetNamespace := dynamicInformersForTargetNamespace.ForResource(schema.GroupVersionResource{
@@ -53,7 +54,7 @@ func NewHighCPUUsageAlertController(
 	})
 
 	return factory.New().
-		WithInformers(configInformer.Infrastructures().Informer(), configInformer.ClusterVersions().Informer(), prometheusAlertInformerForTargetNamespace.Informer()).
+		WithInformers(infraInformer.Informer(), clusterVersionInformer.Informer(), prometheusAlertInformerForTargetNamespace.Informer()).
 		WithSync(c.sync).ResyncEvery(10*time.Minute).
 		ToController("highCPUUsageAlertController", recorder.WithComponentSuffix("high-cpu-usage-alert-controller"))
 }

--- a/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
+++ b/pkg/operator/kubeletversionskewcontroller/kubelet_version_skew_controller.go
@@ -16,8 +16,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	cache "k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -61,23 +61,21 @@ type KubeletVersionSkewController interface {
 
 func NewKubeletVersionSkewController(
 	operatorClient v1helpers.OperatorClient,
-	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	nodeLister corev1listers.NodeLister,
-	nodeInformer cache.SharedIndexInformer,
+	nodeInformer corev1informers.NodeInformer,
 	recorder events.Recorder,
 ) *kubeletVersionSkewController {
 	openShiftVersion := semver.MustParse(status.VersionForOperatorFromEnv())
 	nextOpenShiftVersion := semver.Version{Major: openShiftVersion.Major, Minor: openShiftVersion.Minor + 1}
 	c := &kubeletVersionSkewController{
 		operatorClient:              operatorClient,
-		nodeLister:                  nodeLister,
+		nodeLister:                  nodeInformer.Lister(),
 		apiServerVersion:            semver.MustParse(status.VersionForOperandFromEnv()),
 		minSupportedSkew:            minSupportedKubeletSkewForOpenShiftVersion(openShiftVersion),
 		minSupportedSkewNextVersion: minSupportedKubeletSkewForOpenShiftVersion(nextOpenShiftVersion),
 	}
 	c.Controller = factory.New().
 		WithSync(c.sync).
-		WithInformers(nodeInformer).
+		WithInformers(nodeInformer.Informer()).
 		ToController("KubeletVersionSkewController", recorder.WithComponentSuffix("kubelet-version-skew-controller"))
 	return c
 }

--- a/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
+++ b/pkg/operator/nodekubeconfigcontroller/nodekubeconfigcontroller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
@@ -30,7 +29,7 @@ const workQueueKey = "key"
 type NodeKubeconfigController struct {
 	operatorClient v1helpers.StaticPodOperatorClient
 
-	kubeClient           kubernetes.Interface
+	kubeClient           coreclientv1.CoreV1Interface
 	configMapLister      corev1listers.ConfigMapLister
 	secretLister         corev1listers.SecretLister
 	infrastructureLister configv1listers.InfrastructureLister
@@ -39,7 +38,7 @@ type NodeKubeconfigController struct {
 func NewNodeKubeconfigController(
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	kubeClient kubernetes.Interface,
+	kubeClient coreclientv1.CoreV1Interface,
 	infrastuctureInformer configv1informers.InfrastructureInformer,
 	eventRecorder events.Recorder,
 ) factory.Controller {
@@ -83,7 +82,7 @@ func (c NodeKubeconfigController) sync(ctx context.Context, syncContext factory.
 
 	err = ensureNodeKubeconfigs(
 		ctx,
-		c.kubeClient.CoreV1(),
+		c.kubeClient,
 		c.secretLister,
 		c.configMapLister,
 		c.infrastructureLister,

--- a/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
+++ b/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller.go
@@ -29,23 +29,17 @@ type PodSecurityReadinessController struct {
 	kubeClient     kubernetes.Interface
 	operatorClient v1helpers.OperatorClient
 
-	warningsHandler   *warningsHandler
+	warningsHandler   *WarningsHandler
 	namespaceSelector string
 	psaEvaluator      policy.Evaluator
 }
 
 func NewPodSecurityReadinessController(
-	kubeConfig *rest.Config,
+	kubeClient kubernetes.Interface,
+	wh *WarningsHandler,
 	operatorClient v1helpers.OperatorClient,
 	recorder events.Recorder,
 ) (factory.Controller, error) {
-	warningsHandler := &warningsHandler{}
-
-	kubeClient, err := newWarningAwareKubeClient(warningsHandler, kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	selector, err := nonEnforcingSelector()
 	if err != nil {
 		return nil, err
@@ -61,7 +55,7 @@ func NewPodSecurityReadinessController(
 	c := &PodSecurityReadinessController{
 		operatorClient:    operatorClient,
 		kubeClient:        kubeClient,
-		warningsHandler:   warningsHandler,
+		warningsHandler:   wh,
 		namespaceSelector: selector,
 		psaEvaluator:      psaEvaluator,
 	}
@@ -118,13 +112,21 @@ func nonEnforcingSelector() (string, error) {
 	return selector.Add(*labelsRequirement).String(), nil
 }
 
-func newWarningAwareKubeClient(warningsHandler *warningsHandler, kubeConfig *rest.Config) (*kubernetes.Clientset, error) {
+// NewWarningAwareKubeClient creates a kubernetes.Clientset configured with a
+// WarningsHandler and throttled QPS suitable for the pod security readiness
+// controller.
+func NewWarningAwareKubeClient(kubeConfig *rest.Config) (*kubernetes.Clientset, *WarningsHandler, error) {
+	wh := &WarningsHandler{}
 	kubeClientCopy := rest.CopyConfig(kubeConfig)
-	kubeClientCopy.WarningHandler = warningsHandler
+	kubeClientCopy.WarningHandler = wh
 	// We don't want to overwhelm the apiserver with requests. On a cluster with
 	// 10k namespaces, we would send 10k + 1 requests to the apiserver.
 	kubeClientCopy.QPS = 2
 	kubeClientCopy.Burst = 2
 
-	return kubernetes.NewForConfig(kubeClientCopy)
+	client, err := kubernetes.NewForConfig(kubeClientCopy)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, wh, nil
 }

--- a/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/podsecurityreadinesscontroller_test.go
@@ -352,7 +352,7 @@ func TestPodSecurityViolationController(t *testing.T) {
 
 			controller := &PodSecurityReadinessController{
 				kubeClient: fakeClient,
-				warningsHandler: &warningsHandler{
+				warningsHandler: &WarningsHandler{
 					warnings: tt.warnings,
 				},
 			}

--- a/pkg/operator/podsecurityreadinesscontroller/violation_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/violation_test.go
@@ -113,7 +113,7 @@ func TestIsNamespaceViolating(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockWarnings := &warningsHandler{
+			mockWarnings := &WarningsHandler{
 				warnings: tc.warnings,
 			}
 

--- a/pkg/operator/podsecurityreadinesscontroller/warning.go
+++ b/pkg/operator/podsecurityreadinesscontroller/warning.go
@@ -1,13 +1,13 @@
 package podsecurityreadinesscontroller
 
-// warningsHandler collects the warnings and makes them available.
-type warningsHandler struct {
+// WarningsHandler collects the warnings and makes them available.
+type WarningsHandler struct {
 	warnings []string
 }
 
 // HandleWarningHeader implements the WarningHandler interface. It stores the
 // warning headers.
-func (w *warningsHandler) HandleWarningHeader(code int, agent string, text string) {
+func (w *WarningsHandler) HandleWarningHeader(code int, agent string, text string) {
 	if text == "" {
 		return
 	}
@@ -16,7 +16,7 @@ func (w *warningsHandler) HandleWarningHeader(code int, agent string, text strin
 }
 
 // PopAll returns all warnings and clears the slice.
-func (w *warningsHandler) PopAll() []string {
+func (w *WarningsHandler) PopAll() []string {
 	warnings := w.warnings
 	w.warnings = []string{}
 

--- a/pkg/operator/podsecurityreadinesscontroller/warning_test.go
+++ b/pkg/operator/podsecurityreadinesscontroller/warning_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestWarningHandler(t *testing.T) {
-	w := warningsHandler{}
+	w := WarningsHandler{}
 	warningMessage := "warning"
 	w.HandleWarningHeader(0, "", warningMessage)
 

--- a/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
+++ b/pkg/operator/resourcesynccontroller/resourcesynccontroller.go
@@ -1,7 +1,7 @@
 package resourcesynccontroller
 
 import (
-	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -13,15 +13,15 @@ import (
 func NewResourceSyncController(
 	operatorConfigClient v1helpers.OperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	kubeClient kubernetes.Interface,
+	coreClient corev1client.CoreV1Interface,
 	eventRecorder events.Recorder) (*resourcesynccontroller.ResourceSyncController, error) {
 
 	resourceSyncController := resourcesynccontroller.NewResourceSyncController(
 		"kube-apiserver",
 		operatorConfigClient,
 		kubeInformersForNamespaces,
-		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		v1helpers.CachedSecretGetter(coreClient, kubeInformersForNamespaces),
+		v1helpers.CachedConfigMapGetter(coreClient, kubeInformersForNamespaces),
 		eventRecorder,
 	)
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -116,6 +116,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+	podSecurityKubeClient, podSecurityWarningsHandler, err := podsecurityreadinesscontroller.NewWarningAwareKubeClient(controllerContext.ProtoKubeConfig)
+	if err != nil {
+		return err
+	}
 	operatorV1Client, err := operatorv1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err
@@ -527,7 +531,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 
 	podSecurityReadinessController, err := podsecurityreadinesscontroller.NewPodSecurityReadinessController(
-		controllerContext.ProtoKubeConfig,
+		podSecurityKubeClient,
+		podSecurityWarningsHandler,
 		operatorClient,
 		controllerContext.EventRecorder,
 	)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -83,6 +83,10 @@ import (
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+
+	// -- PHASE 1: Clients and Initialization --
+	// All NewForConfig calls, version parsing, direct API calls that read bootstrap state.
+
 	// This kube client use protobuf, do not use it for CR
 	kubeClient, err := kubernetes.NewForConfig(controllerContext.ProtoKubeConfig)
 	if err != nil {
@@ -112,6 +116,11 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+	operatorV1Client, err := operatorv1client.NewForConfig(controllerContext.KubeConfig)
+	if err != nil {
+		return err
+	}
+
 	operandKubernetesVersion, err := semver.Parse(status.VersionForOperandFromEnv())
 	if err != nil {
 		return err
@@ -121,19 +130,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
-		kubeClient,
-		operatorclient.GlobalUserSpecifiedConfigNamespace,
-		operatorclient.GlobalMachineSpecifiedConfigNamespace,
-		operatorclient.TargetNamespace,
-		operatorclient.OperatorNamespace,
-		"kube-system", // system:openshift:controller:kube-apiserver-check-endpoints role binding
-		"openshift-etcd",
-		"openshift-apiserver",
-	)
-	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
+	desiredVersion := status.VersionForOperatorFromEnv()
+	missingVersion := "0.0.1-snapshot"
 
-	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
 	operatorClient, dynamicInformersForAllNamespaces, err := genericoperatorclient.NewStaticPodOperatorClient(
 		controllerContext.Clock,
 		controllerContext.KubeConfig,
@@ -145,63 +144,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
-
-	securityInformers := securityvnformers.NewSharedInformerFactory(securityClient, 10*time.Minute)
-
-	desiredVersion := status.VersionForOperatorFromEnv()
-	missingVersion := "0.0.1-snapshot"
-
-	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		desiredVersion, missingVersion,
-		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
-		controllerContext.EventRecorder,
-	)
-	go featureGateAccessor.Run(ctx)
-	go configInformers.Start(ctx.Done())
-
-	var featureGates featuregates.FeatureGate
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, _ = featureGateAccessor.CurrentFeatureGates()
-		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
-	case <-time.After(1 * time.Minute):
-		klog.Errorf("timed out waiting for FeatureGate detection")
-		return fmt.Errorf("timed out waiting for FeatureGate detection")
-	}
-
-	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
-		operatorClient,
-		kubeInformersForNamespaces,
-		kubeClient,
-		controllerContext.EventRecorder,
-	)
-	if err != nil {
-		return err
-	}
-
-	operatorV1Client, err := operatorv1client.NewForConfig(controllerContext.KubeConfig)
-	if err != nil {
-		return err
-	}
-	operatorInformers := operatorv1informers.NewSharedInformerFactory(operatorV1Client, 10*time.Minute)
-
-	configObserver := configobservercontroller.NewConfigObserver(
-		operatorClient,
-		kubeInformersForNamespaces,
-		configInformers,
-		operatorInformers,
-		resourceSyncController,
-		featureGateAccessor,
-		controllerContext.EventRecorder,
-		groupVersionsByFeatureGate,
-	)
-
-	serviceAccountIssuerController := serviceaccountissuercontroller.NewController(operatorV1Client.OperatorV1().KubeAPIServers(), operatorInformers, configInformers, controllerContext.EventRecorder)
-
-	eventWatcher := eventwatch.New().
-		WithEventHandler(operatorclient.TargetNamespace, "LateConnections", terminationobserver.ProcessLateConnectionEvents).
-		ToController(kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace), kubeClient.CoreV1(), controllerContext.EventRecorder)
 
 	// TODO: use informer instead of direct api call
 	// Also, in the future there is a plan to make infrastructure type dynamic
@@ -227,6 +169,91 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	var requireMultipleEtcdEndpoints resourceapply.ConditionalFunction = func() bool {
 		return isMultipleEtcdEndpointsRequired
 	}
+
+	// don't change any versions until we sync
+	versionRecorder := status.NewVersionGetter()
+	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-apiserver", metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	for _, version := range clusterOperator.Status.Versions {
+		versionRecorder.SetVersion(version.Name, version.Version)
+	}
+	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
+
+	// -- PHASE 2: Informer Factories --
+	// All SharedInformerFactory and KubeInformersForNamespaces creation.
+
+	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		operatorclient.GlobalUserSpecifiedConfigNamespace,
+		operatorclient.GlobalMachineSpecifiedConfigNamespace,
+		operatorclient.TargetNamespace,
+		operatorclient.OperatorNamespace,
+		"kube-system", // system:openshift:controller:kube-apiserver-check-endpoints role binding
+		"openshift-etcd",
+		"openshift-apiserver",
+	)
+	clusterInformers := v1helpers.NewKubeInformersForNamespaces(kubeClient, "")
+
+	configInformers := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
+	securityInformers := securityvnformers.NewSharedInformerFactory(securityClient, 10*time.Minute)
+	operatorInformers := operatorv1informers.NewSharedInformerFactory(operatorV1Client, 10*time.Minute)
+	dynamicInformersForTargetNamespace := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 12*time.Hour, operatorclient.TargetNamespace, nil)
+	apiextensionsInformers := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClient, 10*time.Minute)
+	migrationInformer := migrationv1alpha1informer.NewSharedInformerFactory(migrationClient, time.Minute*30)
+
+	// -- PHASE 3: Feature Gates --
+	// FeatureGateAccess creation, config informers early start, blocking wait.
+
+	// By default, this will exit(0) the process if the featuregates ever change to a different set of values.
+	featureGateAccessor := featuregates.NewFeatureGateAccess(
+		desiredVersion, missingVersion,
+		configInformers.Config().V1().ClusterVersions(), configInformers.Config().V1().FeatureGates(),
+		controllerContext.EventRecorder,
+	)
+	go featureGateAccessor.Run(ctx)
+	go configInformers.Start(ctx.Done())
+
+	var featureGates featuregates.FeatureGate
+	select {
+	case <-featureGateAccessor.InitialFeatureGatesObserved():
+		featureGates, _ = featureGateAccessor.CurrentFeatureGates()
+		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+	case <-time.After(1 * time.Minute):
+		klog.Errorf("timed out waiting for FeatureGate detection")
+		return fmt.Errorf("timed out waiting for FeatureGate detection")
+	}
+
+	// -- PHASE 4: Controllers --
+	// All controller construction.
+
+	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
+		operatorClient,
+		kubeInformersForNamespaces,
+		kubeClient,
+		controllerContext.EventRecorder,
+	)
+	if err != nil {
+		return err
+	}
+
+	configObserver := configobservercontroller.NewConfigObserver(
+		operatorClient,
+		kubeInformersForNamespaces,
+		configInformers,
+		operatorInformers,
+		resourceSyncController,
+		featureGateAccessor,
+		controllerContext.EventRecorder,
+		groupVersionsByFeatureGate,
+	)
+
+	serviceAccountIssuerController := serviceaccountissuercontroller.NewController(operatorV1Client.OperatorV1().KubeAPIServers(), operatorInformers, configInformers, controllerContext.EventRecorder)
+
+	eventWatcher := eventwatch.New().
+		WithEventHandler(operatorclient.TargetNamespace, "LateConnections", terminationobserver.ProcessLateConnectionEvents).
+		ToController(kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace), kubeClient.CoreV1(), controllerContext.EventRecorder)
 
 	staticResourceController := staticresourcecontroller.NewStaticResourceController(
 		"KubeAPIServerStaticResources",
@@ -277,8 +304,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		WithConditionalResources(bindata.Asset, []string{"assets/alerts/kube-apiserver-slos-extended.yaml"}, notOnSingleReplicaTopology, nil).
 		AddKubeInformers(kubeInformersForNamespaces)
 
-	dynamicInformersForTargetNamespace := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 12*time.Hour, operatorclient.TargetNamespace, nil)
-
 	highCpuUsageAlertController := highcpuusagealertcontroller.NewHighCPUUsageAlertController(
 		configInformers.Config().V1(),
 		dynamicInformersForTargetNamespace,
@@ -307,7 +332,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 	)
 
-	apiextensionsInformers := apiextensionsinformers.NewSharedInformerFactory(apiextensionsClient, 10*time.Minute)
 	connectivityCheckController := connectivitycheckcontroller.NewKubeAPIServerConnectivityCheckController(
 		kubeClient,
 		operatorClient,
@@ -319,17 +343,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		apiextensionsInformers,
 		controllerContext.EventRecorder,
 	)
-
-	// don't change any versions until we sync
-	versionRecorder := status.NewVersionGetter()
-	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "kube-apiserver", metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	for _, version := range clusterOperator.Status.Versions {
-		versionRecorder.SetVersion(version.Name, version.Version)
-	}
-	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
 
 	staticPodControllers, err := staticpod.NewBuilder(operatorClient, kubeClient, kubeInformersForNamespaces, clusterInformers.InformersFor(""), configInformers, controllerContext.Clock).
 		WithEvents(controllerContext.EventRecorder).
@@ -401,7 +414,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		return err
 	}
 
-	migrationInformer := migrationv1alpha1informer.NewSharedInformerFactory(migrationClient, time.Minute*30)
 	migrator := migrators.NewKubeStorageVersionMigrator(migrationClient, migrationInformer.Migration().V1alpha1(), kubeClient.Discovery())
 
 	encryptionControllers, err := encryption.NewControllers(
@@ -516,6 +528,9 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+
+	// -- PHASE 5: Start --
+	// Metrics registration, informer starts, controller goroutine launches.
 
 	// register termination metrics
 	terminationobserver.RegisterMetrics()

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -231,7 +231,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	resourceSyncController, err := resourcesynccontroller.NewResourceSyncController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		kubeClient,
+		kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
 	)
 	if err != nil {
@@ -327,7 +327,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	nodeKubeconfigController := nodekubeconfigcontroller.NewNodeKubeconfigController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		kubeClient,
+		kubeClient.CoreV1(),
 		configInformers.Config().V1().Infrastructures(),
 		controllerContext.EventRecorder,
 	)
@@ -454,7 +454,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	boundSATokenSignerController := boundsatokensignercontroller.NewBoundSATokenSignerController(
 		operatorClient,
 		kubeInformersForNamespaces,
-		kubeClient,
+		kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -311,14 +311,17 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		dynamicClient,
 		controllerContext.EventRecorder)
 
+	targetNSInformersFactory := kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace)
 	targetConfigReconciler := targetconfigcontroller.NewTargetConfigController(
 		os.Getenv("IMAGE"),
 		os.Getenv("OPERATOR_IMAGE"),
 		os.Getenv("OPERATOR_IMAGE_VERSION"),
 		operatorClient,
-		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
+		targetNSInformersFactory.Core().V1().ConfigMaps(),
+		targetNSInformersFactory.Core().V1().Secrets(),
+		targetNSInformersFactory.Core().V1().ServiceAccounts(),
 		kubeInformersForNamespaces,
-		kubeClient,
+		kubeClient.CoreV1(),
 		featureGateAccessor,
 		startupmonitorreadiness.IsStartupMonitorEnabledFunction(configInformers.Config().V1().Infrastructures().Lister(), operatorClient),
 		requireMultipleEtcdEndpoints,
@@ -398,8 +401,10 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	).WithDegradedInertia(newDegradedInertia())
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
-		kubeClient,
+		kubeClient.CoreV1(),
 		operatorClient,
+		configInformers.Config().V1().Networks(),
+		configInformers.Config().V1().Infrastructures(),
 		configInformers,
 		kubeInformersForNamespaces,
 		controllerContext.EventRecorder.WithComponentSuffix("cert-rotation-controller"),

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -305,7 +305,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		AddKubeInformers(kubeInformersForNamespaces)
 
 	highCpuUsageAlertController := highcpuusagealertcontroller.NewHighCPUUsageAlertController(
-		configInformers.Config().V1(),
+		configInformers.Config().V1().Infrastructures(),
+		configInformers.Config().V1().ClusterVersions(),
 		dynamicInformersForTargetNamespace,
 		dynamicClient,
 		controllerContext.EventRecorder)
@@ -444,9 +445,11 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder.WithComponentSuffix("cert-rotation-controller"),
 	)
 
+	targetNSInformers := kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace)
 	terminationObserver := terminationobserver.NewTerminationObserver(
 		operatorclient.TargetNamespace,
-		kubeInformersForNamespaces.InformersFor(operatorclient.TargetNamespace),
+		targetNSInformers.Core().V1().Pods(),
+		targetNSInformers.Core().V1().Events(),
 		kubeClient.CoreV1(),
 		controllerContext.EventRecorder,
 	)
@@ -487,9 +490,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 
 	kubeletVersionSkewController := kubeletversionskewcontroller.NewKubeletVersionSkewController(
 		operatorClient,
-		kubeInformersForNamespaces,
-		clusterInformers.InformersFor("").Core().V1().Nodes().Lister(),
-		clusterInformers.InformersFor("").Core().V1().Nodes().Informer(),
+		clusterInformers.InformersFor("").Core().V1().Nodes(),
 		controllerContext.EventRecorder,
 	)
 
@@ -510,7 +511,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	webhookSupportabilityController := webhooksupportabilitycontroller.NewWebhookSupportabilityController(
 		operatorClient,
 		clusterInformers,
-		apiextensionsInformers,
+		apiextensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),
 		controllerContext.EventRecorder,
 	)
 

--- a/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
+++ b/pkg/operator/targetconfigcontroller/targetconfigcontroller.go
@@ -37,8 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
@@ -56,7 +55,7 @@ type TargetConfigController struct {
 
 	operatorClient v1helpers.StaticPodOperatorClient
 
-	kubeClient      kubernetes.Interface
+	kubeClient      coreclientv1.CoreV1Interface
 	configMapLister corev1listers.ConfigMapLister
 
 	featureGateAccessor featuregates.FeatureGateAccess
@@ -68,9 +67,11 @@ type TargetConfigController struct {
 func NewTargetConfigController(
 	targetImagePullSpec, operatorImagePullSpec, operatorImageVersion string,
 	operatorClient v1helpers.StaticPodOperatorClient,
-	kubeInformersForOpenshiftKubeAPIServerNamespace informers.SharedInformerFactory,
+	configMapInformer coreinformersv1.ConfigMapInformer,
+	secretInformer coreinformersv1.SecretInformer,
+	serviceAccountInformer coreinformersv1.ServiceAccountInformer,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	kubeClient kubernetes.Interface,
+	kubeClient coreclientv1.CoreV1Interface,
 	featureGateAccessor featuregates.FeatureGateAccess,
 	isStartupMonitorEnabledFn func() (bool, error),
 	requireMultipleEtcdEndpointsFn func() bool,
@@ -90,9 +91,9 @@ func NewTargetConfigController(
 
 	return factory.New().WithInformers(
 		operatorClient.Informer(),
-		kubeInformersForOpenshiftKubeAPIServerNamespace.Core().V1().ConfigMaps().Informer(),
-		kubeInformersForOpenshiftKubeAPIServerNamespace.Core().V1().Secrets().Informer(),
-		kubeInformersForOpenshiftKubeAPIServerNamespace.Core().V1().ServiceAccounts().Informer(),
+		configMapInformer.Informer(),
+		secretInformer.Informer(),
+		serviceAccountInformer.Informer(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
 		kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Informer(),
@@ -221,29 +222,29 @@ func etcdEndpointsPresent(configMapLister corev1listers.ConfigMapLister, config 
 func createTargetConfig(ctx context.Context, c TargetConfigController, recorder events.Recorder, operatorSpec *operatorv1.StaticPodOperatorSpec) (bool, error) {
 	errors := []error{}
 
-	_, _, err := manageKubeAPIServerConfig(ctx, c.kubeClient.CoreV1(), recorder, operatorSpec)
+	_, _, err := manageKubeAPIServerConfig(ctx, c.kubeClient, recorder, operatorSpec)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/config", err))
 	}
-	_, _, err = managePods(ctx, c.kubeClient.CoreV1(), c.kubeClient.CoreV1(), c.featureGateAccessor, c.isStartupMonitorEnabledFn, recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.operatorImageVersion)
+	_, _, err = managePods(ctx, c.kubeClient, c.kubeClient, c.featureGateAccessor, c.isStartupMonitorEnabledFn, recorder, operatorSpec, c.targetImagePullSpec, c.operatorImagePullSpec, c.operatorImageVersion)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-pod", err))
 	}
-	_, _, err = ManageClientCABundle(ctx, c.configMapLister, c.kubeClient.CoreV1(), recorder)
+	_, _, err = ManageClientCABundle(ctx, c.configMapLister, c.kubeClient, recorder)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/client-ca", err))
 	}
-	_, _, err = manageKubeAPIServerCABundle(ctx, c.configMapLister, c.kubeClient.CoreV1(), recorder)
+	_, _, err = manageKubeAPIServerCABundle(ctx, c.configMapLister, c.kubeClient, recorder)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/kube-apiserver-server-ca", err))
 	}
 
-	err = ensureKubeAPIServerTrustedCA(ctx, c.kubeClient.CoreV1(), recorder)
+	err = ensureKubeAPIServerTrustedCA(ctx, c.kubeClient, recorder)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "configmap/trusted-ca-bundle", err))
 	}
 
-	err = ensureLocalhostRecoverySAToken(ctx, c.kubeClient.CoreV1(), recorder)
+	err = ensureLocalhostRecoverySAToken(ctx, c.kubeClient, recorder)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("%q: %v", "serviceaccount/localhost-recovery-client", err))
 	}

--- a/pkg/operator/terminationobserver/termination_observer.go
+++ b/pkg/operator/terminationobserver/termination_observer.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -76,7 +76,8 @@ func RegisterMetrics() {
 
 func NewTerminationObserver(
 	targetNamespace string,
-	kubeInformersForTargetNamespace informers.SharedInformerFactory,
+	podInformer corev1informers.PodInformer,
+	eventInformer corev1informers.EventInformer,
 	podsGetter corev1client.PodsGetter,
 	eventRecorder events.Recorder,
 ) *TerminationObserver {
@@ -88,11 +89,11 @@ func NewTerminationObserver(
 		apiServerTerminationTime: map[string]time.Time{},
 	}
 
-	kubeInformersForTargetNamespace.Core().V1().Pods().Informer().AddEventHandler(c.eventHandler())
-	kubeInformersForTargetNamespace.Core().V1().Events().Informer().AddEventHandler(c.terminationEventRecorder())
+	podInformer.Informer().AddEventHandler(c.eventHandler())
+	eventInformer.Informer().AddEventHandler(c.terminationEventRecorder())
 
-	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Pods().Informer().HasSynced)
-	c.cachesToSync = append(c.cachesToSync, kubeInformersForTargetNamespace.Core().V1().Events().Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, podInformer.Informer().HasSynced)
+	c.cachesToSync = append(c.cachesToSync, eventInformer.Informer().HasSynced)
 
 	return c
 }

--- a/pkg/operator/webhooksupportabilitycontroller/webhook_supportability_controller.go
+++ b/pkg/operator/webhooksupportabilitycontroller/webhook_supportability_controller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	apiextensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	apiextensionslistersv1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	admissionregistrationlistersv1 "k8s.io/client-go/listers/admissionregistration/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -29,7 +29,7 @@ type webhookSupportabilityController struct {
 func NewWebhookSupportabilityController(
 	operatorClient v1helpers.StaticPodOperatorClient,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	apiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
+	crdInformer apiextensionsv1informers.CustomResourceDefinitionInformer,
 	recorder events.Recorder,
 ) *webhookSupportabilityController {
 	kubeInformersForAllNamespaces := kubeInformersForNamespaces.InformersFor("")
@@ -38,7 +38,7 @@ func NewWebhookSupportabilityController(
 		mutatingWebhookLister:   kubeInformersForAllNamespaces.Admissionregistration().V1().MutatingWebhookConfigurations().Lister(),
 		validatingWebhookLister: kubeInformersForAllNamespaces.Admissionregistration().V1().ValidatingWebhookConfigurations().Lister(),
 		serviceLister:           kubeInformersForAllNamespaces.Core().V1().Services().Lister(),
-		crdLister:               apiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Lister(),
+		crdLister:               crdInformer.Lister(),
 	}
 	c.Controller = factory.New().
 		WithInformers(
@@ -51,7 +51,7 @@ func NewWebhookSupportabilityController(
 				return hasCRDConversionWebhookConfiguration(crd)
 			}
 			return true // re-queue just in case, the checks are fairly cheap
-		}, apiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Informer()).
+		}, crdInformer.Informer()).
 		WithSync(c.sync).
 		ToController("webhookSupportabilityController", recorder)
 	return c


### PR DESCRIPTION
## Summary
- Export `PodSecurityReadinessController`'s `WarningsHandler` type and `NewWarningAwareKubeClient` function
- Starter.go calls `NewWarningAwareKubeClient` in Phase 1 and passes the client + handler to the constructor
- The controller no longer receives `*rest.Config` directly

Depends on #2242

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] No behavioral changes — client construction moved to starter.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Reliability**
  * Improved controller startup and synchronization by using more specific Kubernetes clients and informers.
  * Enhanced certificate rotation, node configuration, resource synchronization, and termination monitoring.
  * Improved infrastructure topology detection and version tracking during operator startup.

* **Pod Security**
  * Exposed warning handling for clearer integration with pod security readiness checks.
  * Reused warning-aware client setup across pod security components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->