### PR TITLE
OCPBUGS-108524: Fix infinite static pod rollouts from SA token rotation

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -728,7 +728,6 @@ var RevisionSecrets = []revision.RevisionResource{
 
 	// this needs to be revisioned as certsyncer's kubeconfig isn't wired to be live reloaded, nor will be autorecovery
 	{Name: "localhost-recovery-serving-certkey"},
-	{Name: "localhost-recovery-client-token"},
 
 	{Name: "webhook-authenticator", Optional: true},
 }
@@ -750,6 +749,10 @@ var CertConfigMaps = []installer.UnrevisionedResource{
 var CertSecrets = []installer.UnrevisionedResource{
 	{Name: "aggregator-client"},
 	{Name: "localhost-serving-cert-certkey"},
+	// localhost-recovery-client-token is consumed via tokenFile in the cert-syncer kubeconfig,
+	// which client-go re-reads from disk (no restart needed). Revisioning it caused spurious
+	// rollouts whenever external tools (ArgoCD, Kyverno) triggered SA token regeneration.
+	{Name: "localhost-recovery-client-token"},
 	{Name: "service-network-serving-certkey"},
 	{Name: "external-loadbalancer-serving-certkey"},
 	{Name: "internal-loadbalancer-serving-certkey"},


### PR DESCRIPTION
Move localhost-recovery-client-token from RevisionSecrets to CertSecrets so that SA token
data changes no longer trigger new static pod revisions. On clusters where external tools
(ArgoCD, Kyverno, compliance scanners) interact with secrets in openshift-kube-apiserver,
the token gets regenerated every ~60 minutes, and because it was revisioned, each
regeneration triggered a full static pod rollout across all control plane nodes — inflating
revisions to 2400+, bloating etcd, and causing transient API disruptions. The token is
consumed via tokenFile in the cert-syncer kubeconfig, which client-go re-reads from disk
every ~1 minute, so no pod restart is needed; the cert-syncer sidecar already syncs
CertSecrets to disk on change via its informer watch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery token handling so externally regenerated tokens can be picked up automatically without triggering unnecessary application rollouts.
  - Recovery token updates are now applied dynamically, reducing service disruption during token rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->