### PR TITLE
OCPBUGS-99773: remove unused kube-system namespace from informer registration

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -131,7 +131,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorclient.GlobalMachineSpecifiedConfigNamespace,
 		operatorclient.TargetNamespace,
 		operatorclient.OperatorNamespace,
-		"kube-system", // system:openshift:controller:kube-apiserver-check-endpoints role binding
 		"openshift-etcd",
 		"openshift-apiserver",
 	)


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-99773

## Problem

`kube-system` is registered in `kubeInformersForNamespaces` in `starter.go`, but no controller ever queries it via `InformersFor("kube-system")`. The namespace only appears in RBAC asset paths and classification code, neither of which use namespace informers.

This creates an unnecessary watch connection and caches objects from `kube-system` that no controller reads.

## Fix

Remove `kube-system` from the `NewKubeInformersForNamespaces` constructor call. Verified that:
- No controller calls `InformersFor("kube-system")`
- No `SyncConfigMap` or `SyncSecret` rules reference `kube-system`
- The RBAC role binding asset (`check-endpoints-rolebinding-kube-system.yaml`) is deployed via `StaticResourceController`, which does not require a namespace informer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded the system namespace from monitored namespaces to prevent unnecessary monitoring activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->