### PR TITLE
NO-JIRA: Update KMStoKMS scenario to multi provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/api v0.0.0-20260805215214-cfb63858e9d7
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7
-	github.com/openshift/library-go v0.0.0-20260806124457-39539af5eb2c
+	github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7 h1:Lphm0uMAyM26ibbOca0+dg7uLz7GmmrIdeWjzOh5R/U=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7/go.mod h1:u08LcpI8Hq3IpelQLbciGRa/P158cE/O3uQe2Bt3Roo=
-github.com/openshift/library-go v0.0.0-20260806124457-39539af5eb2c h1:giNfw2fwyJS7yJNlFEfKvAVcMHohRdBZJ8E9zJ8FsSo=
-github.com/openshift/library-go v0.0.0-20260806124457-39539af5eb2c/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
+github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad h1:vYl0ePOp91Xz2iw3mgbjeYVcF2+RAENJmpkjCPGnlnc=
+github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/test/e2e-encryption-kms/encryption_kms_2.go
+++ b/test/e2e-encryption-kms/encryption_kms_2.go
@@ -27,39 +27,93 @@ var _ = g.Describe("[sig-api-machinery] kube-apiserver operator", func() {
 })
 
 // testKMSEncryptionKMSToKMSMigration tests migration between two distinct KMS providers
-// (default Vault instance and secondary Vault instance).
+// (default Vault instance and secondary Vault instance) across kube-apiserver,
+// oauth-apiserver, and openshift-apiserver operators.
 // This test:
-// 1. Shuffles the two KMS providers and one AES provider to create a randomized migration order
-// 2. Migrates between the providers in the shuffled order
-// 3. Verifies route is correctly encrypted after each migration
-// 4. Switches to identity (off) to verify the resource is re-written unencrypted
+// 1. Creates SecretOfLife, TokenOfLife, and RouteOfLife test resources
+// 2. Shuffles the two KMS providers to create a randomized migration order
+// 3. Migrates between the two KMS providers (KMS-to-KMS) in the shuffled order
+// 4. Verifies each resource is correctly encrypted with the active KMS provider after each migration
+// 5. Switches to identity (off) to verify the resources are re-written unencrypted
 func testKMSEncryptionKMSToKMSMigration(ctx context.Context, t testing.TB) {
-	library.TestEncryptionProvidersMigration(ctx, t, library.ProvidersMigrationScenario{
-		BasicScenario: library.BasicScenario{
-			Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
-			EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
-			EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
-			OperatorNamespace:               operatorclient.OperatorNamespace,
-			TargetGRs:                       library.WellKnownKASTargetGRs,
-			AssertFunc:                      library.AssertWellKnownSecretsAndConfigMaps,
-		},
-		CreateResourceFunc: library.CreateAndStoreWellKnownSecretOfLife,
-		AssertResourceEncryptedFunc: func(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
-			library.AssertWellKnownSecretOfLifeEncrypted(t, clientSet, resource)
-			library.AssertWellKnownSecretOfLifeEncryptedWithKMS(t, clientSet,
-				operatorclient.GlobalMachineSpecifiedConfigNamespace,
-				"encryption.apiserver.operator.openshift.io/component="+operatorclient.TargetNamespace,
-				resource)
-		},
-		AssertResourceNotEncryptedFunc: library.AssertWellKnownSecretOfLifeNotEncrypted,
-		ResourceFunc:                   library.WellKnownSecretOfLife,
-		ResourceName:                   "SecretOfLife",
-		EncryptionProviders: library.ShuffleEncryptionProviders([]library.EncryptionProvider{
-			librarykms.DefaultVaultEncryptionProvider(ctx, t),
-			librarykms.SecondaryVaultEncryptionProvider(ctx, t),
-		}),
+	providers := library.ShuffleEncryptionProviders([]library.EncryptionProvider{
+		librarykms.DefaultVaultEncryptionProvider(ctx, t),
+		librarykms.SecondaryVaultEncryptionProvider(ctx, t),
 	})
+
+	library.TestEncryptionProvidersMigration(ctx, t,
+		library.ProvidersMigrationScenario{
+			BasicScenario: library.BasicScenario{
+				Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + operatorclient.TargetNamespace,
+				EncryptionConfigSecretName:      fmt.Sprintf("encryption-config-%s", operatorclient.TargetNamespace),
+				EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				OperatorNamespace:               operatorclient.OperatorNamespace,
+				TargetGRs:                       library.WellKnownKASTargetGRs,
+				AssertFunc:                      library.AssertWellKnownSecretsAndConfigMaps,
+			},
+			CreateResourceFunc: library.CreateAndStoreWellKnownSecretOfLife,
+			AssertResourceEncryptedFunc: func(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
+				library.AssertWellKnownSecretOfLifeEncrypted(t, clientSet, resource)
+				library.AssertWellKnownSecretOfLifeEncryptedWithKMS(t, clientSet,
+					operatorclient.GlobalMachineSpecifiedConfigNamespace,
+					"encryption.apiserver.operator.openshift.io/component="+operatorclient.TargetNamespace,
+					resource)
+			},
+			AssertResourceNotEncryptedFunc: library.AssertWellKnownSecretOfLifeNotEncrypted,
+			ResourceFunc:                   library.WellKnownSecretOfLife,
+			ResourceName:                   "SecretOfLife",
+			EncryptionProviders:            providers,
+		},
+		library.ProvidersMigrationScenario{
+			BasicScenario: library.BasicScenario{
+				Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-oauth-apiserver",
+				EncryptionConfigSecretName:      "encryption-config-openshift-oauth-apiserver",
+				EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				OperatorNamespace:               "openshift-authentication-operator",
+				TargetGRs:                       library.WellKnownAuthTargetGRs,
+				AssertFunc:                      library.AssertWellKnownTokens,
+			},
+			CreateResourceFunc: func(t testing.TB, clientSet library.ClientSet, _ string) runtime.Object {
+				return library.CreateAndStoreWellKnownTokenOfLife(ctx, t, clientSet)
+			},
+			AssertResourceEncryptedFunc: func(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
+				library.AssertWellKnownTokenOfLifeEncrypted(t, clientSet, resource)
+				library.AssertWellKnownTokenOfLifeEncryptedWithKMS(t, clientSet,
+					operatorclient.GlobalMachineSpecifiedConfigNamespace,
+					"encryption.apiserver.operator.openshift.io/component=openshift-oauth-apiserver",
+					resource)
+			},
+			AssertResourceNotEncryptedFunc: library.AssertWellKnownTokenOfLifeNotEncrypted,
+			ResourceFunc:                   library.WellKnownTokenOfLife,
+			ResourceName:                   "TokenOfLife",
+		},
+		library.ProvidersMigrationScenario{
+			BasicScenario: library.BasicScenario{
+				Namespace:                       operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				LabelSelector:                   "encryption.apiserver.operator.openshift.io/component" + "=" + "openshift-apiserver",
+				EncryptionConfigSecretName:      "encryption-config-openshift-apiserver",
+				EncryptionConfigSecretNamespace: operatorclient.GlobalMachineSpecifiedConfigNamespace,
+				OperatorNamespace:               "openshift-apiserver-operator",
+				TargetGRs:                       library.WellKnownOASTargetGRs,
+				AssertFunc:                      library.AssertWellKnownRoutes,
+			},
+			CreateResourceFunc: func(t testing.TB, clientSet library.ClientSet, ns string) runtime.Object {
+				return library.CreateAndStoreWellKnownRouteOfLife(ctx, t, clientSet, ns)
+			},
+			AssertResourceEncryptedFunc: func(t testing.TB, clientSet library.ClientSet, resource runtime.Object) {
+				library.AssertWellKnownRouteOfLifeEncrypted(t, clientSet, resource)
+				library.AssertWellKnownRouteOfLifeEncryptedWithKMS(t, clientSet,
+					operatorclient.GlobalMachineSpecifiedConfigNamespace,
+					"encryption.apiserver.operator.openshift.io/component=openshift-apiserver",
+					resource)
+			},
+			AssertResourceNotEncryptedFunc: library.AssertWellKnownRouteOfLifeNotEncrypted,
+			ResourceFunc:                   library.WellKnownRouteOfLife,
+			ResourceName:                   "RouteOfLife",
+		},
+	)
 }
 
 func testKMSPreflightDeploy(ctx context.Context, t testing.TB) {

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -20,8 +20,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -211,6 +213,17 @@ var ciphersUnsupportedByGo = map[string]string{
 	"AES256-SHA256":             "TLS_RSA_WITH_AES_256_CBC_SHA256",
 }
 
+// tlsGroupToCurveID maps OpenShift API TLSGroup values to Go's tls.CurveID.
+var tlsGroupToCurveID = map[configv1.TLSGroup]tls.CurveID{
+	configv1.TLSGroupX25519:             tls.X25519,
+	configv1.TLSGroupSecP256r1:          tls.CurveP256,
+	configv1.TLSGroupSecP384r1:          tls.CurveP384,
+	configv1.TLSGroupSecP521r1:          tls.CurveP521,
+	configv1.TLSGroupX25519MLKEM768:     tls.X25519MLKEM768,
+	configv1.TLSGroupSecP256r1MLKEM768:  tls.SecP256r1MLKEM768,
+	configv1.TLSGroupSecP384r1MLKEM1024: tls.SecP384r1MLKEM1024,
+}
+
 // CipherSuitesToNamesOrDie given a list of cipher suites as ints, return their readable names
 func CipherSuitesToNamesOrDie(intVals []uint16) []string {
 	ret := []string{}
@@ -354,6 +367,44 @@ func OpenSSLToIANACipherSuites(ciphers []string) []string {
 	}
 
 	return ianaCiphers
+}
+
+// TLSGroupToCurveID returns the Go tls.CurveID for an OpenShift API TLSGroup
+// constant, or (0, false) if the group is not recognized.
+func TLSGroupToCurveID(group configv1.TLSGroup) (tls.CurveID, bool) {
+	id, ok := tlsGroupToCurveID[group]
+	return id, ok
+}
+
+// TLSGroupsToCurveIDs converts a slice of TLSGroup values to their tls.CurveID
+// codes. Returns the mapped curve IDs and a list of unrecognized groups.
+// Unrecognized groups are silently filtered — callers should log warnings.
+func TLSGroupsToCurveIDs(groups []configv1.TLSGroup) ([]tls.CurveID, []configv1.TLSGroup) {
+	var curves []tls.CurveID
+	var unrecognized []configv1.TLSGroup
+
+	for _, group := range groups {
+		id, ok := TLSGroupToCurveID(group)
+		if !ok {
+			unrecognized = append(unrecognized, group)
+			continue
+		}
+		curves = append(curves, id)
+	}
+
+	return curves, unrecognized
+}
+
+// ValidTLSGroups returns the recognized TLS group names, sorted alphabetically.
+func ValidTLSGroups() []configv1.TLSGroup {
+	groups := make([]configv1.TLSGroup, 0, len(tlsGroupToCurveID))
+	for g := range tlsGroupToCurveID {
+		groups = append(groups, g)
+	}
+	slices.SortFunc(groups, func(a, b configv1.TLSGroup) int {
+		return strings.Compare(string(a), string(b))
+	})
+	return groups
 }
 
 type TLSCertificateConfig struct {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -184,7 +184,7 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 }
 
 func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	currentMode, externalReason, apiEncryptionConfiguration, err := c.getCurrentModeReasonAndEncryptionConfig(ctx)
+	currentMode, externalReason, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
 	if err != nil {
 		return err
 	}
@@ -394,18 +394,19 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 	return secret, true, nil
 }
 
-func (c *keyController) getCurrentModeReasonAndEncryptionConfig(ctx context.Context) (state.Mode, string, configv1.APIServerEncryption, error) {
-	apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
+func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	operatorSpec, _, _, err := operatorClient.GetOperatorState()
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}
 
-	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, c.unsupportedConfigPrefix)
+	encryptionConfig, err := structuredUnsupportedConfigFrom(operatorSpec.UnsupportedConfigOverrides.Raw, unsupportedConfigPrefix)
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/statemachine/transition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/statemachine/transition.go
@@ -56,12 +56,12 @@ func GetEncryptionConfigAndState(
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
-	desiredEncryptionState := getDesiredEncryptionState(secretData, encryptionSecrets, encryptedGRs)
+	desiredEncryptionState := GetDesiredEncryptionState(secretData, encryptionSecrets, encryptedGRs)
 
 	return secretData, desiredEncryptionState, encryptionSecrets, "", nil
 }
 
-// getDesiredEncryptionState returns the desired state of encryption for all resources.
+// GetDesiredEncryptionState returns the desired state of encryption for all resources.
 // To do this it compares the current state against the available secrets and to-be-encrypted resources.
 // oldEncryptionConfig can be nil if there is no config yet.
 // If there are no secrets, the identity is set for all resources as write key.
@@ -73,7 +73,7 @@ func GetEncryptionConfigAndState(
 // 2. every GR must have all the read-keys (existing as secrets) since last complete migration.
 // 3. if (2) is the case, the write-key must be the most recent key.
 // 4. if (2) and (3) are the case, all non-write keys should be removed.
-func getDesiredEncryptionState(oldSecretData *encryptiondata.Config, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
+func GetDesiredEncryptionState(oldSecretData *encryptiondata.Config, encryptionSecrets []*corev1.Secret, toBeEncryptedGRs []schema.GroupResource) map[schema.GroupResource]state.GroupResourceState {
 	//
 	// STEP 0: start with old encryption config, and alter it towards the desired state in the following STEPs.
 	//

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -126,9 +126,24 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 	// KMS-to-KMS migration: when both old and new are KMS but the config differs,
 	// the key controller creates a new key. We must wait for the next migrated key
 	// rather than asserting no new key is created.
-	if needsUpdate && provider.Type == configv1.EncryptionTypeKMS && previousEncryption.Type == configv1.EncryptionTypeKMS {
-		WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
-		return clientSet
+	// Multi-operator parallel KMS-to-KMS: another goroutine already applied the
+	// KMS config change (needsUpdate=false), but the operator will still create a
+	// new key because the KMS provider config changed. Use targetGRs to determine
+	// if we captured the old key or the new key.
+	if provider.Type == configv1.EncryptionTypeKMS {
+		if needsUpdate {
+			if previousEncryption.Type == configv1.EncryptionTypeKMS {
+				WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+				return clientSet
+			}
+		} else if lastMigratedKeyMeta.Mode == string(configv1.EncryptionTypeKMS) {
+			if len(lastMigratedKeyMeta.Name) > 0 && !allTargetGRsMigrated(lastMigratedKeyMeta, defaultTargetGRs) {
+				WaitForCurrentKeyMigrated(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+			} else {
+				WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+			}
+			return clientSet
+		}
 	}
 
 	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)
@@ -699,4 +714,13 @@ func GetRawWellKnownTokenOfLife(t testing.TB, clientSet ClientSet) string {
 	require.Len(t, resp.Kvs, 1, "expected exactly one key from etcd for token-of-life")
 
 	return string(resp.Kvs[0].Value)
+}
+
+func allTargetGRsMigrated(keyMeta EncryptionKeyMeta, targetGRs []schema.GroupResource) bool {
+	for _, gr := range targetGRs {
+		if !hasResource(gr, keyMeta.Migrated) {
+			return false
+		}
+	}
+	return true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260806124457-39539af5eb2c
+# github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets


### PR DESCRIPTION
NO-JIRA: Update KMStoKMS scenario to multi provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded KMS encryption migration coverage for Secret, Token, and Route resources.
  * Added KMS-to-KMS migration scenarios across kube-apiserver, OAuth API server, and OpenShift API server configurations.
  * Validated encrypted and unencrypted resource states throughout migration workflows.
  * Increased coverage across varied provider configurations and operator-specific settings.
  * Improved confidence in resource availability and protection during encryption migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->