### PR TITLE
OCPBUGS-120318: [release-4.22] Backport 10-minute degraded inertia

### DIFF
--- a/pkg/operator/start_test.go
+++ b/pkg/operator/start_test.go
@@ -1,6 +1,0 @@
-package operator
-
-import "testing"
-
-func TestNothing(t *testing.T) {
-}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -82,6 +82,8 @@ import (
 	migrationv1alpha1informer "sigs.k8s.io/kube-storage-version-migrator/pkg/clients/informer"
 )
 
+const guardControllerDegradedConditionType = "GuardControllerDegraded"
+
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
 	// This kube client use protobuf, do not use it for CR
 	kubeClient, err := kubernetes.NewForConfig(controllerContext.ProtoKubeConfig)
@@ -568,6 +570,9 @@ func newDegradedInertia() status.Inertia {
 		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
 		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
+		// Guard pods and PDBs may temporarily fail to reconcile during upgrades while nodes restart.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(guardControllerDegradedConditionType, 10*time.Minute),
 	).Inertia
 }
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -44,6 +45,7 @@ import (
 	"github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/webhooksupportabilitycontroller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/apiserver/controller/auditpolicy"
+	"github.com/openshift/library-go/pkg/operator/condition"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/encryption"
 	"github.com/openshift/library-go/pkg/operator/encryption/controllers/migrators"
@@ -378,7 +380,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		versionRecorder,
 		controllerContext.EventRecorder,
 		controllerContext.Clock,
-	)
+	).WithDegradedInertia(newDegradedInertia())
 
 	certRotationController, err := certrotationcontroller.NewCertRotationController(
 		kubeClient,
@@ -555,6 +557,18 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 
 	<-ctx.Done()
 	return nil
+}
+
+func newDegradedInertia() status.Inertia {
+	return status.MustNewInertia(
+		2*time.Minute,
+		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		status.InertiaCondition{
+			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
+			Duration:             10 * time.Minute,
+		},
+	).Inertia
 }
 
 // installerErrorInjector mutates the given installer pod to fail or OOM depending on the propability (

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -564,11 +564,18 @@ func newDegradedInertia() status.Inertia {
 		2*time.Minute,
 		// Nodes may temporarily become unready during upgrades while the machine/kubelet restarts.
 		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
-		status.InertiaCondition{
-			ConditionTypeMatcher: regexp.MustCompile("^" + condition.NodeControllerDegradedConditionType + "$"),
-			Duration:             10 * time.Minute,
-		},
+		inertiaForCondition(condition.NodeControllerDegradedConditionType, 10*time.Minute),
+		// Similarly, applying static pods to nodes that are being restarted may temporarily fail.
+		// Use a longer inertia to avoid flapping the ClusterOperator Degraded condition.
+		inertiaForCondition(condition.StaticPodsDegradedConditionType, 10*time.Minute),
 	).Inertia
+}
+
+func inertiaForCondition(cond string, duration time.Duration) status.InertiaCondition {
+	return status.InertiaCondition{
+		ConditionTypeMatcher: regexp.MustCompile("^" + cond + "$"),
+		Duration:             duration,
+	}
 }
 
 // installerErrorInjector mutates the given installer pod to fail or OOM depending on the propability (

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,0 +1,36 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	condition "github.com/openshift/library-go/pkg/operator/condition"
+)
+
+func TestNewDegradedInertia(t *testing.T) {
+	inertia := newDegradedInertia()
+
+	tests := []struct {
+		conditionType string
+		expected      time.Duration
+	}{
+		{
+			conditionType: condition.NodeControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
+			conditionType: "TargetConfigControllerDegraded",
+			expected:      2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.conditionType, func(t *testing.T) {
+			got := inertia(operatorv1.OperatorCondition{Type: tt.conditionType})
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -20,6 +20,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: condition.StaticPodsDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -24,6 +24,10 @@ func TestNewDegradedInertia(t *testing.T) {
 			expected:      10 * time.Minute,
 		},
 		{
+			conditionType: guardControllerDegradedConditionType,
+			expected:      10 * time.Minute,
+		},
+		{
 			conditionType: "TargetConfigControllerDegraded",
 			expected:      2 * time.Minute,
 		},


### PR DESCRIPTION
Sending a separate PR to cherry-pick all relevant commits.