### PR TITLE
CNTRLPLANE-4110: Migrate e2e encryption perf cases to ote

### DIFF
--- a/cmd/cluster-kube-apiserver-operator-tests-ext/dependencymagnet.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/dependencymagnet.go
@@ -6,4 +6,5 @@ import (
 	// Import test packages to register Ginkgo tests
 	_ "github.com/openshift/cluster-kube-apiserver-operator/test/e2e"
 	_ "github.com/openshift/cluster-kube-apiserver-operator/test/e2e-encryption-kms"
+	_ "github.com/openshift/cluster-kube-apiserver-operator/test/e2e-encryption-perf"
 )

--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -112,6 +112,30 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		},
 	})
 
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-apiserver-operator/encryption-perf",
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-perf]")`,
+		},
+	})
+
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-apiserver-operator/encryption-perf-aescbc",
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-perf-aescbc]")`,
+		},
+	})
+
+	extension.AddSuite(oteextension.Suite{
+		Name:        "openshift/cluster-kube-apiserver-operator/encryption-perf-aesgcm",
+		Parallelism: 1,
+		Qualifiers: []string{
+			`name.contains("[Suite:encryption-perf-aesgcm]")`,
+		},
+	})
+
 	specs, err := oteginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build extension test specs from ginkgo: %w", err)

--- a/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
+++ b/cmd/cluster-kube-apiserver-operator-tests-ext/main.go
@@ -120,22 +120,6 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 		},
 	})
 
-	extension.AddSuite(oteextension.Suite{
-		Name:        "openshift/cluster-kube-apiserver-operator/encryption-perf-aescbc",
-		Parallelism: 1,
-		Qualifiers: []string{
-			`name.contains("[Suite:encryption-perf-aescbc]")`,
-		},
-	})
-
-	extension.AddSuite(oteextension.Suite{
-		Name:        "openshift/cluster-kube-apiserver-operator/encryption-perf-aesgcm",
-		Parallelism: 1,
-		Qualifiers: []string{
-			`name.contains("[Suite:encryption-perf-aesgcm]")`,
-		},
-	})
-
 	specs, err := oteginkgo.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't build extension test specs from ginkgo: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20260805215214-cfb63858e9d7
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7
-	github.com/openshift/library-go v0.0.0-20260813053130-afd94040089b
+	github.com/openshift/library-go v0.0.0-20260814122159-7b930c0d20a6
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7 h1:Lphm0uMAyM26ibbOca0+dg7uLz7GmmrIdeWjzOh5R/U=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7/go.mod h1:u08LcpI8Hq3IpelQLbciGRa/P158cE/O3uQe2Bt3Roo=
-github.com/openshift/library-go v0.0.0-20260813053130-afd94040089b h1:zEEp1dDqLV2KvtQA7K5YwA5bvPe8SA5fs+Y2GvppRn8=
-github.com/openshift/library-go v0.0.0-20260813053130-afd94040089b/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
+github.com/openshift/library-go v0.0.0-20260814122159-7b930c0d20a6 h1:i61W73pZMX6T1CADNODJSNQqIIXT84zqs6kRGfkBM9Y=
+github.com/openshift/library-go v0.0.0-20260814122159-7b930c0d20a6/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/test/e2e-encryption-perf/encryption_perf.go
+++ b/test/e2e-encryption-perf/encryption_perf.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -31,23 +32,26 @@ const (
 
 var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
 
+// resolveEncryptionProvider returns the encryption type from the ENCRYPTION_PROVIDER
+// env var (used in OTE/CI), falling back to the -provider flag (used in Makefile runs).
+func resolveEncryptionProvider() configv1.EncryptionType {
+	if env := os.Getenv("ENCRYPTION_PROVIDER"); env != "" {
+		return configv1.EncryptionType(env)
+	}
+	return configv1.EncryptionType(*provider)
+}
+
 var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
-	g.It("TestPerfEncryption [Serial][Timeout:120m][Suite:encryption-perf]", func() {
-		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionType(*provider))
-	})
-
-	g.It("TestPerfEncryptionAESCBC [Serial][Timeout:120m][Suite:encryption-perf-aescbc]", func() {
-		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionTypeAESCBC)
-	})
-
-	g.It("TestPerfEncryptionAESGCM [Serial][Timeout:120m][Suite:encryption-perf-aesgcm]", func() {
-		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionTypeAESGCM)
+	g.It("TestPerfEncryption [Serial][Timeout:120m][Suite:encryption-perf]", func(ctx context.Context) {
+		testPerfEncryption(ctx, g.GinkgoTB())
 	})
 })
 
-func testPerfEncryption(tt testing.TB, encType configv1.EncryptionType) {
+func testPerfEncryption(ctx context.Context, tt testing.TB) {
+	encType := resolveEncryptionProvider()
+	tt.Logf("encryption type: %s\n", encType)
 	operatorClient := operatorencryption.GetOperator(tt)
-	library.TestPerfEncryption(tt.Context(), tt, library.PerfScenario{
+	library.TestPerfEncryption(ctx, tt, library.PerfScenario{
 		BasicScenario: library.BasicScenario{
 			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
 			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,

--- a/test/e2e-encryption-perf/encryption_perf.go
+++ b/test/e2e-encryption-perf/encryption_perf.go
@@ -1,0 +1,175 @@
+package e2e_encryption_perf
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
+	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
+	library "github.com/openshift/library-go/test/library/encryption"
+
+	g "github.com/onsi/ginkgo/v2"
+)
+
+const (
+	cmStatsKey      = "created configmaps"
+	secretsStatsKey = "created secrets"
+)
+
+var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
+
+var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
+	g.It("TestPerfEncryption [Serial][Timeout:120m][Suite:encryption-perf]", func() {
+		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionType(*provider))
+	})
+
+	g.It("TestPerfEncryptionAESCBC [Serial][Timeout:120m][Suite:encryption-perf-aescbc]", func() {
+		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionTypeAESCBC)
+	})
+
+	g.It("TestPerfEncryptionAESGCM [Serial][Timeout:120m][Suite:encryption-perf-aesgcm]", func() {
+		testPerfEncryption(g.GinkgoTB(), configv1.EncryptionTypeAESGCM)
+	})
+})
+
+func testPerfEncryption(tt testing.TB, encType configv1.EncryptionType) {
+	operatorClient := operatorencryption.GetOperator(tt)
+	library.TestPerfEncryption(tt.Context(), tt, library.PerfScenario{
+		BasicScenario: library.BasicScenario{
+			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+			OperatorNamespace:               operatorclient.OperatorNamespace,
+			TargetGRs:                       library.WellKnownKASTargetGRs,
+			AssertFunc:                      library.AssertWellKnownSecretsAndConfigMaps,
+		},
+		GetOperatorConditionsFunc: func(t testing.TB) ([]operatorv1.OperatorCondition, error) {
+			apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return apiServerOperator.Status.Conditions, nil
+		},
+		AssertDBPopulatedFunc: func(t testing.TB, errorStore map[string]int, statStore map[string]int) {
+			secretsCount, ok := statStore[secretsStatsKey]
+			if !ok {
+				err := errors.New("missing secrets count stats, can't continue the test")
+				require.NoError(t, err)
+			}
+			if secretsCount < 25000 {
+				err := fmt.Errorf("expected to create at least 25000 secrets but %d were created", secretsCount)
+				require.NoError(t, err)
+			}
+			t.Logf("Created %d secrets", secretsCount)
+
+			configMpasCount, ok := statStore[cmStatsKey]
+			if !ok {
+				err := errors.New("missing configmaps count stats, can't continue the test")
+				require.NoError(t, err)
+			}
+			if configMpasCount < 14000 {
+				err := fmt.Errorf("expected to create at least 14000 configmaps but %d were created", configMpasCount)
+				require.NoError(t, err)
+			}
+			t.Logf("Created %d configmaps", configMpasCount)
+
+		},
+		AssertMigrationTime: func(t testing.TB, migrationTime time.Duration) {
+			t.Logf("migration took %v", migrationTime)
+			expectedMigrationTime := 28 * time.Minute
+			if migrationTime > expectedMigrationTime {
+				t.Errorf("migration took too long (%v), expected it to take no more than %v", migrationTime, expectedMigrationTime)
+			}
+		},
+		DBLoaderWorkers: 3,
+		DBLoaderFunc: library.DBLoaderRepeat(1, true,
+			createNamespace,
+			waitUntilNamespaceActive,
+			library.DBLoaderRepeatParallel(5010, 50, false, createConfigMap, reportConfigMap),
+			library.DBLoaderRepeatParallel(9010, 50, false, createSecret, reportSecret)),
+		EncryptionProvider: library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: encType}},
+	})
+}
+
+func createSecret(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "encryption-",
+		},
+		Data: map[string][]byte{
+			"quote": []byte("I have no special talents. I am only passionately curious"),
+		},
+	}
+	_, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	return err
+}
+
+func reportSecret(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
+	statsCollector(secretsStatsKey)
+	return nil
+}
+
+func createConfigMap(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "encryption-",
+		},
+		Data:       nil,
+		BinaryData: nil,
+	}
+
+	_, err := kubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+	return err
+}
+
+func reportConfigMap(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
+	statsCollector(cmStatsKey)
+	return nil
+}
+
+func createNamespace(kubeClient kubernetes.Interface, name string, errorCollector func(error), statsCollector func(string)) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+		},
+		Status: corev1.NamespaceStatus{},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	return err
+}
+
+func waitUntilNamespaceActive(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
+	err := wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
+		ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if ns.Status.Phase == corev1.NamespaceActive {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		err = fmt.Errorf("failed waiting for ns to become ready, err %v", err)
+		errorCollector(err)
+	}
+	return err
+}

--- a/test/e2e-encryption-perf/encryption_perf_test.go
+++ b/test/e2e-encryption-perf/encryption_perf_test.go
@@ -1,10 +1,6 @@
 package e2e_encryption_perf
 
-import (
-	"testing"
-
-	configv1 "github.com/openshift/api/config/v1"
-)
+import "testing"
 
 // This test calls the shared TestPerfEncryption function which
 // can be called from both standard Go tests and Ginkgo tests.
@@ -12,5 +8,5 @@ import (
 // This situation is temporary until we test the new encryption perf ote jobs.
 // Eventually all tests will be run only as part of the OTE framework.
 func TestPerfEncryption(tt *testing.T) {
-	testPerfEncryption(tt, configv1.EncryptionType(*provider))
+	testPerfEncryption(tt.Context(), tt)
 }

--- a/test/e2e-encryption-perf/encryption_perf_test.go
+++ b/test/e2e-encryption-perf/encryption_perf_test.go
@@ -1,159 +1,16 @@
 package e2e_encryption_perf
 
 import (
-	"context"
-	"errors"
-	"flag"
-	"fmt"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/operatorclient"
-	operatorencryption "github.com/openshift/cluster-kube-apiserver-operator/test/library/encryption"
-	library "github.com/openshift/library-go/test/library/encryption"
 )
 
-const (
-	cmStatsKey      = "created configmaps"
-	secretsStatsKey = "created secrets"
-)
-
-var provider = flag.String("provider", "aescbc", "encryption provider used by the tests")
-
+// This test calls the shared TestPerfEncryption function which
+// can be called from both standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new encryption perf ote jobs.
+// Eventually all tests will be run only as part of the OTE framework.
 func TestPerfEncryption(tt *testing.T) {
-	operatorClient := operatorencryption.GetOperator(tt)
-	library.TestPerfEncryption(tt.Context(), tt, library.PerfScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       library.WellKnownKASTargetGRs,
-			AssertFunc:                      library.AssertWellKnownSecretsAndConfigMaps,
-		},
-		GetOperatorConditionsFunc: func(t testing.TB) ([]operatorv1.OperatorCondition, error) {
-			apiServerOperator, err := operatorClient.Get(context.TODO(), "cluster", metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-			return apiServerOperator.Status.Conditions, nil
-		},
-		AssertDBPopulatedFunc: func(t testing.TB, errorStore map[string]int, statStore map[string]int) {
-			secretsCount, ok := statStore[secretsStatsKey]
-			if !ok {
-				err := errors.New("missing secrets count stats, can't continue the test")
-				require.NoError(t, err)
-			}
-			if secretsCount < 25000 {
-				err := fmt.Errorf("expected to create at least 25000 secrets but %d were created", secretsCount)
-				require.NoError(t, err)
-			}
-			t.Logf("Created %d secrets", secretsCount)
-
-			configMpasCount, ok := statStore[cmStatsKey]
-			if !ok {
-				err := errors.New("missing configmaps count stats, can't continue the test")
-				require.NoError(t, err)
-			}
-			if configMpasCount < 14000 {
-				err := fmt.Errorf("expected to create at least 14000 configmaps but %d were created", configMpasCount)
-				require.NoError(t, err)
-			}
-			t.Logf("Created %d configmaps", configMpasCount)
-
-		},
-		AssertMigrationTime: func(t testing.TB, migrationTime time.Duration) {
-			t.Logf("migration took %v", migrationTime)
-			expectedMigrationTime := 28 * time.Minute
-			if migrationTime > expectedMigrationTime {
-				t.Errorf("migration took too long (%v), expected it to take no more than %v", migrationTime, expectedMigrationTime)
-			}
-		},
-		DBLoaderWorkers: 3,
-		DBLoaderFunc: library.DBLoaderRepeat(1, true,
-			createNamespace,
-			waitUntilNamespaceActive,
-			library.DBLoaderRepeatParallel(5010, 50, false, createConfigMap, reportConfigMap),
-			library.DBLoaderRepeatParallel(9010, 50, false, createSecret, reportSecret)),
-		EncryptionProvider: library.EncryptionProvider{APIServerEncryption: configv1.APIServerEncryption{Type: configv1.EncryptionType(*provider)}},
-	})
-}
-
-func createSecret(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
-			GenerateName: "encryption-",
-		},
-		Data: map[string][]byte{
-			"quote": []byte("I have no special talents. I am only passionately curious"),
-		},
-	}
-	_, err := kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-	return err
-}
-
-func reportSecret(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
-	statsCollector(secretsStatsKey)
-	return nil
-}
-
-func createConfigMap(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
-	cm := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
-			GenerateName: "encryption-",
-		},
-		Data:       nil,
-		BinaryData: nil,
-	}
-
-	_, err := kubeClient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
-	return err
-}
-
-func reportConfigMap(_ kubernetes.Interface, _ string, _ func(error), statsCollector func(string)) error {
-	statsCollector(cmStatsKey)
-	return nil
-}
-
-func createNamespace(kubeClient kubernetes.Interface, name string, errorCollector func(error), statsCollector func(string)) error {
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "",
-		},
-		Status: corev1.NamespaceStatus{},
-	}
-	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
-	return err
-}
-
-func waitUntilNamespaceActive(kubeClient kubernetes.Interface, namespace string, errorCollector func(error), statsCollector func(string)) error {
-	err := wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
-		ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if ns.Status.Phase == corev1.NamespaceActive {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		err = fmt.Errorf("failed waiting for ns to become ready, err %v", err)
-		errorCollector(err)
-	}
-	return err
+	testPerfEncryption(tt, configv1.EncryptionType(*provider))
 }

--- a/vendor/github.com/openshift/library-go/test/library/encryption/errors.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/errors.go
@@ -46,7 +46,7 @@ func transientAPIError(err error) bool {
 	switch {
 	case err == nil:
 		return false
-	case errors.IsServerTimeout(err), errors.IsTooManyRequests(err), net.IsProbableEOF(err), net.IsConnectionReset(err), net.IsNoRoutesError(err), isConnectionRefusedError(err), isGolangNetTimeout(err):
+	case errors.IsServiceUnavailable(err), errors.IsServerTimeout(err), errors.IsTooManyRequests(err), net.IsProbableEOF(err), net.IsConnectionReset(err), net.IsNoRoutesError(err), isConnectionRefusedError(err), isGolangNetTimeout(err):
 		return true
 	default:
 		return false

--- a/vendor/github.com/openshift/library-go/test/library/encryption/perf_helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/perf_helpers.go
@@ -26,6 +26,10 @@ func watchForMigrationControllerProgressingCondition(t testing.TB, getOperatorCo
 	err := wait.Poll(waitPollInterval, waitPollTimeout, func() (bool, error) {
 		conditions, err := getOperatorConditionsFn(t)
 		if err != nil {
+			if transientAPIError(err) {
+				t.Logf("failed to get operator conditions, will retry: %v", err)
+				return false, nil
+			}
 			return false, err
 		}
 		for _, cond := range conditions {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260813053130-afd94040089b
+# github.com/openshift/library-go v0.0.0-20260814122159-7b930c0d20a6
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
Migrate e2e encryption perf cases to ote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end encryption performance coverage for configurable encryption providers.
  * Added a dedicated serial test suite for more consistent performance measurements.
  * Tests validate resource creation thresholds, readiness, parallel resource loading, and migration timing.
  * Improved reporting for encryption performance results and setup or resource-polling errors.
  * Provider selection is available through test settings or command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->