### PR TITLE
OCPBUGS-86789: Extend AWS shutdown delay to 300s

### DIFF
--- a/pkg/operator/configobservation/apiserver/observe_termination_duration.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration.go
@@ -38,12 +38,18 @@ func ObserveShutdownDelayDuration(genericListers configobserver.Listers, _ event
 		// reduce the shutdown delay to 0 to reach the maximum downtime for SNO
 		observedShutdownDelayDuration = "0s"
 	case infra.Spec.PlatformSpec.Type == configv1.AWSPlatformType:
+		// PRIOR CONTEXT (when delay was 129s):
 		// AWS has a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804
 		// We need to extend the shutdown-delay-duration so that an NLB has a chance to notice and remove unhealthy instance.
 		// Once the mentioned issue is resolved this code must be removed and default values applied
 		//
 		// Note this is the official number we got from AWS
-		observedShutdownDelayDuration = "129s"
+		// ---
+		// NEW OBSERVATIONS AS OF AUGUST 2026:
+		// 129s is no longer sufficient, we have observed the delay for NLB to notice and remove unhealthy instances to be widening.
+		// The newest bug is https://redhat.atlassian.net/browse/OCPBUGS-86789
+		// 300s appears to be sufficient now to let NLB drain.
+		observedShutdownDelayDuration = "300s"
 	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
 		// We are receiving inconsistent information from the GCP support team.
 		// In some responses, they confirm an additional ~60s delay in traffic propagation,
@@ -119,11 +125,11 @@ func ObserveGracefulTerminationDuration(genericListers configobserver.Listers, _
 		// We need to extend the shutdown-delay-duration so that an NLB has a chance to notice and remove unhealthy instance.
 		// Once the mentioned issue is resolved this code must be removed and default values applied
 		//
-		// 194s is calculated as follows:
-		//   the initial 129s is reserved fo the minimal termination period - the time needed for an LB to take an instance out of rotation
+		// 365s is calculated as follows:
+		//   the initial 300s is reserved for the minimal termination period - the time needed for an LB to take an instance out of rotation
 		//   additional 60s for finishing all in-flight requests
 		//   an extra 5s to make sure the potential SIGTERM will be sent after the server terminates itself
-		observedGracefulTerminationDuration = "194"
+		observedGracefulTerminationDuration = "365"
 	case infra.Spec.PlatformSpec.Type == configv1.GCPPlatformType:
 		// 160s is calculated as follows:
 		//   the initial 95s is reserved fo the minimal termination period - the time needed for an LB to take an instance out of rotation

--- a/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
+++ b/pkg/operator/configobservation/apiserver/observe_termination_duration_test.go
@@ -29,7 +29,6 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 		platformType            configv1.PlatformType
 		controlPlaneTopology    configv1.TopologyMode
 	}{
-
 		// scenario 1
 		{
 			name:                  "default value is not applied",
@@ -47,7 +46,7 @@ func TestObserveWatchTerminationDuration(t *testing.T) {
 		{
 			name:                  "the gracefulTerminationDuration is extended due to a known AWS issue: https://bugzilla.redhat.com/show_bug.cgi?id=1943804a",
 			existingKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "135"},
-			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "194"},
+			expectedKubeAPIConfig: map[string]interface{}{"gracefulTerminationDuration": "365"},
 			platformType:          configv1.AWSPlatformType,
 		},
 
@@ -111,7 +110,6 @@ func TestObserveShutdownDelayDuration(t *testing.T) {
 		platformType            configv1.PlatformType
 		controlPlaneTopology    configv1.TopologyMode
 	}{
-
 		// scenario 1
 		{
 			name: "a config with a shutdown-delay-duration value is respected",
@@ -133,8 +131,8 @@ func TestObserveShutdownDelayDuration(t *testing.T) {
 				if len(shutdownDurationArgs) != 1 {
 					return fmt.Errorf("expected only one argument under shutdown-delay-duration key, got %d", len(shutdownDurationArgs))
 				}
-				if shutdownDurationArgs[0] != "129s" {
-					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 129s, got %v", shutdownDurationArgs[0])
+				if shutdownDurationArgs[0] != "300s" {
+					return fmt.Errorf("incorrect shutdown-delay-duration value, expected = 300s, got %v", shutdownDurationArgs[0])
 				}
 				return nil
 			},


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the AWS API server shutdown delay to 300 seconds, allowing additional time for graceful termination.
  * Updated the corresponding graceful termination duration to 365 seconds.
  * Updated validation and expected behavior to reflect the revised shutdown timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->