### PR TITLE
vendor: update library-go to encryption-refactor-fn-injection branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,3 +145,5 @@ require (
 )
 
 replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+
+replace github.com/openshift/library-go => /Users/lszaszki/go/src/github.com/openshift/library-go

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7 h1:Lphm0uMAyM26ibbOca0+dg7uLz7GmmrIdeWjzOh5R/U=
 github.com/openshift/client-go v0.0.0-20260806041845-b74fb348f1e7/go.mod h1:u08LcpI8Hq3IpelQLbciGRa/P158cE/O3uQe2Bt3Roo=
-github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad h1:vYl0ePOp91Xz2iw3mgbjeYVcF2+RAENJmpkjCPGnlnc=
-github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad/go.mod h1:IrZbEK+wVUMEd+aXzYR2DCCh0p5IaQ7DvycYGP7qIYM=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1 h1:PMTgifBcBRLJJiM+LgSzPDTk9/Rx4qS09OUrfpY6GBQ=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -434,7 +434,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 		resourceSyncController,
 		kmsEncryptionStatusProvider,
-		kmspreflight.NewAlwaysSucceedKMSPreflightDeployer(),
+		kmspreflight.NewStaticPodPreflightDeployer(
+			operatorclient.TargetNamespace,
+			kubeClient.CoreV1(),
+			kubeClient.RbacV1(),
+			controllerContext.EventRecorder,
+			os.Getenv("OPERATOR_IMAGE"),
+			[]string{"cluster-kube-apiserver-operator", "kms-preflight"},
+			10*time.Second,
+		),
 	)
 	if err != nil {
 		return err

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers.go
@@ -63,35 +63,39 @@ func NewControllers(
 		}
 	}
 
+	keyController := controllers.NewKeyController(
+		component,
+		unsupportedConfigPrefix,
+		provider,
+		deployer,
+		encryptionEnabledChecker.PreconditionFulfilled,
+		operatorClient,
+		apiServerClient,
+		apiServerInformer,
+		kubeInformersForNamespaces,
+		secretsClient,
+		configMapClient,
+		encryptionSecretSelector,
+		eventRecorder,
+		encryptionStatusProvider,
+	)
+	stateController := controllers.NewStateController(
+		component,
+		provider,
+		deployer,
+		encryptionEnabledChecker.PreconditionFulfilled,
+		operatorClient,
+		apiServerInformer,
+		kubeInformersForNamespaces,
+		secretsClient,
+		encryptionSecretSelector,
+		eventRecorder,
+	)
+	computer := controllers.NewEncryptionComputer(keyController, stateController)
+
 	encryptionControllers := []factory.Controller{
-		controllers.NewKeyController(
-			component,
-			unsupportedConfigPrefix,
-			provider,
-			deployer,
-			encryptionEnabledChecker.PreconditionFulfilled,
-			operatorClient,
-			apiServerClient,
-			apiServerInformer,
-			kubeInformersForNamespaces,
-			secretsClient,
-			configMapClient,
-			encryptionSecretSelector,
-			eventRecorder,
-			encryptionStatusProvider,
-		),
-		controllers.NewStateController(
-			component,
-			provider,
-			deployer,
-			encryptionEnabledChecker.PreconditionFulfilled,
-			operatorClient,
-			apiServerInformer,
-			kubeInformersForNamespaces,
-			secretsClient,
-			encryptionSecretSelector,
-			eventRecorder,
-		),
+		keyController.ToFactoryController(),
+		stateController.ToFactoryController(),
 		controllers.NewPruneController(
 			component,
 			provider,
@@ -136,9 +140,9 @@ func NewControllers(
 		provider,
 		encryptionEnabledChecker.PreconditionFulfilled,
 		preflightDeployer,
+		computer,
 		operatorClient,
 		apiServerClient,
-		apiServerInformer,
 		secretsClient,
 		configMapClient,
 		encryptionStatusProvider,

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/condition_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -16,6 +17,7 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -96,7 +98,14 @@ func (c *conditionController) sync(ctx context.Context, _ factory.SyncContext) (
 	}
 
 	encryptedGRs := c.provider.EncryptedGRs()
-	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredState, foundSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(
+		ctx,
+		c.deployer.DeployedEncryptionConfigSecret,
+		func(ctx context.Context) ([]*corev1.Secret, error) {
+			return secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+		},
+		encryptedGRs,
+	)
 	if err != nil || len(transitioningReason) > 0 {
 		// do not update the encryption condition (cond). Note: progressing is set elsewhere.
 		cond = nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/encryption_computer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/encryption_computer.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+var _ EncryptionConfigurationComputer = &EncryptionComputer{}
+
+// EncryptionComputer is backed by the running key and state controllers and
+// allows computing their outputs without side effects.
+type EncryptionComputer struct {
+	keyController   *keyController
+	stateController *stateController
+	// syncCtx holds a single rate-limiting queue whose goroutine lives for the
+	// lifetime of this object. Re-queue requests issued during computation are
+	// intentionally discarded.
+	syncCtx factory.SyncContext
+}
+
+// NewEncryptionComputer creates an EncryptionComputer backed by the same
+// controller instances returned by NewKeyController and NewStateController.
+func NewEncryptionComputer(keyCtrl *keyController, stateCtrl *stateController) *EncryptionComputer {
+	return &EncryptionComputer{
+		keyController:   keyCtrl,
+		stateController: stateCtrl,
+		syncCtx: factory.NewSyncContext(
+			"EncryptionConfigurationComputer",
+			events.NewLoggingEventRecorder("encryption-configuration-computer", clock.RealClock{}),
+		),
+	}
+}
+
+// ComputeEncryptionConfiguration implements EncryptionConfigurationComputer.
+// It computes the encryption configuration that would result after creating
+// the next key, giving the KMS preflight deployer the configuration it needs
+// to test the plugin before the key is actually created.
+func (e *EncryptionComputer) ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error) {
+	newKeySecret, err := e.keyController.computeKeySecret(ctx, e.syncCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := e.stateController
+	listKeySecretsFn := sc.listKeySecretsFn
+	if newKeySecret != nil {
+		listKeySecretsFn = func(ctx context.Context) ([]*corev1.Secret, error) {
+			existing, err := sc.listKeySecretsFn(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return append(existing, newKeySecret), nil
+		}
+	}
+
+	secret, _, err := sc.computeEncryptionConfigSecretWithCustomListKeySecretFn(ctx, e.syncCtx.Queue(), listKeySecretsFn)
+	return secret, err
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/encryption_computer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/encryption_computer.go
@@ -40,8 +40,12 @@ func NewEncryptionComputer(keyCtrl *keyController, stateCtrl *stateController) *
 // It computes the encryption configuration that would result after creating
 // the next key, giving the KMS preflight deployer the configuration it needs
 // to test the plugin before the key is actually created.
+//
+// It unconditionally skips the KMS preflight gate: the preflight controller
+// calls this method to obtain the configuration it will deploy for testing,
+// so blocking on a result that does not exist yet would deadlock.
 func (e *EncryptionComputer) ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error) {
-	newKeySecret, err := e.keyController.computeKeySecret(ctx, e.syncCtx)
+	newKeySecret, err := e.keyController.computeKeySecretSkippingPreflight(ctx, e.syncCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_computer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_computer.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+)
+
+// KeyComputer uses a keyController to compute what key secret would be
+// needed without actually creating it.
+type KeyComputer struct {
+	controller *keyController
+}
+
+func newKeyComputer(controller *keyController) *KeyComputer {
+	return &KeyComputer{controller: controller}
+}
+
+// ComputeKey returns the key secret that would be created by the key
+// controller, or nil if no new key is needed.
+func (k *KeyComputer) ComputeKey(ctx context.Context, syncCtx factory.SyncContext) (*corev1.Secret, error) {
+	return k.controller.computeKeySecret(ctx, syncCtx)
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -66,6 +66,9 @@ const (
 //	encryption.apiserver.operator.openshift.io/migrated-timestamp instead of
 //	the key secret's creationTimestamp because the clock is supposed to
 //	start when a migration has been finished, not when it begins.
+// keyController creates and manages encryption key secrets. Call ToFactoryController
+// to get a runnable factory.Controller; pass the *keyController itself to
+// NewEncryptionComputer (both are in the same package).
 type keyController struct {
 	operatorClient  operatorv1helpers.OperatorClient
 	apiServerClient configv1client.APIServerInterface
@@ -84,6 +87,17 @@ type keyController struct {
 	encryptionStatusProvider kms.EncryptionStatusProvider
 
 	unsupportedConfigPrefix []string
+
+	getAPIServerAndOperatorSpecFn    func(context.Context) (*configv1.APIServer, *operatorv1.OperatorSpec, error)
+	deployedEncryptionConfigSecretFn func(context.Context) (*corev1.Secret, bool, error)
+	listKeySecretsFn                 func(context.Context) ([]*corev1.Secret, error)
+	getKMSPluginSecretFn             func(context.Context, string) (*corev1.Secret, error)
+	getKMSPluginConfigMapFn          func(context.Context, string) (*corev1.ConfigMap, error)
+
+	// fields used only by ToFactoryController
+	apiServerInformer          configv1informers.APIServerInformer
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces
+	eventRecorder              events.Recorder
 }
 
 func NewKeyController(
@@ -102,7 +116,7 @@ func NewKeyController(
 	eventRecorder events.Recorder,
 	// encryptionStatusProvider is required for KMS operators; it gates key creation on a preflight check.
 	encryptionStatusProvider kms.EncryptionStatusProvider,
-) factory.Controller {
+) *keyController {
 	c := &keyController{
 		operatorClient:  operatorClient,
 		apiServerClient: apiServerClient,
@@ -119,8 +133,40 @@ func NewKeyController(
 		configMapClient:          configMapClient,
 
 		encryptionStatusProvider: encryptionStatusProvider,
+
+		apiServerInformer:          apiServerInformer,
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		eventRecorder:              eventRecorder,
 	}
 
+	c.getAPIServerAndOperatorSpecFn = func(ctx context.Context) (*configv1.APIServer, *operatorv1.OperatorSpec, error) {
+		apiServer, err := c.apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+		operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+		if err != nil {
+			return nil, nil, err
+		}
+		return apiServer, operatorSpec, nil
+	}
+	c.deployedEncryptionConfigSecretFn = c.deployer.DeployedEncryptionConfigSecret
+	c.listKeySecretsFn = func(ctx context.Context) ([]*corev1.Secret, error) {
+		return secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+	}
+	c.getKMSPluginSecretFn = func(ctx context.Context, name string) (*corev1.Secret, error) {
+		return c.secretClient.Secrets(openshiftConfigNS).Get(ctx, name, metav1.GetOptions{})
+	}
+	c.getKMSPluginConfigMapFn = func(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+		return c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, name, metav1.GetOptions{})
+	}
+
+	return c
+}
+
+// ToFactoryController wraps this keyController in a factory.Controller so it
+// can be added to a controller set and run.
+func (c *keyController) ToFactoryController() factory.Controller {
 	return factory.New().
 		WithSync(c.sync).
 		WithControllerInstanceName(c.controllerInstanceName).
@@ -129,18 +175,18 @@ func NewKeyController(
 		// resync. Increasing this significantly delays in-place config propagation.
 		ResyncEvery(time.Minute).
 		WithInformers(
-			apiServerInformer.Informer(),
-			operatorClient.Informer(),
-			kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+			c.apiServerInformer.Informer(),
+			c.operatorClient.Informer(),
+			c.kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
 			// openshift-config secrets/configmaps are not watched directly. While we could
 			// build a mechanism to watch only the referenced resources, creating and
 			// maintaining it is not free, and watching all resources in the namespace
 			// would create excessive API server load. Instead, changes are picked up
 			// on the next periodic resync.
-			deployer,
+			c.deployer,
 		).ToController(
 		c.controllerInstanceName,
-		eventRecorder.WithComponentSuffix("encryption-key-controller"),
+		c.eventRecorder.WithComponentSuffix("encryption-key-controller"),
 	)
 }
 
@@ -169,7 +215,19 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	err = c.checkAndCreateKeys(ctx, syncCtx, c.provider.EncryptedGRs())
+	keySecret, err := c.computeKeySecret(ctx, syncCtx)
+	if err == nil && keySecret != nil {
+		keyID, _ := state.NameToKeyID(keySecret.Name)
+		_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
+		if errors.IsAlreadyExists(createErr) {
+			err = c.validateExistingSecret(ctx, keySecret, keyID)
+		} else if createErr != nil {
+			syncCtx.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, createErr)
+			err = createErr
+		} else {
+			syncCtx.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created", keySecret.Name)
+		}
+	}
 	if err != nil {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -183,25 +241,61 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 	return err
 }
 
-func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	currentMode, externalReason, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, c.apiServerClient, c.operatorClient, c.unsupportedConfigPrefix)
+func (c *keyController) computeKeySecret(ctx context.Context, syncContext factory.SyncContext) (*corev1.Secret, error) {
+	ensureKMSPreflightPassedFn := c.ensureKMSPreflightPassed
+	if c.encryptionStatusProvider == nil {
+		// No provider means read-only/compute-only context (e.g. EncryptionComputer).
+		// Skip the preflight gate so callers can observe what key would be created.
+		ensureKMSPreflightPassedFn = func(_ context.Context, _ string) (bool, error) { return true, nil }
+	}
+	return checkAndCreateKeys(
+		ctx, syncContext, c.provider.EncryptedGRs(),
+		c.instanceName, c.unsupportedConfigPrefix,
+		c.getAPIServerAndOperatorSpecFn,
+		c.deployedEncryptionConfigSecretFn,
+		c.listKeySecretsFn,
+		c.getKMSPluginSecretFn,
+		c.getKMSPluginConfigMapFn,
+		ensureKMSPreflightPassedFn,
+	)
+}
+
+func checkAndCreateKeys(
+	ctx context.Context,
+	syncContext factory.SyncContext,
+	encryptedGRs []schema.GroupResource,
+	instanceName string,
+	unsupportedConfigPrefix []string,
+	getAPIServerAndOperatorSpecFn func(context.Context) (*configv1.APIServer, *operatorv1.OperatorSpec, error),
+	deployedEncryptionConfigSecretFn func(context.Context) (*corev1.Secret, bool, error),
+	listKeySecretsFn func(context.Context) ([]*corev1.Secret, error),
+	getKMSPluginSecretFn func(context.Context, string) (*corev1.Secret, error),
+	getKMSPluginConfigMapFn func(context.Context, string) (*corev1.ConfigMap, error),
+	ensureKMSPreflightPassedFn func(context.Context, string) (bool, error),
+) (*corev1.Secret, error) {
+	currentMode, externalReason, apiEncryptionConfiguration, err := getCurrentModeReasonAndEncryptionConfig(ctx, getAPIServerAndOperatorSpecFn, unsupportedConfigPrefix)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	currentConfig, desiredEncryptionState, secrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentConfig, desiredEncryptionState, encryptionSecrets, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(
+		ctx,
+		deployedEncryptionConfigSecretFn,
+		listKeySecretsFn,
+		encryptedGRs,
+	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(isProgressingReason) > 0 {
 		syncContext.Queue().AddAfter(syncContext.QueueKey(), 2*time.Minute)
-		return nil
+		return nil, nil
 	}
 
 	// avoid intended start of encryption
-	hasBeenOnBefore := currentConfig != nil || len(secrets) > 0
+	hasBeenOnBefore := currentConfig != nil || len(encryptionSecrets) > 0
 	if currentMode == state.Identity && !hasBeenOnBefore {
-		return nil
+		return nil, nil
 	}
 
 	var (
@@ -219,7 +313,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		var err error
 		desiredProviderCfg, err = newKMSProviderConfig(apiEncryptionConfiguration.KMS)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -227,7 +321,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 	for gr, grKeys := range desiredEncryptionState {
 		latestKeyID, internalReason, needed, err := needsNewKey(grKeys, currentMode, externalReason, encryptedGRs, desiredProviderCfg)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !needed {
 			continue
@@ -247,7 +341,7 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 		reasons = append(reasons, fmt.Sprintf("%s-%s", gr.Resource, internalReason))
 	}
 	if !newKeyRequired {
-		return nil
+		return nil, nil
 	}
 
 	if commonReason != nil && len(*commonReason) > 0 && len(reasons) > 1 {
@@ -256,26 +350,15 @@ func (c *keyController) checkAndCreateKeys(ctx context.Context, syncContext fact
 
 	sort.Sort(sort.StringSlice(reasons))
 	internalReason := strings.Join(reasons, ", ")
-	keySecret, preconditionMet, err := c.generateKeySecret(ctx, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason)
+	keySecret, preconditionMet, err := generateKeySecret(ctx, instanceName, newKeyID, currentMode, apiEncryptionConfiguration, desiredProviderCfg, internalReason, externalReason, getKMSPluginSecretFn, getKMSPluginConfigMapFn, ensureKMSPreflightPassedFn)
 	if err != nil {
-		return fmt.Errorf("failed to create key: %v", err)
+		return nil, fmt.Errorf("failed to create key: %v", err)
 	}
 	if !preconditionMet {
 		syncContext.Queue().AddAfter(syncContext.QueueKey(), 30*time.Second)
-		return nil
+		return nil, nil
 	}
-	_, createErr := c.secretClient.Secrets("openshift-config-managed").Create(ctx, keySecret, metav1.CreateOptions{})
-	if errors.IsAlreadyExists(createErr) {
-		return c.validateExistingSecret(ctx, keySecret, newKeyID)
-	}
-	if createErr != nil {
-		syncContext.Recorder().Warningf("EncryptionKeyCreateFailed", "Secret %q failed to create: %v", keySecret.Name, err)
-		return createErr
-	}
-
-	syncContext.Recorder().Eventf("EncryptionKeyCreated", "Secret %q successfully created: %q", keySecret.Name, reasons)
-
-	return nil
+	return keySecret, nil
 }
 
 func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *corev1.Secret, keyID uint64) error {
@@ -306,7 +389,7 @@ func (c *keyController) validateExistingSecret(ctx context.Context, keySecret *c
 //   - (secret, true,  nil) — preflight passed; caller should persist the key.
 //   - (nil,   false, nil) — preflight still in progress; caller should back off.
 //   - (nil,   false, err) — preflight failed or transient error; caller should surface it.
-func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string) (*corev1.Secret, bool, error) {
+func generateKeySecret(ctx context.Context, instanceName string, keyID uint64, currentMode state.Mode, apiServerEncryption configv1.APIServerEncryption, desiredProviderCfg kmsProviderConfig, internalReason, externalReason string, getKMSPluginSecretFn func(context.Context, string) (*corev1.Secret, error), getKMSPluginConfigMapFn func(context.Context, string) (*corev1.ConfigMap, error), ensureKMSPreflightPassedFn func(context.Context, string) (bool, error)) (*corev1.Secret, bool, error) {
 	bs := crypto.ModeToNewKeyFunc[currentMode]()
 	ks := state.KeyState{
 		Key: apiserverv1.Key{
@@ -335,7 +418,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		if secretName, expectedKeys, err := desiredProviderCfg.referencedSecretName(); err != nil {
 			return nil, false, err
 		} else if len(secretName) > 0 {
-			refSecret, err = c.secretClient.Secrets(openshiftConfigNS).Get(ctx, secretName, metav1.GetOptions{})
+			refSecret, err = getKMSPluginSecretFn(ctx, secretName)
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to get secret %s in %s: %w", secretName, openshiftConfigNS, err)
 			}
@@ -354,7 +437,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		if cmName, expectedKeys, err := desiredProviderCfg.referencedConfigMapName(); err != nil {
 			return nil, false, err
 		} else if len(cmName) > 0 {
-			refCM, err = c.configMapClient.ConfigMaps(openshiftConfigNS).Get(ctx, cmName, metav1.GetOptions{})
+			refCM, err = getKMSPluginConfigMapFn(ctx, cmName)
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to get configmap %s in %s: %w", cmName, openshiftConfigNS, err)
 			}
@@ -378,7 +461,7 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to compute KMS config hash: %w", err)
 		}
-		preflightPassed, err := c.ensureKMSPreflightPassed(ctx, configHash)
+		preflightPassed, err := ensureKMSPreflightPassedFn(ctx, configHash)
 		if err != nil {
 			return nil, false, err
 		}
@@ -387,21 +470,15 @@ func (c *keyController) generateKeySecret(ctx context.Context, keyID uint64, cur
 		}
 	}
 
-	secret, err := secrets.FromKeyState(c.instanceName, ks)
+	secret, err := secrets.FromKeyState(instanceName, ks)
 	if err != nil {
 		return nil, false, err
 	}
 	return secret, true, nil
 }
 
-// getCurrentModeReasonAndEncryptionConfig the active encryption mode, any external rotation reason from unsupported config overrides, and the full encryption spec.
-func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, apiServerClient configv1client.APIServerInterface, operatorClient operatorv1helpers.OperatorClient, unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
-	apiServer, err := apiServerClient.Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return "", "", configv1.APIServerEncryption{}, err
-	}
-
-	operatorSpec, _, _, err := operatorClient.GetOperatorState()
+func getCurrentModeReasonAndEncryptionConfig(ctx context.Context, getAPIServerAndOperatorSpecFn func(context.Context) (*configv1.APIServer, *operatorv1.OperatorSpec, error), unsupportedConfigPrefix []string) (state.Mode, string, configv1.APIServerEncryption, error) {
+	apiServer, operatorSpec, err := getAPIServerAndOperatorSpecFn(ctx)
 	if err != nil {
 		return "", "", configv1.APIServerEncryption{}, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/key_controller.go
@@ -244,8 +244,6 @@ func (c *keyController) sync(ctx context.Context, syncCtx factory.SyncContext) (
 func (c *keyController) computeKeySecret(ctx context.Context, syncContext factory.SyncContext) (*corev1.Secret, error) {
 	ensureKMSPreflightPassedFn := c.ensureKMSPreflightPassed
 	if c.encryptionStatusProvider == nil {
-		// No provider means read-only/compute-only context (e.g. EncryptionComputer).
-		// Skip the preflight gate so callers can observe what key would be created.
 		ensureKMSPreflightPassedFn = func(_ context.Context, _ string) (bool, error) { return true, nil }
 	}
 	return checkAndCreateKeys(
@@ -257,6 +255,22 @@ func (c *keyController) computeKeySecret(ctx context.Context, syncContext factor
 		c.getKMSPluginSecretFn,
 		c.getKMSPluginConfigMapFn,
 		ensureKMSPreflightPassedFn,
+	)
+}
+
+// computeKeySecretSkippingPreflight is like computeKeySecret but unconditionally
+// skips the KMS preflight gate. Used by EncryptionComputer to observe what key
+// would be created without blocking on the preflight result it is trying to feed.
+func (c *keyController) computeKeySecretSkippingPreflight(ctx context.Context, syncContext factory.SyncContext) (*corev1.Secret, error) {
+	return checkAndCreateKeys(
+		ctx, syncContext, c.provider.EncryptedGRs(),
+		c.instanceName, c.unsupportedConfigPrefix,
+		c.getAPIServerAndOperatorSpecFn,
+		c.deployedEncryptionConfigSecretFn,
+		c.listKeySecretsFn,
+		c.getKMSPluginSecretFn,
+		c.getKMSPluginConfigMapFn,
+		func(_ context.Context, _ string) (bool, error) { return true, nil },
 	)
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/kms_preflight_controller.go
@@ -19,7 +19,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -27,6 +26,22 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 )
+
+// EncryptionConfigurationComputer computes the encryption configuration secret
+// passed to the preflight deployer right before it creates a new deployment.
+type EncryptionConfigurationComputer interface {
+	ComputeEncryptionConfiguration(ctx context.Context) (*corev1.Secret, error)
+}
+
+// NoopEncryptionConfigurationComputer is a placeholder EncryptionConfigurationComputer
+// that returns nil until a real implementation is available.
+type NoopEncryptionConfigurationComputer struct{}
+
+var _ EncryptionConfigurationComputer = NoopEncryptionConfigurationComputer{}
+
+func (NoopEncryptionConfigurationComputer) ComputeEncryptionConfiguration(_ context.Context) (*corev1.Secret, error) {
+	return nil, nil
+}
 
 // kmsConfigHasherResourceProvider abstracts fetching the Secret and ConfigMap referenced
 // by a KMS provider config.
@@ -205,6 +220,9 @@ type kmsPreflightController struct {
 	configMapsClient corev1client.ConfigMapsGetter
 
 	deployer KMSPreflightDeployer
+	// encryptionConfigurationComputer is called right before Deploy to produce the
+	// encryption configuration secret passed to the deployer.
+	encryptionConfigurationComputer EncryptionConfigurationComputer
 	// dirtyDeployer is true when preflight resources may exist in the cluster.
 	// Set to true after each Deploy and cleared to false after a successful Cleanup,
 	// so that repeated Cleanup calls in steady state issue no API requests.
@@ -295,9 +313,9 @@ func NewKMSPreflightController(
 	provider Provider,
 	preconditionsFulfilledFn preconditionsFulfilled,
 	deployer KMSPreflightDeployer,
+	encryptionConfigurationComputer EncryptionConfigurationComputer,
 	operatorClient operatorv1helpers.OperatorClient,
 	apiServerClient configv1client.APIServerInterface,
-	apiServerInformer configv1informers.APIServerInformer,
 	// secretsClient and configMapsClient read referenced Secrets and ConfigMaps in
 	// openshift-config for hash computation. No informer is needed: the key-controller
 	// detects config changes and updates ObservedConfigHash, which triggers this
@@ -315,7 +333,8 @@ func NewKMSPreflightController(
 		secretsClient:    secretsClient,
 		configMapsClient: configMapsClient,
 
-		deployer: deployer,
+		deployer:                        deployer,
+		encryptionConfigurationComputer: encryptionConfigurationComputer,
 		// assume resources may exist from a previous process run
 		dirtyDeployer:            true,
 		provider:                 provider,
@@ -501,9 +520,12 @@ func (c *kmsPreflightController) runPreflightChecks(ctx context.Context) (requeu
 				message: fmt.Sprintf("preflight check failed for hash %s: pod was removed but failure is recorded in status", requiredHash),
 			}
 		}
+		encryptionConfig, err := c.encryptionConfigurationComputer.ComputeEncryptionConfiguration(ctx)
+		if err != nil {
+			return true, "", "", fmt.Errorf("failed to compute encryption configuration: %w", err)
+		}
 		c.dirtyDeployer = true
-		// TODO: compute the encryption configuration and pass it to the deployer
-		if err := c.deployer.Deploy(ctx, requiredHash, nil); err != nil {
+		if err := c.deployer.Deploy(ctx, requiredHash, encryptionConfig); err != nil {
 			return true, "", "", err
 		}
 		return true, "RunningPreflightCheck", fmt.Sprintf("Deploying preflight pod for hash %s", requiredHash), nil
@@ -750,8 +772,8 @@ func (c *kmsPreflightController) preflightRequired(ctx context.Context) (string,
 	}
 
 	// No requeue needed: the key-controller will update ObservedConfigHash when it
-	// picks up the config change (via apiServerInformer), which triggers us through
-	// operatorClient.Informer(). The minute-based resync is a backstop.
+	// picks up the config change, which triggers us through operatorClient.Informer().
+	// The minute-based resync is a backstop.
 	if currentHash != requiredHash {
 		klog.V(4).Infof("KMS config hash changed: required=%s, current=%s; waiting for the key-controller to update ObservedConfigHash", requiredHash, currentHash)
 		return "", nil, nil

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/migration_controller.go
@@ -168,7 +168,14 @@ func (c *migrationController) sync(ctx context.Context, syncCtx factory.SyncCont
 // TODO doc
 func (c *migrationController) migrateKeysIfNeededAndRevisionStable(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) (migratingResources []schema.GroupResource, err error) {
 	// no storage migration during revision changes
-	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	currentEncryptionConfig, desiredEncryptionState, _, isTransitionalReason, err := statemachine.GetEncryptionConfigAndState(
+		ctx,
+		c.deployer.DeployedEncryptionConfigSecret,
+		func(ctx context.Context) ([]*corev1.Secret, error) {
+			return secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+		},
+		encryptedGRs,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/prune_controller.go
@@ -121,7 +121,14 @@ func (c *pruneController) sync(ctx context.Context, syncCtx factory.SyncContext)
 }
 
 func (c *pruneController) deleteOldMigratedSecrets(ctx context.Context, syncContext factory.SyncContext, encryptedGRs []schema.GroupResource) error {
-	_, desiredEncryptionConfig, _, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+	_, desiredEncryptionConfig, _, isProgressingReason, err := statemachine.GetEncryptionConfigAndState(
+		ctx,
+		c.deployer.DeployedEncryptionConfigSecret,
+		func(ctx context.Context) ([]*corev1.Secret, error) {
+			return secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+		},
+		encryptedGRs,
+	)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/controllers/state_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -16,6 +17,7 @@ import (
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
+	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 	"github.com/openshift/library-go/pkg/operator/encryption/statemachine"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -46,6 +48,14 @@ type stateController struct {
 	deployer                 statemachine.Deployer
 	provider                 Provider
 	preconditionsFulfilledFn preconditionsFulfilled
+
+	deployedEncryptionConfigSecretFn func(context.Context) (*corev1.Secret, bool, error)
+	listKeySecretsFn                 func(context.Context) ([]*corev1.Secret, error)
+
+	// fields used only by ToFactoryController
+	apiServerConfigInformer    configv1informers.APIServerInformer
+	kubeInformersForNamespaces operatorv1helpers.KubeInformersForNamespaces
+	eventRecorder              events.Recorder
 }
 
 func NewStateController(
@@ -59,7 +69,7 @@ func NewStateController(
 	secretClient corev1client.SecretsGetter,
 	encryptionSecretSelector metav1.ListOptions,
 	eventRecorder events.Recorder,
-) factory.Controller {
+) *stateController {
 	c := &stateController{
 		operatorClient:         operatorClient,
 		instanceName:           instanceName,
@@ -70,16 +80,31 @@ func NewStateController(
 		deployer:                 deployer,
 		provider:                 provider,
 		preconditionsFulfilledFn: preconditionsFulfilledFn,
+
+		apiServerConfigInformer:    apiServerConfigInformer,
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		eventRecorder:              eventRecorder,
 	}
 
+	c.deployedEncryptionConfigSecretFn = c.deployer.DeployedEncryptionConfigSecret
+	c.listKeySecretsFn = func(ctx context.Context) ([]*corev1.Secret, error) {
+		return secrets.ListKeySecrets(ctx, c.secretClient, c.encryptionSecretSelector)
+	}
+
+	return c
+}
+
+// ToFactoryController wraps this stateController in a factory.Controller so it
+// can be added to a controller set and run.
+func (c *stateController) ToFactoryController() factory.Controller {
 	return factory.New().ResyncEvery(time.Minute).WithSync(c.sync).WithControllerInstanceName(c.controllerInstanceName).WithInformers(
-		operatorClient.Informer(),
-		kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
-		apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
-		deployer,
+		c.operatorClient.Informer(),
+		c.kubeInformersForNamespaces.InformersFor("openshift-config-managed").Core().V1().Secrets().Informer(),
+		c.apiServerConfigInformer.Informer(), // do not remove, used by the precondition checker
+		c.deployer,
 	).ToController(
 		c.controllerInstanceName,
-		eventRecorder.WithComponentSuffix("encryption-state-controller"),
+		c.eventRecorder.WithComponentSuffix("encryption-state-controller"),
 	)
 }
 
@@ -108,7 +133,17 @@ func (c *stateController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		return err // we will get re-kicked when the operator status updates
 	}
 
-	configError := c.generateAndApplyCurrentEncryptionConfigSecret(ctx, syncCtx.Queue(), syncCtx.Recorder(), c.provider.EncryptedGRs())
+	secretToApply, pendingEvents, configError := c.computeEncryptionConfigSecret(ctx, syncCtx.Queue())
+	if configError == nil && secretToApply != nil {
+		_, changed, applyErr := resourceapply.ApplySecret(ctx, c.secretClient, syncCtx.Recorder(), secretToApply)
+		if applyErr != nil {
+			configError = applyErr
+		} else if changed {
+			for _, event := range pendingEvents {
+				syncCtx.Recorder().Eventf(event.reason, "%s", event.message)
+			}
+		}
+	}
 	if configError != nil {
 		degradedCondition = degradedCondition.
 			WithStatus(operatorv1.ConditionTrue).
@@ -126,51 +161,57 @@ type eventWithReason struct {
 	message string
 }
 
-func (c *stateController) generateAndApplyCurrentEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, recorder events.Recorder, encryptedGRs []schema.GroupResource) error {
-	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(ctx, c.deployer, c.secretClient, c.encryptionSecretSelector, encryptedGRs)
+func (c *stateController) computeEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface) (*corev1.Secret, []eventWithReason, error) {
+	return c.computeEncryptionConfigSecretWithCustomListKeySecretFn(ctx, queue, c.listKeySecretsFn)
+}
+
+func (c *stateController) computeEncryptionConfigSecretWithCustomListKeySecretFn(ctx context.Context, queue workqueue.RateLimitingInterface, listKeySecretsFn func(context.Context) ([]*corev1.Secret, error)) (*corev1.Secret, []eventWithReason, error) {
+	return generateEncryptionConfigSecret(ctx, queue, c.provider.EncryptedGRs(), c.instanceName, c.deployedEncryptionConfigSecretFn, listKeySecretsFn)
+}
+
+func generateEncryptionConfigSecret(ctx context.Context, queue workqueue.RateLimitingInterface, encryptedGRs []schema.GroupResource, instanceName string, deployedEncryptionConfigSecretFn func(context.Context) (*corev1.Secret, bool, error), listKeySecretsFn func(context.Context) ([]*corev1.Secret, error)) (*corev1.Secret, []eventWithReason, error) {
+	currentConfig, desiredEncryptionState, encryptionSecrets, transitioningReason, err := statemachine.GetEncryptionConfigAndState(
+		ctx,
+		deployedEncryptionConfigSecretFn,
+		listKeySecretsFn,
+		encryptedGRs,
+	)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if len(transitioningReason) > 0 {
 		queue.AddAfter(stateWorkKey, 2*time.Minute)
-		return nil
+		return nil, nil, nil
 	}
 
 	if currentConfig == nil && len(encryptionSecrets) == 0 {
 		// we depend on the key controller to create the first key to bootstrap encryption.
 		// Later-on either the config exists or there are keys, even in the case of disabled
 		// encryption via the apiserver config.
-		return nil
+		return nil, nil, nil
 	}
 
 	desiredSecretData, err := encryptiondata.FromEncryptionState(desiredEncryptionState)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	changed, err := c.applyEncryptionConfigSecret(ctx, desiredSecretData, recorder)
+	secretToApply, err := applyEncryptionConfigSecret(instanceName, desiredSecretData)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	if changed {
-		currentEncryptionConfig, _ := encryptiondata.ToEncryptionState(currentConfig, encryptionSecrets)
-		if actionEvents := eventsFromEncryptionConfigChanges(currentEncryptionConfig, desiredEncryptionState); len(actionEvents) > 0 {
-			for _, event := range actionEvents {
-				recorder.Eventf(event.reason, "%s", event.message)
-			}
-		}
-	}
-	return nil
+	currentEncryptionConfig, _ := encryptiondata.ToEncryptionState(currentConfig, encryptionSecrets)
+	pendingEvents := eventsFromEncryptionConfigChanges(currentEncryptionConfig, desiredEncryptionState)
+
+	return secretToApply, pendingEvents, nil
 }
 
-func (c *stateController) applyEncryptionConfigSecret(ctx context.Context, secretData *encryptiondata.Config, recorder events.Recorder) (bool, error) {
-	s, err := encryptiondata.ToSecret("openshift-config-managed", fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, c.instanceName), secretData)
+func applyEncryptionConfigSecret(instanceName string, secretData *encryptiondata.Config) (*corev1.Secret, error) {
+	s, err := encryptiondata.ToSecret("openshift-config-managed", fmt.Sprintf("%s-%s", encryptiondata.EncryptionConfSecretName, instanceName), secretData)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-
-	_, changed, applyErr := resourceapply.ApplySecret(ctx, c.secretClient, recorder, s)
-	return changed, applyErr
+	return s, nil
 }
 
 // eventsFromEncryptionConfigChanges return slice of event reasons with messages corresponding to a difference between current and desired encryption state.

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/pluginlifecycle/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,7 +26,8 @@ type KMSPluginBuilder struct {
 	staticPod                  bool
 	errorIfNotFound            bool
 
-	healthReporter *healthReporter
+	healthReporter    *healthReporter
+	injectSocketFlags bool
 }
 
 // NewKMSPluginBuilder creates a builder that defaults to deployment mode.
@@ -61,6 +63,15 @@ func (b *KMSPluginBuilder) WithDiskSecretName(name string) *KMSPluginBuilder {
 // callers like the preflight checker that expect the Secret to be present.
 func (b *KMSPluginBuilder) WithSecretRequired() *KMSPluginBuilder {
 	b.errorIfNotFound = true
+	return b
+}
+
+// WithPreflightChecker tells Apply to inject --kms-sockets and
+// --kms-socket-to-verify flags into the checker container's args. The socket
+// to verify is the highest-keyID provider (first in the sorted list), which is
+// the one the key controller is about to create a key for.
+func (b *KMSPluginBuilder) WithPreflightChecker() *KMSPluginBuilder {
+	b.injectSocketFlags = true
 	return b
 }
 
@@ -195,7 +206,30 @@ func (b *KMSPluginBuilder) Apply(ctx context.Context, podSpec *corev1.PodSpec, c
 		return err
 	}
 
+	if b.injectSocketFlags {
+		if err := injectPreflightSocketFlags(podSpec.Containers, containerName, sockets); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// injectPreflightSocketFlags appends --kms-sockets and --kms-socket-to-verify
+// to the named container's args. sockets[0] is the highest-keyID provider
+// (the one being verified).
+func injectPreflightSocketFlags(containers []corev1.Container, containerName string, sockets []string) error {
+	for i, c := range containers {
+		if c.Name != containerName {
+			continue
+		}
+		containers[i].Args = append(c.Args,
+			fmt.Sprintf("--kms-sockets=%s", strings.Join(sockets, ",")),
+			fmt.Sprintf("--kms-socket-to-verify=%s", sockets[0]),
+		)
+		return nil
+	}
+	return fmt.Errorf("container %s not found for preflight socket flag injection", containerName)
 }
 
 func fetchEncryptionConfig(ctx context.Context, encryptionConfigNamespace, encryptionConfigSecretName string, secretClient corev1client.SecretsGetter, errorIfNotFound bool) (*encryptiondata.Config, error) {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/cmd.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/cmd.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const kmsSocketEndpoint = "unix:///var/run/kmsplugin/kms.sock"
-
 type options struct {
-	kmsCallTimeout time.Duration
-	podName        string
-	podNamespace   string
-	configHash     string
-	kubeconfig     string
+	kmsSockets        []string
+	kmsSocketToVerify string
+	kmsCallTimeout    time.Duration
+	podName           string
+	podNamespace      string
+	configHash        string
+	kubeconfig        string
 }
 
 // NewCommand creates the kms-preflight cobra command.
@@ -45,6 +45,8 @@ func NewCommand(ctx context.Context) *cobra.Command {
 }
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringSliceVar(&o.kmsSockets, "kms-sockets", nil, "KMS plugin endpoints in unix:// URI format (e.g. unix:///var/run/kmsplugin/kms-1.sock); each is checked for reachability (Status)")
+	fs.StringVar(&o.kmsSocketToVerify, "kms-socket-to-verify", "", "KMS plugin endpoint that requires full verification (Status + Encrypt + Decrypt)")
 	fs.DurationVar(&o.kmsCallTimeout, "kms-call-timeout", 0, "timeout for each gRPC call to the KMS plugin")
 	fs.StringVar(&o.configHash, "config-hash", o.configHash, "hash of config to use for encryption")
 	fs.StringVar(&o.podName, "pod-name", o.podName, "name of pod to use to report checker status")
@@ -53,6 +55,22 @@ func (o *options) addFlags(fs *pflag.FlagSet) {
 }
 
 func (o *options) validate() error {
+	if len(o.kmsSockets) == 0 {
+		return fmt.Errorf("--kms-sockets is required, at least one")
+	}
+	if o.kmsSocketToVerify == "" {
+		return fmt.Errorf("--kms-socket-to-verify is required")
+	}
+	found := false
+	for _, s := range o.kmsSockets {
+		if s == o.kmsSocketToVerify {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("--kms-socket-to-verify %q must be one of --kms-sockets", o.kmsSocketToVerify)
+	}
 	if o.kmsCallTimeout <= 0 {
 		return fmt.Errorf("--kms-call-timeout must be greater than 0")
 	}
@@ -70,13 +88,31 @@ func (o *options) validate() error {
 }
 
 func (o *options) run(ctx context.Context) error {
-	klog.Infof("Running KMS preflight check at %s", kmsSocketEndpoint)
+	// Check reachability (Status) for all sockets. This validates that every
+	// KMS plugin sidecar started and is healthy, including older providers that
+	// are still needed for decryption.
+	for _, socket := range o.kmsSockets {
+		if socket == o.kmsSocketToVerify {
+			continue
+		}
+		klog.Infof("Checking reachability of KMS plugin at %s", socket)
+		service, err := k8senvelopekmsv2.NewGRPCService(ctx, socket, "preflight", o.kmsCallTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to create KMS gRPC client for %s: %w", socket, err)
+		}
+		c := newChecker(service)
+		if _, err := c.checkStatus(ctx); err != nil {
+			return fmt.Errorf("KMS plugin at %s is not reachable: %w", socket, err)
+		}
+		klog.Infof("KMS plugin at %s is reachable", socket)
+	}
 
-	// k8senvelopekmsv2.NewGRPCService is not a public API and may change.
-	// If it breaks, we can inline a minimal gRPC client using k8s.io/kms directly.
-	service, err := k8senvelopekmsv2.NewGRPCService(ctx, kmsSocketEndpoint, "preflight", o.kmsCallTimeout)
+	// Full verification (Status + Encrypt + Decrypt) on the provider that
+	// needs it — typically the newest one that is about to receive a key.
+	klog.Infof("Running full KMS preflight check at %s", o.kmsSocketToVerify)
+	service, err := k8senvelopekmsv2.NewGRPCService(ctx, o.kmsSocketToVerify, "preflight", o.kmsCallTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to create KMS gRPC client: %w", err)
+		return fmt.Errorf("failed to create KMS gRPC client for %s: %w", o.kmsSocketToVerify, err)
 	}
 
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", o.kubeconfig)
@@ -88,13 +124,12 @@ func (o *options) run(ctx context.Context) error {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
 
-	checker := newChecker(service)
+	c := newChecker(service)
 	start := time.Now()
-	status, checkErr := checker.check(ctx)
+	status, checkErr := c.check(ctx)
 
 	podClient := kubeClient.CoreV1().Pods(o.podNamespace)
 	reportErr := setPodCheckCondition(ctx, podClient, o.podName, o.configHash, status, checkErr)
-	// join the errors to not lose the original error message
 	if err := errors.Join(checkErr, reportErr); err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/kms/preflight/deployer.go
@@ -89,6 +89,7 @@ func (d *PodPreflightDeployer) Deploy(ctx context.Context, configHash string, en
 
 	err = pluginlifecycle.NewKMSPluginBuilder().
 		WithSecretRequired().
+		WithPreflightChecker().
 		FromEncryptionConfigSecret(d.namespace, EncryptionConfigSecretName, d.coreClient).
 		Apply(ctx, &pod.Spec, CheckContainerName)
 	if err != nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/encryption/statemachine/transition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/encryption/statemachine/transition.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/encryption/encryptiondata"
-	"github.com/openshift/library-go/pkg/operator/encryption/secrets"
 	"github.com/openshift/library-go/pkg/operator/encryption/state"
 )
 
@@ -30,13 +27,12 @@ type Deployer interface {
 
 func GetEncryptionConfigAndState(
 	ctx context.Context,
-	deployer Deployer,
-	secretClient corev1client.SecretsGetter,
-	encryptionSecretSelector metav1.ListOptions,
+	getDeployedEncryptionConfigSecret func(context.Context) (*corev1.Secret, bool, error),
+	listKeySecrets func(context.Context) ([]*corev1.Secret, error),
 	encryptedGRs []schema.GroupResource,
 ) (current *encryptiondata.Config, desired map[schema.GroupResource]state.GroupResourceState, encryptionSecrets []*corev1.Secret, transitioningReason string, err error) {
 	// get current config
-	encryptionConfigSecret, converged, err := deployer.DeployedEncryptionConfigSecret(ctx)
+	encryptionConfigSecret, converged, err := getDeployedEncryptionConfigSecret(ctx)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
@@ -52,7 +48,7 @@ func GetEncryptionConfigAndState(
 	}
 
 	// compute desired config
-	encryptionSecrets, err = secrets.ListKeySecrets(ctx, secretClient, encryptionSecretSelector)
+	encryptionSecrets, err = listKeySecrets(ctx)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}

--- a/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
+++ b/vendor/github.com/openshift/library-go/test/library/encryption/helpers.go
@@ -126,24 +126,9 @@ func SetAndWaitForEncryptionType(ctx context.Context, t testing.TB, provider Enc
 	// KMS-to-KMS migration: when both old and new are KMS but the config differs,
 	// the key controller creates a new key. We must wait for the next migrated key
 	// rather than asserting no new key is created.
-	// Multi-operator parallel KMS-to-KMS: another goroutine already applied the
-	// KMS config change (needsUpdate=false), but the operator will still create a
-	// new key because the KMS provider config changed. Use targetGRs to determine
-	// if we captured the old key or the new key.
-	if provider.Type == configv1.EncryptionTypeKMS {
-		if needsUpdate {
-			if previousEncryption.Type == configv1.EncryptionTypeKMS {
-				WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
-				return clientSet
-			}
-		} else if lastMigratedKeyMeta.Mode == string(configv1.EncryptionTypeKMS) {
-			if len(lastMigratedKeyMeta.Name) > 0 && !allTargetGRsMigrated(lastMigratedKeyMeta, defaultTargetGRs) {
-				WaitForCurrentKeyMigrated(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
-			} else {
-				WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
-			}
-			return clientSet
-		}
+	if needsUpdate && provider.Type == configv1.EncryptionTypeKMS && previousEncryption.Type == configv1.EncryptionTypeKMS {
+		WaitForNextMigratedKey(t, clientSet.Kube, lastMigratedKeyMeta, defaultTargetGRs, namespace, labelSelector)
+		return clientSet
 	}
 
 	WaitForEncryptionKeyBasedOn(t, clientSet.Kube, lastMigratedKeyMeta, provider.Type, defaultTargetGRs, namespace, labelSelector)
@@ -714,13 +699,4 @@ func GetRawWellKnownTokenOfLife(t testing.TB, clientSet ClientSet) string {
 	require.Len(t, resp.Kvs, 1, "expected exactly one key from etcd for token-of-life")
 
 	return string(resp.Kvs[0].Value)
-}
-
-func allTargetGRsMigrated(keyMeta EncryptionKeyMeta, targetGRs []schema.GroupResource) bool {
-	for _, gr := range targetGRs {
-		if !hasResource(gr, keyMeta.Migrated) {
-			return false
-		}
-	}
-	return true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,7 @@ github.com/openshift/client-go/security/informers/externalversions/internalinter
 github.com/openshift/client-go/security/informers/externalversions/security
 github.com/openshift/client-go/security/informers/externalversions/security/v1
 github.com/openshift/client-go/security/listers/security/v1
-# github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad
+# github.com/openshift/library-go v0.0.0-20260811065205-2bf145c31cad => /Users/lszaszki/go/src/github.com/openshift/library-go
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/assets
@@ -1758,3 +1758,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20251001123353-fd5b1fb35db1
+# github.com/openshift/library-go => /Users/lszaszki/go/src/github.com/openshift/library-go


### PR DESCRIPTION
Pick up the encryption refactoring from library-go:
- Function injection into checkAndCreateKeys/generateKeySecret
- Promotion of checkAndCreateKeys and helpers to package-level functions
- KeyComputer and EncryptionComputer for read-only key/config computation
- KMS preflight controller wired with EncryptionConfigurationComputer
- TLS group/curve mapping support (crypto package)

Uses a local replace directive pointing to the development branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption setup with a Kubernetes KMS preflight validation step.
  * Preflight checks now use the configured deployment settings and run at regular intervals.
  * Replaced the previous validation behavior that always reported success with meaningful checks and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->