### PR TITLE
OCPBUGS-38661: Use 10min inertia for GuardControllerDegraded

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -586,6 +586,9 @@ func newDegradedInertia() status.Inertia {
 		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
 		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
+		// Guard pods and PDBs may temporarily fail to reconcile during upgrades while nodes restart.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(condition.GuardControllerDegradedConditionType, 10*time.Minute),
 	).Inertia
 }
 

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -24,6 +24,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: condition.GuardControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},


### PR DESCRIPTION
This is in line with other condition types.
GuardController also deploys static pods, hence it will degrade in a
very similar manner to StaticPods, which is already in the list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a 10-minute stabilization period before reporting guard controller degradation, reducing transient status changes.
- **Tests**
  - Added coverage to verify the guard controller degradation delay.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->